### PR TITLE
feat: truthful sync runtime status

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,0 +1,45 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("sync CLI commands", () => {
+  let tmpDir: string;
+  const rootDir = path.resolve(__dirname, "../../../..");
+  const cliPath = path.resolve(rootDir, "packages/cli/dist/index.js");
+
+  beforeAll(() => {
+    execSync("npm run build", { cwd: rootDir, stdio: "pipe", timeout: 30000 });
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-sync-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(args: string): string {
+    return execSync(`node ${cliPath} ${args}`, {
+      cwd: tmpDir,
+      env: { ...process.env, TODU_DATA_DIR: tmpDir, TODU_CONFIG: "" },
+      encoding: "utf-8",
+      timeout: 15000,
+    }).trim();
+  }
+
+  it("sync status shows standalone mode in text format", () => {
+    const output = run("sync status");
+    expect(output).toContain("standalone");
+    expect(output).toContain("disconnected");
+  });
+
+  it("sync status shows standalone mode in JSON format", () => {
+    const output = run("sync status --format json");
+    const status = JSON.parse(output);
+    expect(status.local.mode).toBe("standalone");
+    expect(status.remote.state).toBe("disconnected");
+  });
+});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,0 +1,34 @@
+import type { Todu } from "@todu/engine";
+import type { Command } from "commander";
+import { formatJSON } from "../format.js";
+
+export function registerSyncCommands(program: Command, getTodu: () => Promise<Todu>): void {
+  const sync = program.command("sync").description("Sync status and control");
+
+  sync
+    .command("status")
+    .description("Show sync status")
+    .action(async () => {
+      const todu = await getTodu();
+      try {
+        const status = todu.sync.status();
+        const opts = program.opts();
+
+        if (opts.format === "json") {
+          console.log(formatJSON(status));
+          return;
+        }
+
+        console.log(`Local Mode:   ${status.local.mode}`);
+        console.log(`Remote Sync:  ${status.remote.state}`);
+        if (status.remote.server) {
+          console.log(`Server:       ${status.remote.server}`);
+        }
+        if (status.remote.lastSync) {
+          console.log(`Last Sync:    ${status.remote.lastSync}`);
+        }
+      } finally {
+        await todu.close();
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { registerLabelCommands } from "./commands/label.js";
 import { registerNoteCommands } from "./commands/note.js";
 import { registerProjectCommands } from "./commands/project.js";
 import { registerRecurringCommands } from "./commands/recurring.js";
+import { registerSyncCommands } from "./commands/sync.js";
 import { registerTaskCommands } from "./commands/task.js";
 import { getConfigPath, loadConfig, resolveDataDir } from "./config.js";
 import { setColorEnabled } from "./format.js";
@@ -46,6 +47,7 @@ registerLabelCommands(program, getTodu);
 registerNoteCommands(program, getTodu);
 registerRecurringCommands(program, getTodu);
 registerHabitCommands(program, getTodu);
+registerSyncCommands(program, getTodu);
 registerConfigCommands(program);
 
 program.parse();

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -79,10 +79,11 @@ describe("createTodu", () => {
     expect(config.storagePath).toBe(tmpDir);
   });
 
-  it("reports sync as disconnected by default", async () => {
+  it("reports sync status as standalone/disconnected by default", async () => {
     todu = await createTodu({ storagePath: tmpDir });
     const status = todu.sync.status();
-    expect(status.connected).toBe(false);
+    expect(status.local.mode).toBe("standalone");
+    expect(status.remote.state).toBe("disconnected");
   });
 
   it("closes without error", async () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -8,9 +8,15 @@ import { type Storage, initEphemeralStorage, initStorage } from "./storage.js";
 import { connectSyncClient } from "./sync-client.js";
 import { type SyncServer, startSyncServer } from "./sync-server.js";
 import { createTaskNamespace } from "./tasks.js";
-import { type Todu, type ToduConfig, createStubNamespaces } from "./todu.js";
+import {
+  type LocalSyncMode,
+  type SyncStatus,
+  type Todu,
+  type ToduConfig,
+  createStubNamespaces,
+} from "./todu.js";
 
-export type { Todu, ToduConfig } from "./todu.js";
+export type { Todu, ToduConfig, SyncStatus, LocalSyncMode, RemoteSyncState } from "./todu.js";
 export type {
   HabitNamespace,
   LabelNamespace,
@@ -89,6 +95,19 @@ export async function createTodu(
   // and Electron launch triggers template processing.
   await processTemplates(storage.catalog);
 
+  // Determine local sync mode
+  const localMode: LocalSyncMode = config?.syncClient
+    ? "ephemeral-client"
+    : config?.syncServer
+      ? "sync-server"
+      : "standalone";
+
+  const syncStatus: SyncStatus = {
+    local: { mode: localMode },
+    // Remote multi-device sync is not yet implemented (phase 3)
+    remote: { state: "disconnected" },
+  };
+
   const stubs = createStubNamespaces(resolvedConfig);
 
   return {
@@ -99,6 +118,11 @@ export async function createTodu(
     note: createNoteNamespace(storage.catalog, storage.repo),
     recurring: createRecurringNamespace(storage.catalog, storage.repo),
     habit: createHabitNamespace(storage.catalog, storage.repo),
+    sync: {
+      status: () => syncStatus,
+      start: () => Promise.resolve(),
+      stop: () => Promise.resolve(),
+    },
     onChange(callback: () => void): () => void {
       storage.catalog.on("change", callback);
       return () => {

--- a/packages/engine/src/sync-status.test.ts
+++ b/packages/engine/src/sync-status.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTodu } from "./index.js";
+import type { Todu } from "./todu.js";
+
+const TEST_SYNC_PORT = 24398;
+
+describe("sync status", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-sync-status-"));
+  });
+
+  afterEach(async () => {
+    await new Promise((r) => setTimeout(r, 100));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("standalone mode reports correct status", async () => {
+    const todu = await createTodu({ storagePath: tmpDir });
+
+    const status = todu.sync.status();
+    expect(status.local.mode).toBe("standalone");
+    expect(status.remote.state).toBe("disconnected");
+    expect(status.remote.server).toBeUndefined();
+    expect(status.remote.lastSync).toBeUndefined();
+
+    await todu.close();
+  });
+
+  it("sync-server mode reports correct status", async () => {
+    const todu = await createTodu({
+      storagePath: tmpDir,
+      syncServer: true,
+      syncPort: TEST_SYNC_PORT,
+    });
+
+    const status = todu.sync.status();
+    expect(status.local.mode).toBe("sync-server");
+    expect(status.remote.state).toBe("disconnected");
+
+    await todu.close();
+  });
+
+  it("ephemeral-client mode reports correct status", async () => {
+    // Need a server for the client to connect to
+    const server = await createTodu({
+      storagePath: tmpDir,
+      syncServer: true,
+      syncPort: TEST_SYNC_PORT,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    const client = await createTodu({
+      storagePath: tmpDir,
+      syncClient: true,
+      syncPort: TEST_SYNC_PORT,
+    });
+
+    const status = client.sync.status();
+    expect(status.local.mode).toBe("ephemeral-client");
+    expect(status.remote.state).toBe("disconnected");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("start() and stop() are no-ops (remote sync not yet implemented)", async () => {
+    const todu = await createTodu({ storagePath: tmpDir });
+
+    // Should not throw
+    await todu.sync.start();
+    await todu.sync.stop();
+
+    // Status unchanged
+    const status = todu.sync.status();
+    expect(status.remote.state).toBe("disconnected");
+
+    await todu.close();
+  });
+});

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -119,10 +119,38 @@ export interface HabitNamespace {
   history(id: HabitId, days?: number): Promise<Result<HabitHistoryEntry[]>>;
 }
 
+// ============================================================================
+// Sync status types
+// ============================================================================
+
+/** How this instance coordinates with other local processes. */
+export type LocalSyncMode = "standalone" | "ephemeral-client" | "sync-server";
+
+/** Remote multi-device sync connection state. */
+export type RemoteSyncState = "disconnected" | "connected" | "syncing";
+
+export interface SyncStatus {
+  /** Local coordination mode with other processes on this machine. */
+  local: {
+    mode: LocalSyncMode;
+  };
+  /** Multi-device replication state (phase 3 — currently always disconnected). */
+  remote: {
+    state: RemoteSyncState;
+    /** Sync server URL if configured. */
+    server?: string;
+    /** ISO timestamp of last successful sync. */
+    lastSync?: string;
+  };
+}
+
 export interface SyncNamespace {
+  /** Start remote multi-device sync connection. */
   start(): Promise<void>;
+  /** Stop remote multi-device sync connection. */
   stop(): Promise<void>;
-  status(): { connected: boolean };
+  /** Get current sync status (local mode + remote state). */
+  status(): SyncStatus;
 }
 
 export interface ConfigNamespace {
@@ -215,7 +243,10 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
     sync: {
       start: () => Promise.resolve(),
       stop: () => Promise.resolve(),
-      status: () => ({ connected: false }),
+      status: () => ({
+        local: { mode: "standalone" as LocalSyncMode },
+        remote: { state: "disconnected" as RemoteSyncState },
+      }),
     },
     config: {
       get: () => config,


### PR DESCRIPTION
## Problem

`todu.sync.status()` always returned `{ connected: false }` regardless of actual runtime state. No way to know if CLI is running standalone, as an ephemeral sync client, or as a sync server.

## Solution

Replace the boolean stub with a structured `SyncStatus` type:

```typescript
interface SyncStatus {
  local: { mode: 'standalone' | 'ephemeral-client' | 'sync-server' };
  remote: { state: 'disconnected' | 'connected' | 'syncing'; server?: string; lastSync?: string };
}
```

Two orthogonal dimensions:
- **local.mode** — how this instance coordinates with other processes on the same machine
- **remote.state** — multi-device replication state (phase 3, currently always `disconnected`)

`start()`/`stop()` remain no-ops until remote sync is implemented.

### CLI

```
$ todu sync status
Local Mode:   standalone
Remote Sync:  disconnected

$ todu sync status --format json
{"local":{"mode":"standalone"},"remote":{"state":"disconnected"}}
```

## Changes

| File | Change |
|------|--------|
| `todu.ts` | New `SyncStatus`, `LocalSyncMode`, `RemoteSyncState` types. Redesigned `SyncNamespace` interface. |
| `index.ts` | Wire real mode detection in `createTodu` based on `syncClient`/`syncServer` config. |
| `cli/commands/sync.ts` | New `sync status` command (text + JSON). |
| `cli/index.ts` | Register sync commands. |

## Tests

6 new tests:
- Engine: standalone, sync-server, ephemeral-client, start/stop no-ops
- CLI: text output, JSON output

All 412 tests pass.

Task: #1740