### PR TITLE
Remove redundant CI trigger on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
CI already runs on PRs before merge. Deployments will use tags, not main pushes.

One-line change to remove the `push: branches: [main]` trigger.