### PR TITLE
fix: replace broken root typecheck with per-workspace typechecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ check-ci: ## Lint + format + typecheck (no auto-fix, CI mode)
 typecheck: ## Run TypeScript type checking only
 	npm run typecheck
 
-pre-pr: ## Run pre-PR checks (check + test)
+pre-pr: ## Run pre-PR checks (check + test + build)
 	npm run check:ci
 	npm test
+	npm run build
 
 clean: ## Remove build artifacts
 	rm -rf packages/*/dist packages/*/*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "build:cli": "npm run --workspace=packages/cli build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check": "biome check --write --error-on-warnings . && tsgo --noEmit",
-    "check:ci": "biome check --error-on-warnings . && tsgo --noEmit",
-    "typecheck": "tsgo --noEmit",
+    "check": "biome check --write --error-on-warnings . && npm run typecheck",
+    "check:ci": "biome check --error-on-warnings . && npm run typecheck",
+    "typecheck": "npm run --workspace=packages/core build && npm run --workspace=packages/engine build && npm run --workspace=packages/cli typecheck",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,8 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json"
+    "build": "tsgo -p tsconfig.build.json",
+    "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
     "@todu/engine": "^0.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json"
+    "build": "tsgo -p tsconfig.build.json",
+    "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "tsgo -p tsconfig.build.json"
+    "build": "tsgo -p tsconfig.build.json",
+    "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
     "@automerge/automerge": "^3.2.3",


### PR DESCRIPTION
## Problem

Root `tsgo --noEmit` silently passed on type errors that per-package builds caught. This meant `make check`, `make pre-pr`, and pre-commit hooks gave false confidence.

Verified by injecting `const x: number = "hello"` into engine code:
- **Before**: `npm run typecheck` passed silently ❌
- **After**: `npm run typecheck` catches the error ✅

## Changes

- Add `typecheck` script to each package using `tsgo -p tsconfig.build.json --noEmit`
- Root `typecheck` now chains per-workspace typechecks (same config as build)
- `check` and `check:ci` use the fixed typecheck automatically
- `make pre-pr` now also runs `npm run build` as a final gate

## Files Changed

| File | Change |
|------|--------|
| `package.json` | Root typecheck/check scripts use per-workspace chain |
| `packages/core/package.json` | Add `typecheck` script |
| `packages/engine/package.json` | Add `typecheck` script |
| `packages/cli/package.json` | Add `typecheck` script |
| `Makefile` | `pre-pr` adds `npm run build` as final gate |

Task: #1629