### PR TITLE
fix: Migrate old catalogs missing schema fields (#1623)

### DIFF
--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Repo } from "@automerge/automerge-repo";
+import type { DocumentId } from "@automerge/automerge-repo";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import type { CatalogDocument } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTodu } from "./index.js";
 import type { Todu } from "./index.js";
@@ -83,5 +87,39 @@ describe("createTodu", () => {
     todu = await createTodu({ storagePath: tmpDir });
     await expect(todu.close()).resolves.toBeUndefined();
     todu = null; // prevent double-close in afterEach
+  });
+
+  it("migrates old catalog missing fields", async () => {
+    // Simulate an old catalog with only projects and version
+    const repo = new Repo({
+      storage: new NodeFSStorageAdapter(tmpDir),
+    });
+    const handle = repo.create<Partial<CatalogDocument>>();
+    handle.change((doc) => {
+      doc.version = 1;
+      doc.projects = [];
+      // Deliberately missing: labels, taskListDocIds, settings
+    });
+    const markerPath = path.join(tmpDir, "todu-catalog.id");
+    fs.writeFileSync(markerPath, handle.documentId, "utf-8");
+    await repo.flush();
+    await repo.shutdown();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Load with createTodu — should migrate without crashing
+    todu = await createTodu({ storagePath: tmpDir });
+
+    // All operations should work on migrated catalog
+    const projects = await todu.project.list();
+    expect(projects.ok).toBe(true);
+
+    const tasks = await todu.task.list();
+    expect(tasks.ok).toBe(true);
+
+    const labels = await todu.label.list();
+    expect(labels.ok).toBe(true);
+
+    const notes = await todu.note.list();
+    expect(notes.ok).toBe(true);
   });
 });

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import type { DocHandle, DocumentId } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
-import { CATALOG_DOC_KEY, type CatalogDocument, createEmptyCatalog } from "@todu/core";
+import {
+  CATALOG_DOC_KEY,
+  type CatalogDocument,
+  SCHEMA_VERSION,
+  createEmptyCatalog,
+} from "@todu/core";
 
 // ============================================================================
 // Storage layer — Automerge repo + document management
@@ -60,6 +65,7 @@ async function loadOrCreateCatalog(
   if (fs.existsSync(markerPath)) {
     const docId = fs.readFileSync(markerPath, "utf-8").trim() as DocumentId;
     const handle = await repo.find<CatalogDocument>(docId);
+    migrateCatalog(handle);
     return handle;
   }
 
@@ -78,4 +84,35 @@ async function loadOrCreateCatalog(
   fs.writeFileSync(markerPath, handle.documentId, "utf-8");
 
   return handle;
+}
+
+/**
+ * Migrate an existing catalog document to the current schema.
+ * Backfills any missing fields that were added in later versions.
+ * This ensures engine code can always assume catalog fields exist.
+ */
+function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
+  const doc = handle.doc();
+  if (!doc) return;
+
+  const defaults = createEmptyCatalog();
+  let needsMigration = false;
+
+  // Check for missing fields
+  if (!Array.isArray(doc.projects)) needsMigration = true;
+  if (!Array.isArray(doc.labels)) needsMigration = true;
+  if (doc.taskListDocIds === undefined || doc.taskListDocIds === null) needsMigration = true;
+  if (doc.settings === undefined || doc.settings === null) needsMigration = true;
+  if (doc.version === undefined || doc.version === null) needsMigration = true;
+
+  if (!needsMigration) return;
+
+  handle.change((d) => {
+    if (!Array.isArray(d.projects)) d.projects = defaults.projects;
+    if (!Array.isArray(d.labels)) d.labels = defaults.labels;
+    if (d.taskListDocIds === undefined || d.taskListDocIds === null)
+      d.taskListDocIds = defaults.taskListDocIds;
+    if (d.settings === undefined || d.settings === null) d.settings = defaults.settings;
+    if (d.version === undefined || d.version === null) d.version = SCHEMA_VERSION;
+  });
 }


### PR DESCRIPTION
## Problem
`todu-new task list` crashes with raw TypeError on data directories created by older code versions. Fields added in later PRs (`taskListDocIds`, `labels`, `settings`) are missing from old catalogs.

## Fix
Added `migrateCatalog()` in `storage.ts` that runs when loading an existing catalog. It compares the loaded document against `createEmptyCatalog()` defaults and backfills any missing fields.

This is a proper migration at the storage layer — engine code can always assume catalog fields exist after initialization. No scattered `?? {}` guards needed.

### What gets migrated
- `projects` — `[]` if missing
- `labels` — `[]` if missing
- `taskListDocIds` — `{}` if missing
- `settings` — default settings if missing
- `version` — current schema version if missing

### Test
Creates a deliberately incomplete catalog (only `version` + `projects`), loads it via `createTodu()`, then verifies all operations (project list, task list, label list, note list) work without error.

234 tests passing.

Task: #1623