### PR TITLE
feat: unify config/data-dir resolution across CLI and Electron

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -13,7 +13,9 @@ export function registerConfigCommands(program: Command): void {
     .description("Show resolved configuration")
     .action(() => {
       const opts = program.opts();
-      const sources = resolveConfigSources(opts.config);
+      const configPath = getConfigPath(opts.config);
+      const fileConfig = loadConfig(configPath);
+      const sources = resolveConfigSources(opts.config, fileConfig);
       const configExists = fs.existsSync(sources.configPath);
 
       if (opts.format === "json") {

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -131,7 +131,8 @@ describe("config", () => {
     it("reports --config flag as source", () => {
       const configPath = path.join(tmpDir, "config.yaml");
       fs.writeFileSync(configPath, "data_dir: ./mydata\n");
-      const sources = resolveConfigSources(configPath);
+      const config = loadConfig(configPath);
+      const sources = resolveConfigSources(configPath, config);
       expect(sources.configSource).toBe("--config flag");
       expect(sources.dataDirSource).toContain("config file");
       expect(sources.dataDir).toBe(path.join(tmpDir, "mydata"));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,38 +1,33 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import {
+  type ToduFileConfig,
+  resolveConfigPath,
+  resolveConfigSources,
+  resolveDataDir,
+} from "@todu/core";
 import { parse, stringify } from "yaml";
 
 // ============================================================================
-// Configuration
+// CLI Configuration
+//
+// Config file parsing (YAML) and saving live here.
+// Path resolution is delegated to @todu/core for consistency across clients.
 // ============================================================================
 
-export interface ToduConfig {
-  /** Path to data directory (absolute or relative to config file) */
-  data_dir?: string;
-}
-
-const DEFAULT_CONFIG_DIR = path.join(os.homedir(), ".config", "todu");
-const DEFAULT_CONFIG_FILE = path.join(DEFAULT_CONFIG_DIR, "config.yaml");
-const DEFAULT_DATA_DIR = path.join(DEFAULT_CONFIG_DIR, "data");
-
-/**
- * Resolve config file path:
- * 1. Explicit --config flag
- * 2. TODU_CONFIG env var
- * 3. Default: ~/.config/todu/config.yaml
- */
-export function getConfigPath(override?: string): string {
-  if (override) return path.resolve(override);
-  if (process.env.TODU_CONFIG) return path.resolve(process.env.TODU_CONFIG);
-  return DEFAULT_CONFIG_FILE;
-}
+// Re-export from core so existing CLI consumers don't break
+export type { ToduFileConfig as ToduConfig } from "@todu/core";
+export {
+  resolveConfigPath as getConfigPath,
+  resolveConfigSources,
+  resolveDataDir,
+} from "@todu/core";
 
 /**
  * Load config from YAML file. Returns empty config if file doesn't exist.
  * Throws on malformed YAML so users know their config is broken.
  */
-export function loadConfig(configPath: string): ToduConfig {
+export function loadConfig(configPath: string): ToduFileConfig {
   let content: string;
   try {
     content = fs.readFileSync(configPath, "utf-8");
@@ -40,72 +35,14 @@ export function loadConfig(configPath: string): ToduConfig {
     return {}; // File not found — that's fine
   }
   // Let YAML parse errors surface
-  return (parse(content) as ToduConfig) ?? {};
+  return (parse(content) as ToduFileConfig) ?? {};
 }
 
 /**
  * Save config to YAML file. Creates directory if needed.
  */
-export function saveConfig(config: ToduConfig, configPath: string): void {
+export function saveConfig(config: ToduFileConfig, configPath: string): void {
   const dir = path.dirname(configPath);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(configPath, stringify(config), "utf-8");
-}
-
-/**
- * Resolve the data directory path.
- *
- * Priority:
- * 1. TODU_DATA_DIR env var (for tests / backward compat)
- * 2. data_dir from config file (resolved relative to config file location)
- * 3. Default: ~/.config/todu/data
- */
-export function resolveDataDir(configPath: string, config: ToduConfig): string {
-  // Env var takes precedence (backward compat, tests)
-  if (process.env.TODU_DATA_DIR) {
-    return path.resolve(process.env.TODU_DATA_DIR);
-  }
-
-  // Config file data_dir
-  if (config.data_dir) {
-    const configDir = path.dirname(configPath);
-    return path.resolve(configDir, config.data_dir);
-  }
-
-  // Default
-  return DEFAULT_DATA_DIR;
-}
-
-/**
- * Describe where each resolved value came from.
- */
-export function resolveConfigSources(configOverride?: string): {
-  configPath: string;
-  configSource: string;
-  dataDir: string;
-  dataDirSource: string;
-} {
-  const configPath = getConfigPath(configOverride);
-  let configSource: string;
-  if (configOverride) {
-    configSource = "--config flag";
-  } else if (process.env.TODU_CONFIG) {
-    configSource = "TODU_CONFIG env var";
-  } else {
-    configSource = "default";
-  }
-
-  const config = loadConfig(configPath);
-  const dataDir = resolveDataDir(configPath, config);
-
-  let dataDirSource: string;
-  if (process.env.TODU_DATA_DIR) {
-    dataDirSource = "TODU_DATA_DIR env var";
-  } else if (config.data_dir) {
-    dataDirSource = `config file (${configPath})`;
-  } else {
-    dataDirSource = "default";
-  }
-
-  return { configPath, configSource, dataDir, dataDirSource };
 }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,130 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_CONFIG_DIR,
+  DEFAULT_CONFIG_FILE,
+  DEFAULT_DATA_DIR,
+  resolveConfigPath,
+  resolveConfigSources,
+  resolveDataDir,
+  resolveStoragePath,
+} from "./config.js";
+
+describe("config resolution", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ["TODU_CONFIG", "TODU_DATA_DIR"]) {
+      origEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(origEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  describe("defaults", () => {
+    it("DEFAULT_CONFIG_DIR is ~/.config/todu", () => {
+      expect(DEFAULT_CONFIG_DIR).toBe(path.join(os.homedir(), ".config", "todu"));
+    });
+
+    it("DEFAULT_CONFIG_FILE is ~/.config/todu/config.yaml", () => {
+      expect(DEFAULT_CONFIG_FILE).toBe(path.join(os.homedir(), ".config", "todu", "config.yaml"));
+    });
+
+    it("DEFAULT_DATA_DIR is ~/.config/todu/data", () => {
+      expect(DEFAULT_DATA_DIR).toBe(path.join(os.homedir(), ".config", "todu", "data"));
+    });
+  });
+
+  describe("resolveConfigPath", () => {
+    it("uses override when provided", () => {
+      expect(resolveConfigPath("/custom/config.yaml")).toBe("/custom/config.yaml");
+    });
+
+    it("uses TODU_CONFIG env var", () => {
+      process.env.TODU_CONFIG = "/env/config.yaml";
+      expect(resolveConfigPath()).toBe("/env/config.yaml");
+    });
+
+    it("falls back to default", () => {
+      expect(resolveConfigPath()).toBe(DEFAULT_CONFIG_FILE);
+    });
+
+    it("override beats env var", () => {
+      process.env.TODU_CONFIG = "/env/config.yaml";
+      expect(resolveConfigPath("/override/config.yaml")).toBe("/override/config.yaml");
+    });
+  });
+
+  describe("resolveDataDir", () => {
+    it("uses TODU_DATA_DIR env var first", () => {
+      process.env.TODU_DATA_DIR = "/env/data";
+      expect(resolveDataDir("/any/config.yaml", { data_dir: "./other" })).toBe("/env/data");
+    });
+
+    it("resolves data_dir relative to config file", () => {
+      expect(resolveDataDir("/home/user/.config/todu/config.yaml", { data_dir: "./data" })).toBe(
+        "/home/user/.config/todu/data",
+      );
+    });
+
+    it("handles absolute data_dir", () => {
+      expect(resolveDataDir("/any/config.yaml", { data_dir: "/absolute/path" })).toBe(
+        "/absolute/path",
+      );
+    });
+
+    it("falls back to DEFAULT_DATA_DIR when no config", () => {
+      expect(resolveDataDir("/any/config.yaml", {})).toBe(DEFAULT_DATA_DIR);
+    });
+  });
+
+  describe("resolveStoragePath", () => {
+    it("uses TODU_DATA_DIR env var", () => {
+      process.env.TODU_DATA_DIR = "/env/data";
+      expect(resolveStoragePath()).toBe("/env/data");
+    });
+
+    it("falls back to DEFAULT_DATA_DIR", () => {
+      expect(resolveStoragePath()).toBe(DEFAULT_DATA_DIR);
+    });
+  });
+
+  describe("resolveConfigSources", () => {
+    it("reports --config flag as source", () => {
+      const sources = resolveConfigSources("/custom/config.yaml", { data_dir: "./mydata" });
+      expect(sources.configSource).toBe("--config flag");
+      expect(sources.dataDirSource).toContain("config file");
+      expect(sources.dataDir).toBe("/custom/mydata");
+    });
+
+    it("reports TODU_CONFIG env var as source", () => {
+      process.env.TODU_CONFIG = "/env/config.yaml";
+      const sources = resolveConfigSources();
+      expect(sources.configSource).toBe("TODU_CONFIG env var");
+    });
+
+    it("reports TODU_DATA_DIR as source when set", () => {
+      process.env.TODU_DATA_DIR = "/override/data";
+      const sources = resolveConfigSources();
+      expect(sources.dataDirSource).toBe("TODU_DATA_DIR env var");
+      expect(sources.dataDir).toBe("/override/data");
+    });
+
+    it("reports default when nothing configured", () => {
+      const sources = resolveConfigSources();
+      expect(sources.configSource).toBe("default");
+      expect(sources.dataDirSource).toBe("default");
+      expect(sources.dataDir).toBe(DEFAULT_DATA_DIR);
+    });
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,111 @@
+import os from "node:os";
+import path from "node:path";
+
+// ============================================================================
+// Shared configuration resolution
+//
+// Single source of truth for config and data directory paths.
+// Used by CLI, Electron, and any future client.
+//
+// This module handles path resolution only. Config file parsing (YAML)
+// stays in the CLI package which has the yaml dependency.
+// ============================================================================
+
+export const DEFAULT_CONFIG_DIR = path.join(os.homedir(), ".config", "todu");
+export const DEFAULT_CONFIG_FILE = path.join(DEFAULT_CONFIG_DIR, "config.yaml");
+export const DEFAULT_DATA_DIR = path.join(DEFAULT_CONFIG_DIR, "data");
+
+export interface ToduFileConfig {
+  /** Path to data directory (absolute or relative to config file) */
+  data_dir?: string;
+}
+
+/**
+ * Resolve config file path.
+ *
+ * Priority:
+ * 1. Explicit override (e.g. --config flag)
+ * 2. TODU_CONFIG env var
+ * 3. Default: ~/.config/todu/config.yaml
+ */
+export function resolveConfigPath(override?: string): string {
+  if (override) return path.resolve(override);
+  if (process.env.TODU_CONFIG) return path.resolve(process.env.TODU_CONFIG);
+  return DEFAULT_CONFIG_FILE;
+}
+
+/**
+ * Resolve the data directory path.
+ *
+ * Priority:
+ * 1. TODU_DATA_DIR env var (for tests / backward compat)
+ * 2. data_dir from config file (resolved relative to config file location)
+ * 3. Default: ~/.config/todu/data
+ */
+export function resolveDataDir(configPath: string, config: ToduFileConfig): string {
+  // Env var takes precedence (backward compat, tests)
+  if (process.env.TODU_DATA_DIR) {
+    return path.resolve(process.env.TODU_DATA_DIR);
+  }
+
+  // Config file data_dir
+  if (config.data_dir) {
+    const configDir = path.dirname(configPath);
+    return path.resolve(configDir, config.data_dir);
+  }
+
+  // Default
+  return DEFAULT_DATA_DIR;
+}
+
+/**
+ * Describe where each resolved value came from.
+ * Useful for `todu config show` and debugging.
+ */
+export function resolveConfigSources(
+  configOverride?: string,
+  config?: ToduFileConfig,
+): {
+  configPath: string;
+  configSource: string;
+  dataDir: string;
+  dataDirSource: string;
+} {
+  const configPath = resolveConfigPath(configOverride);
+  let configSource: string;
+  if (configOverride) {
+    configSource = "--config flag";
+  } else if (process.env.TODU_CONFIG) {
+    configSource = "TODU_CONFIG env var";
+  } else {
+    configSource = "default";
+  }
+
+  const resolvedConfig = config ?? {};
+  const dataDir = resolveDataDir(configPath, resolvedConfig);
+
+  let dataDirSource: string;
+  if (process.env.TODU_DATA_DIR) {
+    dataDirSource = "TODU_DATA_DIR env var";
+  } else if (resolvedConfig.data_dir) {
+    dataDirSource = `config file (${configPath})`;
+  } else {
+    dataDirSource = "default";
+  }
+
+  return { configPath, configSource, dataDir, dataDirSource };
+}
+
+/**
+ * Resolve storage path using env vars and defaults.
+ *
+ * For clients that don't parse config files (e.g. Electron).
+ * Checks TODU_DATA_DIR env var, then falls back to default.
+ * If a config file with data_dir is needed, use resolveDataDir instead.
+ */
+export function resolveStoragePath(): string {
+  if (process.env.TODU_DATA_DIR) {
+    return path.resolve(process.env.TODU_DATA_DIR);
+  }
+  return DEFAULT_DATA_DIR;
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,10 +1,2 @@
-import path from "node:path";
-
-/** Default base directory for todu data (relative to cwd) */
-export const DEFAULT_DATA_DIR = path.join(".todu", "data");
-
-/** Default config file path (relative to cwd) */
-export const DEFAULT_CONFIG_PATH = path.join(".todu", "config.yaml");
-
 /** Automerge document ID for the catalog (stable, well-known) */
 export const CATALOG_DOC_KEY = "todu-catalog";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types.js";
 export * from "./schema.js";
 export * from "./constants.js";
+export * from "./config.js";
 export * from "./validation.js";
 export * from "./schedule.js";

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1,3 +1,4 @@
+import { resolveStoragePath } from "@todu/core";
 import { createTodu } from "@todu/engine";
 import type { Todu } from "@todu/engine";
 import { BrowserWindow, app } from "electron";
@@ -9,8 +10,11 @@ let mainWindow: BrowserWindow | null = null;
 let todu: Todu | null = null;
 
 async function init(): Promise<void> {
+  // Resolve storage path using the same config chain as CLI
+  const storagePath = resolveStoragePath();
+
   // Initialize engine with sync server so CLI can connect
-  todu = await createTodu({ syncServer: true });
+  todu = await createTodu({ storagePath, syncServer: true });
 
   // Register all IPC handlers
   registerIpcHandlers(todu);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_DATA_DIR } from "@todu/core";
 import { createHabitNamespace, registerHabitProcessor } from "./habits.js";
 import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
@@ -50,9 +49,11 @@ export type { SchedulableItem, ProcessingContext, TemplateProcessor } from "./sc
  *   propagate bidirectionally via Automerge sync protocol. Used by CLI.
  * - Neither — Standalone, no sync. Used by tests.
  */
-export async function createTodu(config?: Partial<ToduConfig>): Promise<Todu> {
+export async function createTodu(
+  config: Pick<ToduConfig, "storagePath"> & Partial<Omit<ToduConfig, "storagePath">>,
+): Promise<Todu> {
   const resolvedConfig: ToduConfig = {
-    storagePath: config?.storagePath ?? DEFAULT_DATA_DIR,
+    storagePath: config.storagePath,
   };
 
   const storage = await initStorage(resolvedConfig.storagePath);


### PR DESCRIPTION
## Problem

CLI and Electron resolved data directories differently, resulting in two separate data stores:

- **CLI**: `~/.config/todu/data/` (from `packages/cli/src/config.ts`)
- **Electron**: `.todu/data` (relative to cwd, from `@todu/core` constants)
- **Engine fallback**: `.todu/data` (same broken relative path)

They shared engine code but never saw each other's data.

## Solution

Moved config path resolution to `@todu/core` as the single source of truth:

| What | Where |
|------|-------|
| Path resolution (`resolveConfigPath`, `resolveDataDir`, `resolveStoragePath`, `resolveConfigSources`) | `@todu/core/config` |
| Default data dir: `~/.config/todu/data/` | `@todu/core/config` |
| YAML config parsing (`loadConfig`, `saveConfig`) | `@todu/cli` (keeps `yaml` dep) |
| CLI re-exports core functions | `packages/cli/src/config.ts` |

### Resolution priority (unchanged)
1. `TODU_DATA_DIR` env var
2. `data_dir` from config file
3. Default: `~/.config/todu/data/`

### Key changes
- **Core**: New `config.ts` with shared resolution. `DEFAULT_DATA_DIR` is now absolute (`~/.config/todu/data/`), not relative
- **CLI**: Delegates to core, keeps YAML parsing. Re-exports maintain backward compat for CLI consumers
- **Electron**: Uses `resolveStoragePath()` from core instead of engine's implicit fallback
- **Engine**: `createTodu` now requires `storagePath` — no implicit fallback to a broken relative path
- Removed old relative `DEFAULT_DATA_DIR` and `DEFAULT_CONFIG_PATH` from core constants

## Tests

- 17 new tests in `packages/core/src/config.test.ts` covering all resolution paths
- All 402 existing tests pass (including CLI integration tests with `--config` flag)

Task: #1738