### PR TITLE
feat: Electron recurring template + notes views

### DIFF
--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -1,14 +1,22 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { Placeholder } from "./components/Placeholder.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { queryClient, setupChangeListener } from "./lib/query-client.js";
 import { LabelsView } from "./views/LabelsView.js";
+import { NotesView } from "./views/NotesView.js";
 import { ProjectsView } from "./views/ProjectsView.js";
+import { RecurringView } from "./views/RecurringView.js";
 import { TasksView } from "./views/TasksView.js";
 
-function ViewRouter({ activeView }: { activeView: string }): ReactNode {
+function ViewRouter({
+  activeView,
+  onNavigateToEntity,
+}: {
+  activeView: string;
+  onNavigateToEntity: (entityType: string, entityId: string) => void;
+}): ReactNode {
   switch (activeView) {
     case "projects":
       return <ProjectsView />;
@@ -17,9 +25,9 @@ function ViewRouter({ activeView }: { activeView: string }): ReactNode {
     case "habits":
       return <Placeholder title="Habits" />;
     case "recurring":
-      return <Placeholder title="Recurring" />;
+      return <RecurringView />;
     case "notes":
-      return <Placeholder title="Notes" />;
+      return <NotesView onNavigateToEntity={onNavigateToEntity} />;
     case "labels":
       return <LabelsView />;
     case "agent":
@@ -37,12 +45,31 @@ export function App(): ReactNode {
     return cleanup;
   }, []);
 
+  // Navigate to an entity from notes or other cross-view links.
+  // For now, switches to the appropriate top-level view.
+  // TODO: deep-link to specific entity detail (needs view-level state lifting)
+  const handleNavigateToEntity = useCallback((entityType: string, _entityId: string) => {
+    switch (entityType) {
+      case "task":
+        setActiveView("tasks");
+        break;
+      case "project":
+        setActiveView("projects");
+        break;
+      case "habit":
+        setActiveView("habits");
+        break;
+      default:
+        break;
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <div className="app-layout">
         <Sidebar activeView={activeView} onNavigate={setActiveView} />
         <main className="content-area">
-          <ViewRouter activeView={activeView} />
+          <ViewRouter activeView={activeView} onNavigateToEntity={handleNavigateToEntity} />
         </main>
       </div>
       <StatusBar />

--- a/packages/electron/src/renderer/components/SchedulePresetPicker.tsx
+++ b/packages/electron/src/renderer/components/SchedulePresetPicker.tsx
@@ -1,0 +1,141 @@
+import { type ReactNode, useState } from "react";
+
+const WEEKDAYS = [
+  { value: "MO", label: "Mon" },
+  { value: "TU", label: "Tue" },
+  { value: "WE", label: "Wed" },
+  { value: "TH", label: "Thu" },
+  { value: "FR", label: "Fri" },
+  { value: "SA", label: "Sat" },
+  { value: "SU", label: "Sun" },
+];
+
+type Preset = "daily" | "weekdays" | "weekly" | "monthly" | "custom";
+
+function presetToRRule(preset: Preset, weekday: string, monthday: string): string {
+  switch (preset) {
+    case "daily":
+      return "FREQ=DAILY";
+    case "weekdays":
+      return "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR";
+    case "weekly":
+      return `FREQ=WEEKLY;BYDAY=${weekday}`;
+    case "monthly":
+      return `FREQ=MONTHLY;BYMONTHDAY=${monthday}`;
+    case "custom":
+      return "";
+  }
+}
+
+function detectPreset(rrule: string): {
+  preset: Preset;
+  weekday: string;
+  monthday: string;
+  custom: string;
+} {
+  const upper = rrule.toUpperCase();
+  if (upper === "FREQ=DAILY") return { preset: "daily", weekday: "MO", monthday: "1", custom: "" };
+  if (upper === "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR")
+    return { preset: "weekdays", weekday: "MO", monthday: "1", custom: "" };
+  if (upper.startsWith("FREQ=WEEKLY;BYDAY=") && !upper.includes(",")) {
+    const day = upper.replace("FREQ=WEEKLY;BYDAY=", "");
+    return { preset: "weekly", weekday: day, monthday: "1", custom: "" };
+  }
+  if (upper.startsWith("FREQ=MONTHLY;BYMONTHDAY=")) {
+    const day = upper.replace("FREQ=MONTHLY;BYMONTHDAY=", "");
+    return { preset: "monthly", weekday: "MO", monthday: day, custom: "" };
+  }
+  return { preset: "custom", weekday: "MO", monthday: "1", custom: rrule };
+}
+
+export function SchedulePresetPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (rrule: string) => void;
+}): ReactNode {
+  const detected = detectPreset(value);
+  const [preset, setPreset] = useState<Preset>(detected.preset);
+  const [weekday, setWeekday] = useState(detected.weekday);
+  const [monthday, setMonthday] = useState(detected.monthday);
+  const [custom, setCustom] = useState(detected.custom);
+
+  const handlePresetChange = (newPreset: Preset) => {
+    setPreset(newPreset);
+    if (newPreset === "custom") {
+      onChange(custom);
+    } else {
+      onChange(presetToRRule(newPreset, weekday, monthday));
+    }
+  };
+
+  const handleWeekdayChange = (day: string) => {
+    setWeekday(day);
+    onChange(`FREQ=WEEKLY;BYDAY=${day}`);
+  };
+
+  const handleMonthdayChange = (day: string) => {
+    setMonthday(day);
+    onChange(`FREQ=MONTHLY;BYMONTHDAY=${day}`);
+  };
+
+  const handleCustomChange = (rrule: string) => {
+    setCustom(rrule);
+    onChange(rrule);
+  };
+
+  return (
+    <div className="schedule-picker">
+      <select
+        className="input"
+        value={preset}
+        onChange={(e) => handlePresetChange(e.target.value as Preset)}
+      >
+        <option value="daily">Daily</option>
+        <option value="weekdays">Every weekday</option>
+        <option value="weekly">Weekly (pick day)</option>
+        <option value="monthly">Monthly (pick date)</option>
+        <option value="custom">Custom RRULE</option>
+      </select>
+
+      {preset === "weekly" && (
+        <select
+          className="input schedule-sub-select"
+          value={weekday}
+          onChange={(e) => handleWeekdayChange(e.target.value)}
+        >
+          {WEEKDAYS.map((d) => (
+            <option key={d.value} value={d.value}>
+              {d.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {preset === "monthly" && (
+        <select
+          className="input schedule-sub-select"
+          value={monthday}
+          onChange={(e) => handleMonthdayChange(e.target.value)}
+        >
+          {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
+            <option key={d} value={String(d)}>
+              Day {d}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {preset === "custom" && (
+        <input
+          type="text"
+          className="input schedule-custom-input"
+          placeholder="e.g. FREQ=WEEKLY;BYDAY=MO,WE,FR"
+          value={custom}
+          onChange={(e) => handleCustomChange(e.target.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/hooks/useTodu.ts
+++ b/packages/electron/src/renderer/hooks/useTodu.ts
@@ -3,11 +3,14 @@ import type {
   CreateLabelInput,
   CreateNoteInput,
   CreateProjectInput,
+  CreateRecurringInput,
   CreateTaskInput,
   LabelId,
   NoteFilter,
   NoteId,
   ProjectId,
+  RecurringFilter,
+  RecurringId,
   Result,
   TaskFilter,
   TaskId,
@@ -15,6 +18,7 @@ import type {
   ToduError,
   UpdateLabelInput,
   UpdateProjectInput,
+  UpdateRecurringInput,
   UpdateTaskInput,
 } from "@todu/core/browser";
 
@@ -259,6 +263,106 @@ export function useDeleteLabel() {
     mutationFn: async (id: LabelId) => unwrap(await window.todu.label.delete(id)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.labels });
+    },
+  });
+}
+
+// ============================================================================
+// Recurring Hooks
+// ============================================================================
+
+export function useRecurringList(filter?: RecurringFilter) {
+  return useQuery({
+    queryKey: queryKeys.recurring(filter),
+    queryFn: async () => unwrap(await window.todu.recurring.list(filter)),
+  });
+}
+
+export function useRecurringDetail(id: string) {
+  return useQuery({
+    queryKey: queryKeys.recurringDetail(id),
+    queryFn: async () => unwrap(await window.todu.recurring.get(id as RecurringId)),
+    enabled: !!id,
+  });
+}
+
+export function useUpcoming(options?: { templateId?: string; days?: number }) {
+  return useQuery({
+    queryKey: queryKeys.recurringUpcoming(options),
+    queryFn: async () =>
+      unwrap(
+        await window.todu.recurring.upcoming(
+          options?.templateId
+            ? { templateId: options.templateId as RecurringId, days: options.days }
+            : { days: options?.days },
+        ),
+      ),
+  });
+}
+
+export function useCreateRecurring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: CreateRecurringInput) =>
+      unwrap(await window.todu.recurring.create(input)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+    },
+  });
+}
+
+export function useUpdateRecurring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, input }: { id: RecurringId; input: UpdateRecurringInput }) =>
+      unwrap(await window.todu.recurring.update(id, input)),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recurringDetail(id) });
+    },
+  });
+}
+
+export function useDeleteRecurring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: RecurringId) => unwrap(await window.todu.recurring.delete(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+    },
+  });
+}
+
+export function usePauseRecurring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: RecurringId) => unwrap(await window.todu.recurring.pause(id)),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recurringDetail(id) });
+    },
+  });
+}
+
+export function useResumeRecurring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: RecurringId) => unwrap(await window.todu.recurring.resume(id)),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recurringDetail(id) });
+    },
+  });
+}
+
+export function useGenerateOccurrence() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ templateId, date }: { templateId: RecurringId; date: string }) =>
+      unwrap(await window.todu.recurring.generate(templateId, date)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }

--- a/packages/electron/src/renderer/lib/describe-schedule.test.ts
+++ b/packages/electron/src/renderer/lib/describe-schedule.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { describeSchedule } from "./describe-schedule.js";
+
+describe("describeSchedule", () => {
+  it("describes daily", () => {
+    expect(describeSchedule("FREQ=DAILY")).toBe("Daily");
+  });
+
+  it("describes daily with interval", () => {
+    expect(describeSchedule("FREQ=DAILY;INTERVAL=3")).toBe("Every 3 days");
+  });
+
+  it("describes daily with byday", () => {
+    expect(describeSchedule("FREQ=DAILY;BYDAY=MO,WE")).toBe("Daily on Monday, Wednesday");
+  });
+
+  it("describes weekdays", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR")).toBe("Every weekday");
+  });
+
+  it("describes weekly on specific day", () => {
+    expect(describeSchedule("FREQ=WEEKLY;BYDAY=TU")).toBe("Weekly on Tuesday");
+  });
+
+  it("describes weekly with interval", () => {
+    expect(describeSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR")).toBe(
+      "Every 2 weeks on Monday, Friday",
+    );
+  });
+
+  it("describes weekly without byday", () => {
+    expect(describeSchedule("FREQ=WEEKLY")).toBe("Weekly");
+  });
+
+  it("describes monthly on day", () => {
+    expect(describeSchedule("FREQ=MONTHLY;BYMONTHDAY=15")).toBe("Monthly on day 15");
+  });
+
+  it("describes monthly with interval", () => {
+    expect(describeSchedule("FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1")).toBe(
+      "Every 3 months on day 1",
+    );
+  });
+
+  it("describes monthly without bymonthday", () => {
+    expect(describeSchedule("FREQ=MONTHLY")).toBe("Monthly");
+  });
+
+  it("describes yearly", () => {
+    expect(describeSchedule("FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15")).toBe("Yearly on March 15");
+  });
+
+  it("describes yearly with interval", () => {
+    expect(describeSchedule("FREQ=YEARLY;INTERVAL=2")).toBe("Every 2 years");
+  });
+
+  it("returns raw rule for unknown frequency", () => {
+    expect(describeSchedule("SOMETHING=WEIRD")).toBe("SOMETHING=WEIRD");
+  });
+
+  it("handles case insensitivity in parts", () => {
+    expect(describeSchedule("freq=daily")).toBe("Daily");
+  });
+});

--- a/packages/electron/src/renderer/lib/describe-schedule.ts
+++ b/packages/electron/src/renderer/lib/describe-schedule.ts
@@ -1,0 +1,94 @@
+/**
+ * Browser-safe RRULE description. Mirrors the engine's describeSchedule()
+ * without needing node:module or the rrule CJS package.
+ */
+
+const DAY_NAMES: Record<string, string> = {
+  MO: "Monday",
+  TU: "Tuesday",
+  WE: "Wednesday",
+  TH: "Thursday",
+  FR: "Friday",
+  SA: "Saturday",
+  SU: "Sunday",
+};
+
+const MONTH_NAMES = [
+  "",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function parseRRuleParts(rule: string): Record<string, string> {
+  const parts: Record<string, string> = {};
+  for (const segment of rule.split(";")) {
+    const [key, value] = segment.split("=");
+    if (key && value) parts[key.toUpperCase()] = value;
+  }
+  return parts;
+}
+
+function formatDayList(byday: string): string {
+  return byday
+    .split(",")
+    .map((d) => DAY_NAMES[d.toUpperCase()] ?? d)
+    .join(", ");
+}
+
+function isWeekdays(days: string[]): boolean {
+  const weekdays = new Set(["MO", "TU", "WE", "TH", "FR"]);
+  return days.length === 5 && days.every((d) => weekdays.has(d.toUpperCase()));
+}
+
+export function describeSchedule(rule: string): string {
+  const parts = parseRRuleParts(rule);
+  const freq = (parts.FREQ ?? "").toUpperCase();
+  const interval = parts.INTERVAL ? Number.parseInt(parts.INTERVAL, 10) : 1;
+  const byday = parts.BYDAY;
+  const bymonthday = parts.BYMONTHDAY;
+  const bymonth = parts.BYMONTH;
+
+  switch (freq) {
+    case "DAILY": {
+      if (interval === 1) {
+        if (byday) return `Daily on ${formatDayList(byday)}`;
+        return "Daily";
+      }
+      return `Every ${interval} days`;
+    }
+    case "WEEKLY": {
+      const prefix = interval === 1 ? "Weekly" : `Every ${interval} weeks`;
+      if (byday) {
+        const days = byday.split(",");
+        if (isWeekdays(days)) return interval === 1 ? "Every weekday" : `${prefix} on weekdays`;
+        return `${prefix} on ${formatDayList(byday)}`;
+      }
+      return prefix;
+    }
+    case "MONTHLY": {
+      const prefix = interval === 1 ? "Monthly" : `Every ${interval} months`;
+      if (bymonthday) return `${prefix} on day ${bymonthday}`;
+      return prefix;
+    }
+    case "YEARLY": {
+      const prefix = interval === 1 ? "Yearly" : `Every ${interval} years`;
+      if (bymonth && bymonthday) {
+        const monthName = MONTH_NAMES[Number.parseInt(bymonth, 10)] ?? bymonth;
+        return `${prefix} on ${monthName} ${bymonthday}`;
+      }
+      return prefix;
+    }
+    default:
+      return rule;
+  }
+}

--- a/packages/electron/src/renderer/styles.css
+++ b/packages/electron/src/renderer/styles.css
@@ -865,3 +865,115 @@ button.detail-description {
 .input-error {
   border-color: #ef4444 !important;
 }
+
+/* ============================================================================
+ * Schedule Preset Picker
+ * ============================================================================ */
+
+.schedule-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.schedule-sub-select {
+  max-width: 200px;
+}
+
+.schedule-custom-input {
+  font-family: monospace;
+  font-size: 13px;
+}
+
+/* ============================================================================
+ * Recurring Detail extras
+ * ============================================================================ */
+
+.toolbar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.detail-paused-badge {
+  margin-left: 8px;
+  font-size: 12px;
+  vertical-align: middle;
+}
+
+.status-paused {
+  background: #78716c;
+  color: #fafaf9;
+}
+
+.inline-schedule-edit {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.clickable-value {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: inherit;
+  text-align: left;
+}
+
+.clickable-value:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.data-table-compact {
+  font-size: 13px;
+}
+
+.data-table-compact td,
+.data-table-compact th {
+  padding: 6px 10px;
+}
+
+.generated-tag {
+  color: #22c55e;
+  font-size: 13px;
+}
+
+.skip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* ============================================================================
+ * Notes
+ * ============================================================================ */
+
+.cell-content {
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #ccc;
+}
+
+.entity-link {
+  background: none;
+  border: none;
+  color: #60a5fa;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+  text-decoration: none;
+}
+
+.entity-link:hover {
+  text-decoration: underline;
+}
+
+.form-hint {
+  font-size: 12px;
+  color: #888;
+  margin-top: 2px;
+}

--- a/packages/electron/src/renderer/views/CreateNoteDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateNoteDialog.tsx
@@ -1,0 +1,95 @@
+import { type ReactNode, useState } from "react";
+import { useCreateNote } from "../hooks/useTodu.js";
+
+export function CreateNoteDialog({ onClose }: { onClose: () => void }): ReactNode {
+  const createNote = useCreateNote();
+  const [content, setContent] = useState("");
+  const [tagsInput, setTagsInput] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = () => {
+    if (!content.trim()) {
+      setError("Content is required");
+      return;
+    }
+    setError("");
+    const tags = tagsInput
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    createNote.mutate(
+      {
+        content: content.trim(),
+        tags: tags.length > 0 ? tags : undefined,
+        author: "user",
+      },
+      {
+        onSuccess: onClose,
+        onError: (err) => setError(err instanceof Error ? err.message : "Failed to create note"),
+      },
+    );
+  };
+
+  return (
+    <div
+      className="dialog-overlay"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div
+        className="dialog dialog-wide"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={undefined}
+      >
+        <h3 className="dialog-title">New Journal Note</h3>
+
+        {error && <div className="dialog-error">{error}</div>}
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="note-content">
+            Content *
+          </label>
+          <textarea
+            id="note-content"
+            className="input"
+            rows={5}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Write your note…"
+            ref={(el) => el?.focus()}
+          />
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="note-tags">
+            Tags
+          </label>
+          <input
+            id="note-tags"
+            className="input"
+            value={tagsInput}
+            onChange={(e) => setTagsInput(e.target.value)}
+            placeholder="tag1, tag2, tag3"
+          />
+          <span className="form-hint">Comma-separated</span>
+        </div>
+
+        <div className="dialog-actions">
+          <button type="button" className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={!content.trim() || createNote.isPending}
+          >
+            {createNote.isPending ? "Creating…" : "Create Note"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/views/CreateRecurringDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateRecurringDialog.tsx
@@ -1,0 +1,183 @@
+import { createProjectId } from "@todu/core/browser";
+import { type ReactNode, useState } from "react";
+import { SchedulePresetPicker } from "../components/SchedulePresetPicker.js";
+import { useCreateRecurring, useProjects } from "../hooks/useTodu.js";
+
+export function CreateRecurringDialog({ onClose }: { onClose: () => void }): ReactNode {
+  const { data: projects } = useProjects();
+  const createRecurring = useCreateRecurring();
+
+  const [title, setTitle] = useState("");
+  const [schedule, setSchedule] = useState("FREQ=DAILY");
+  const [projectId, setProjectId] = useState("");
+  const [priority, setPriority] = useState("medium");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
+  const [endDate, setEndDate] = useState("");
+  const [error, setError] = useState("");
+
+  const effectiveProjectId = projectId || projects?.[0]?.id || "";
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const handleSubmit = () => {
+    if (!title.trim()) {
+      setError("Title is required");
+      return;
+    }
+    if (!schedule.trim()) {
+      setError("Schedule is required");
+      return;
+    }
+    if (!effectiveProjectId) {
+      setError("Select a project");
+      return;
+    }
+    setError("");
+    createRecurring.mutate(
+      {
+        title: title.trim(),
+        schedule,
+        projectId: createProjectId(effectiveProjectId),
+        timezone,
+        startDate,
+        priority: priority as "high" | "medium" | "low",
+        description: description.trim() || undefined,
+        endDate: endDate || undefined,
+      },
+      {
+        onSuccess: onClose,
+        onError: (err) =>
+          setError(err instanceof Error ? err.message : "Failed to create template"),
+      },
+    );
+  };
+
+  return (
+    <div
+      className="dialog-overlay"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <div
+        className="dialog dialog-wide"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={undefined}
+      >
+        <h3 className="dialog-title">New Recurring Template</h3>
+
+        {error && <div className="dialog-error">{error}</div>}
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="rec-title">
+            Title *
+          </label>
+          <input
+            id="rec-title"
+            className="input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Recurring task title"
+            ref={(el) => el?.focus()}
+          />
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="rec-schedule">
+            Schedule *
+          </label>
+          <SchedulePresetPicker value={schedule} onChange={setSchedule} />
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="rec-project">
+            Project *
+          </label>
+          <select
+            id="rec-project"
+            className="input"
+            value={effectiveProjectId}
+            onChange={(e) => setProjectId(e.target.value)}
+          >
+            {projects?.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="form-row">
+          <div className="form-field">
+            <label className="form-label" htmlFor="rec-priority">
+              Priority
+            </label>
+            <select
+              id="rec-priority"
+              className="input"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+            >
+              <option value="high">High</option>
+              <option value="medium">Medium</option>
+              <option value="low">Low</option>
+            </select>
+          </div>
+          <div className="form-field">
+            <label className="form-label" htmlFor="rec-start">
+              Start Date *
+            </label>
+            <input
+              id="rec-start"
+              type="date"
+              className="input"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </div>
+          <div className="form-field">
+            <label className="form-label" htmlFor="rec-end">
+              End Date
+            </label>
+            <input
+              id="rec-end"
+              type="date"
+              className="input"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="rec-desc">
+            Description
+          </label>
+          <textarea
+            id="rec-desc"
+            className="input"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description"
+          />
+        </div>
+
+        <div className="dialog-actions">
+          <button type="button" className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleSubmit}
+            disabled={createRecurring.isPending}
+          >
+            {createRecurring.isPending ? "Creating…" : "Create Template"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/views/NoteList.tsx
+++ b/packages/electron/src/renderer/views/NoteList.tsx
@@ -1,0 +1,199 @@
+import type { NoteEntityType, NoteFilter, NoteId } from "@todu/core/browser";
+import { type ReactNode, useMemo, useState } from "react";
+import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { useDeleteNote, useNotes, useProjects, useTasks } from "../hooks/useTodu.js";
+
+export function NoteList({
+  onCreateNote,
+  onNavigateToEntity,
+}: {
+  onCreateNote: () => void;
+  onNavigateToEntity: (entityType: string, entityId: string) => void;
+}): ReactNode {
+  const [filterType, setFilterType] = useState<string>("all");
+  const [filterTag, setFilterTag] = useState("");
+
+  const filter: NoteFilter = {
+    ...(filterType !== "all" && filterType !== "standalone"
+      ? { entityType: filterType as NoteEntityType }
+      : {}),
+    ...(filterTag ? { tag: filterTag } : {}),
+  };
+
+  const { data: notes, isLoading, isError, error } = useNotes(filter);
+  const { data: projects } = useProjects();
+  const { data: tasks } = useTasks();
+  const deleteNote = useDeleteNote();
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; preview: string } | null>(null);
+
+  // Build entity name lookup
+  const entityNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects ?? []) map.set(p.id, p.name);
+    for (const t of tasks ?? []) map.set(t.id, t.title);
+    return map;
+  }, [projects, tasks]);
+
+  // Collect all tags across notes for the filter dropdown
+  const allTags = useMemo(() => {
+    const tags = new Set<string>();
+    for (const note of notes ?? []) {
+      for (const tag of note.tags) tags.add(tag);
+    }
+    return Array.from(tags).sort();
+  }, [notes]);
+
+  // Filter standalone notes client-side (no entityType)
+  const displayNotes = filterType === "standalone" ? notes?.filter((n) => !n.entityType) : notes;
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    deleteNote.mutate(deleteTarget.id as NoteId, {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  };
+
+  const entityLabel = (entityType?: string, entityId?: string): ReactNode => {
+    if (!entityType || !entityId) return <span className="empty-hint">Standalone</span>;
+    const name = entityNames.get(entityId) ?? entityId.slice(0, 12);
+    return (
+      <button
+        type="button"
+        className="entity-link"
+        onClick={(e) => {
+          e.stopPropagation();
+          onNavigateToEntity(entityType, entityId);
+        }}
+      >
+        {entityType}: {name}
+      </button>
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2 className="view-title">Notes</h2>
+        </div>
+        <div className="loading-state">Loading notes…</div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2 className="view-title">Notes</h2>
+        </div>
+        <div className="error-state">
+          <p>Failed to load notes</p>
+          <p className="error-detail">{error instanceof Error ? error.message : "Unknown error"}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-container">
+      <div className="view-header">
+        <h2 className="view-title">Notes</h2>
+        <button type="button" className="btn btn-primary" onClick={onCreateNote}>
+          + New Note
+        </button>
+      </div>
+
+      <div className="filter-bar">
+        <div className="filter-row">
+          <select
+            className="filter-select"
+            value={filterType}
+            onChange={(e) => setFilterType(e.target.value)}
+          >
+            <option value="all">All types</option>
+            <option value="standalone">Standalone</option>
+            <option value="task">Task comments</option>
+            <option value="project">Project comments</option>
+            <option value="habit">Habit comments</option>
+          </select>
+          <select
+            className="filter-select"
+            value={filterTag}
+            onChange={(e) => setFilterTag(e.target.value)}
+          >
+            <option value="">All tags</option>
+            {allTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {!displayNotes || displayNotes.length === 0 ? (
+        <div className="empty-state">
+          <p>No notes found</p>
+        </div>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Author</th>
+              <th>Content</th>
+              <th>Attached To</th>
+              <th>Tags</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {displayNotes.map((note) => (
+              <tr key={note.id}>
+                <td className="cell-date">{note.createdAt.slice(0, 16).replace("T", " ")}</td>
+                <td>{note.author}</td>
+                <td className="cell-content">
+                  {note.content.length > 100 ? `${note.content.slice(0, 100)}…` : note.content}
+                </td>
+                <td>{entityLabel(note.entityType, note.entityId)}</td>
+                <td>
+                  <div className="label-chips">
+                    {note.tags.map((tag) => (
+                      <span key={tag} className="chip chip-label">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="cell-actions">
+                  <button
+                    type="button"
+                    className="btn btn-danger btn-sm"
+                    onClick={() =>
+                      setDeleteTarget({
+                        id: note.id,
+                        preview: note.content.slice(0, 50),
+                      })
+                    }
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {deleteTarget && (
+        <ConfirmDialog
+          title="Delete Note"
+          message={`Delete note "${deleteTarget.preview}…"? This cannot be undone.`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/views/NotesView.tsx
+++ b/packages/electron/src/renderer/views/NotesView.tsx
@@ -1,0 +1,34 @@
+import { type ReactNode, useState } from "react";
+import { CreateNoteDialog } from "./CreateNoteDialog.js";
+import { NoteList } from "./NoteList.js";
+
+type NotesViewState = { view: "list" } | { view: "create" };
+
+export function NotesView({
+  onNavigateToEntity,
+}: {
+  onNavigateToEntity: (entityType: string, entityId: string) => void;
+}): ReactNode {
+  const [state, setState] = useState<NotesViewState>({ view: "list" });
+
+  switch (state.view) {
+    case "list":
+      return (
+        <NoteList
+          onCreateNote={() => setState({ view: "create" })}
+          onNavigateToEntity={onNavigateToEntity}
+        />
+      );
+
+    case "create":
+      return (
+        <>
+          <NoteList
+            onCreateNote={() => setState({ view: "create" })}
+            onNavigateToEntity={onNavigateToEntity}
+          />
+          <CreateNoteDialog onClose={() => setState({ view: "list" })} />
+        </>
+      );
+  }
+}

--- a/packages/electron/src/renderer/views/RecurringDetail.tsx
+++ b/packages/electron/src/renderer/views/RecurringDetail.tsx
@@ -1,0 +1,395 @@
+import type { RecurringId } from "@todu/core/browser";
+import { type ReactNode, useMemo, useState } from "react";
+import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { PriorityChip } from "../components/PriorityChip.js";
+import { SchedulePresetPicker } from "../components/SchedulePresetPicker.js";
+import {
+  useDeleteRecurring,
+  useGenerateOccurrence,
+  usePauseRecurring,
+  useProjects,
+  useRecurringDetail,
+  useResumeRecurring,
+  useUpcoming,
+  useUpdateRecurring,
+} from "../hooks/useTodu.js";
+import { describeSchedule } from "../lib/describe-schedule.js";
+
+// ============================================================================
+// Upcoming Occurrences
+// ============================================================================
+
+function UpcomingSection({ templateId }: { templateId: string }): ReactNode {
+  const { data: upcoming, isLoading } = useUpcoming({ templateId, days: 30 });
+  const generate = useGenerateOccurrence();
+  const [generated, setGenerated] = useState<Map<string, string>>(new Map());
+
+  const handleGenerate = (date: string) => {
+    generate.mutate(
+      { templateId: templateId as RecurringId, date },
+      {
+        onSuccess: (task) => {
+          setGenerated((prev) => new Map(prev).set(date, task.id));
+        },
+      },
+    );
+  };
+
+  if (isLoading) return <div className="loading-state">Loading upcoming…</div>;
+  if (!upcoming || upcoming.length === 0)
+    return <div className="empty-hint">No upcoming occurrences</div>;
+
+  return (
+    <table className="data-table data-table-compact">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {upcoming.map((occ) => {
+          const taskId = generated.get(occ.date);
+          return (
+            <tr key={occ.date}>
+              <td className="cell-date">{occ.date}</td>
+              <td>
+                {taskId ? (
+                  <span className="generated-tag">✓ Task created: {taskId.slice(0, 12)}…</span>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => handleGenerate(occ.date)}
+                    disabled={generate.isPending}
+                  >
+                    Generate
+                  </button>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// ============================================================================
+// Skip List
+// ============================================================================
+
+function SkipList({ dates }: { dates: string[] }): ReactNode {
+  if (dates.length === 0) return <div className="empty-hint">No skipped dates</div>;
+  return (
+    <div className="skip-list">
+      {dates.map((d) => (
+        <span key={d} className="chip chip-inactive">
+          {d}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Recurring Detail View
+// ============================================================================
+
+export function RecurringDetail({
+  templateId,
+  onBack,
+}: {
+  templateId: string;
+  onBack: () => void;
+}): ReactNode {
+  const { data: template, isLoading, isError, error } = useRecurringDetail(templateId);
+  const { data: projects } = useProjects();
+  const updateRecurring = useUpdateRecurring();
+  const deleteRecurring = useDeleteRecurring();
+  const pauseRecurring = usePauseRecurring();
+  const resumeRecurring = useResumeRecurring();
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  const projectMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects ?? []) map.set(p.id, p.name);
+    return map;
+  }, [projects]);
+
+  if (isLoading) {
+    return (
+      <div className="view-container">
+        <div className="loading-state">Loading template…</div>
+      </div>
+    );
+  }
+
+  if (isError || !template) {
+    return (
+      <div className="view-container">
+        <button type="button" className="btn btn-secondary btn-sm" onClick={onBack}>
+          ← Back
+        </button>
+        <div className="error-state">
+          <p>Failed to load template</p>
+          <p className="error-detail">
+            {error instanceof Error ? error.message : "Template not found"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleInlineEdit = (field: string, currentValue: string) => {
+    setEditingField(field);
+    setEditValue(currentValue);
+  };
+
+  const handleInlineSave = (field: string) => {
+    setEditingField(null);
+    if (editValue !== (template as Record<string, unknown>)[field]) {
+      updateRecurring.mutate({
+        id: template.id as RecurringId,
+        input: { [field]: editValue },
+      });
+    }
+  };
+
+  const handleDelete = () => {
+    deleteRecurring.mutate(template.id as RecurringId, { onSuccess: onBack });
+  };
+
+  const handlePauseToggle = () => {
+    if (template.paused) {
+      resumeRecurring.mutate(template.id as RecurringId);
+    } else {
+      pauseRecurring.mutate(template.id as RecurringId);
+    }
+  };
+
+  return (
+    <div className="view-container">
+      <div className="detail-toolbar">
+        <button type="button" className="btn btn-secondary btn-sm" onClick={onBack}>
+          ← Back
+        </button>
+        <div className="toolbar-actions">
+          <button
+            type="button"
+            className={`btn btn-sm ${template.paused ? "btn-primary" : "btn-secondary"}`}
+            onClick={handlePauseToggle}
+          >
+            {template.paused ? "▶ Resume" : "⏸ Pause"}
+          </button>
+          <button
+            type="button"
+            className="btn btn-danger btn-sm"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {/* Title */}
+      <div className="detail-title-row">
+        {editingField === "title" ? (
+          <input
+            className="input detail-title-input"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={() => handleInlineSave("title")}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleInlineSave("title");
+              if (e.key === "Escape") setEditingField(null);
+            }}
+            ref={(el) => el?.focus()}
+          />
+        ) : (
+          <button
+            type="button"
+            className="detail-title clickable"
+            onClick={() => handleInlineEdit("title", template.title)}
+          >
+            {template.title}
+            {template.paused && (
+              <span className="chip status-paused detail-paused-badge">paused</span>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Schedule */}
+      <div className="detail-field">
+        <span className="detail-label">Schedule</span>
+        {editingField === "schedule" ? (
+          <div className="inline-schedule-edit">
+            <SchedulePresetPicker value={editValue} onChange={(v) => setEditValue(v)} />
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => {
+                setEditingField(null);
+                if (editValue !== template.schedule) {
+                  updateRecurring.mutate({
+                    id: template.id as RecurringId,
+                    input: { schedule: editValue },
+                  });
+                }
+              }}
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={() => setEditingField(null)}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="clickable-value"
+            onClick={() => handleInlineEdit("schedule", template.schedule)}
+          >
+            {describeSchedule(template.schedule)}
+          </button>
+        )}
+      </div>
+
+      {/* Priority */}
+      <div className="detail-field">
+        <span className="detail-label">Priority</span>
+        <select
+          className="filter-select inline-select"
+          value={template.priority}
+          onChange={(e) =>
+            updateRecurring.mutate({
+              id: template.id as RecurringId,
+              input: { priority: e.target.value as "high" | "medium" | "low" },
+            })
+          }
+        >
+          <option value="high">High</option>
+          <option value="medium">Medium</option>
+          <option value="low">Low</option>
+        </select>
+      </div>
+
+      {/* Project */}
+      <div className="detail-field">
+        <span className="detail-label">Project</span>
+        <select
+          className="filter-select inline-select"
+          value={template.projectId}
+          onChange={(e) =>
+            updateRecurring.mutate({
+              id: template.id as RecurringId,
+              input: { projectId: e.target.value as RecurringId },
+            })
+          }
+        >
+          {projects?.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Dates */}
+      <div className="detail-field">
+        <span className="detail-label">Start Date</span>
+        <span>{template.startDate}</span>
+      </div>
+      {template.endDate && (
+        <div className="detail-field">
+          <span className="detail-label">End Date</span>
+          <span>{template.endDate}</span>
+        </div>
+      )}
+      <div className="detail-field">
+        <span className="detail-label">Next Due</span>
+        <span>{template.nextDue ?? "—"}</span>
+      </div>
+      <div className="detail-field">
+        <span className="detail-label">Timezone</span>
+        <span>{template.timezone}</span>
+      </div>
+
+      {/* Labels */}
+      <div className="detail-field">
+        <span className="detail-label">Labels</span>
+        <div className="label-chips">
+          {template.labels.length > 0 ? (
+            template.labels.map((l) => (
+              <span key={l} className="chip chip-label">
+                {l}
+              </span>
+            ))
+          ) : (
+            <span className="empty-hint">None</span>
+          )}
+        </div>
+      </div>
+
+      {/* Description */}
+      <div className="detail-section">
+        <h3 className="section-title">Description</h3>
+        {editingField === "description" ? (
+          <textarea
+            className="input detail-description-input"
+            rows={3}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={() => handleInlineSave("description")}
+            ref={(el) => el?.focus()}
+          />
+        ) : (
+          <button
+            type="button"
+            className="detail-description clickable"
+            onClick={() => handleInlineEdit("description", template.description ?? "")}
+          >
+            {template.description || <span className="empty-hint">Click to add description…</span>}
+          </button>
+        )}
+      </div>
+
+      {/* Metadata */}
+      <div className="detail-meta">
+        <span>Created: {template.createdAt.slice(0, 10)}</span>
+        <span>Updated: {template.updatedAt.slice(0, 10)}</span>
+        <span>ID: {template.id}</span>
+      </div>
+
+      {/* Upcoming Occurrences */}
+      <div className="detail-section">
+        <h3 className="section-title">Upcoming Occurrences (next 30 days)</h3>
+        <UpcomingSection templateId={templateId} />
+      </div>
+
+      {/* Skip List */}
+      <div className="detail-section">
+        <h3 className="section-title">Skipped Dates</h3>
+        <SkipList dates={template.skippedDates ?? []} />
+      </div>
+
+      {/* Delete confirmation */}
+      {showDeleteConfirm && (
+        <ConfirmDialog
+          title="Delete Template"
+          message={`Delete "${template.title}"? This cannot be undone. Existing generated tasks will not be affected.`}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/views/RecurringDetail.tsx
+++ b/packages/electron/src/renderer/views/RecurringDetail.tsx
@@ -1,4 +1,4 @@
-import type { RecurringId } from "@todu/core/browser";
+import { type RecurringId, createProjectId } from "@todu/core/browser";
 import { type ReactNode, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { PriorityChip } from "../components/PriorityChip.js";
@@ -291,7 +291,7 @@ export function RecurringDetail({
           onChange={(e) =>
             updateRecurring.mutate({
               id: template.id as RecurringId,
-              input: { projectId: e.target.value as RecurringId },
+              input: { projectId: createProjectId(e.target.value) },
             })
           }
         >

--- a/packages/electron/src/renderer/views/RecurringList.tsx
+++ b/packages/electron/src/renderer/views/RecurringList.tsx
@@ -1,0 +1,137 @@
+import type { RecurringFilter } from "@todu/core/browser";
+import { type ReactNode, useMemo, useState } from "react";
+import { PriorityChip } from "../components/PriorityChip.js";
+import { useProjects, useRecurringList } from "../hooks/useTodu.js";
+import { describeSchedule } from "../lib/describe-schedule.js";
+
+export function RecurringList({
+  onSelectTemplate,
+  onCreateTemplate,
+}: {
+  onSelectTemplate: (id: string) => void;
+  onCreateTemplate: () => void;
+}): ReactNode {
+  const [filterStatus, setFilterStatus] = useState<"all" | "active" | "paused">("all");
+  const [filterProject, setFilterProject] = useState("");
+
+  const filter: RecurringFilter = {
+    ...(filterStatus === "active" ? { paused: false } : {}),
+    ...(filterStatus === "paused" ? { paused: true } : {}),
+    ...(filterProject ? { projectId: filterProject as RecurringFilter["projectId"] } : {}),
+  };
+
+  const { data: templates, isLoading, isError, error } = useRecurringList(filter);
+  const { data: projects } = useProjects();
+
+  const projectMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects ?? []) map.set(p.id, p.name);
+    return map;
+  }, [projects]);
+
+  if (isLoading) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2 className="view-title">Recurring Templates</h2>
+        </div>
+        <div className="loading-state">Loading templates…</div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2 className="view-title">Recurring Templates</h2>
+        </div>
+        <div className="error-state">
+          <p>Failed to load templates</p>
+          <p className="error-detail">{error instanceof Error ? error.message : "Unknown error"}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-container">
+      <div className="view-header">
+        <h2 className="view-title">Recurring Templates</h2>
+        <button type="button" className="btn btn-primary" onClick={onCreateTemplate}>
+          + New Template
+        </button>
+      </div>
+
+      <div className="filter-bar">
+        <div className="filter-row">
+          <select
+            className="filter-select"
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value as "all" | "active" | "paused")}
+          >
+            <option value="all">All statuses</option>
+            <option value="active">Active only</option>
+            <option value="paused">Paused only</option>
+          </select>
+          <select
+            className="filter-select"
+            value={filterProject}
+            onChange={(e) => setFilterProject(e.target.value)}
+          >
+            <option value="">All projects</option>
+            {projects?.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {!templates || templates.length === 0 ? (
+        <div className="empty-state">
+          <p>No recurring templates</p>
+        </div>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Schedule</th>
+              <th>Project</th>
+              <th>Priority</th>
+              <th>Next Due</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {templates.map((t) => (
+              <tr
+                key={t.id}
+                className="clickable-row"
+                onClick={() => onSelectTemplate(t.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") onSelectTemplate(t.id);
+                }}
+              >
+                <td className="cell-name">{t.title}</td>
+                <td className="cell-schedule">{describeSchedule(t.schedule)}</td>
+                <td className="cell-project">{projectMap.get(t.projectId) ?? "—"}</td>
+                <td>
+                  <PriorityChip priority={t.priority} />
+                </td>
+                <td className="cell-date">{t.nextDue?.slice(0, 10) ?? "—"}</td>
+                <td>
+                  <span className={`chip ${t.paused ? "status-paused" : "status-active"}`}>
+                    {t.paused ? "paused" : "active"}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/views/RecurringView.tsx
+++ b/packages/electron/src/renderer/views/RecurringView.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode, useState } from "react";
+import { CreateRecurringDialog } from "./CreateRecurringDialog.js";
+import { RecurringDetail } from "./RecurringDetail.js";
+import { RecurringList } from "./RecurringList.js";
+
+type RecurringViewState =
+  | { view: "list" }
+  | { view: "detail"; templateId: string }
+  | { view: "create" };
+
+export function RecurringView(): ReactNode {
+  const [state, setState] = useState<RecurringViewState>({ view: "list" });
+
+  switch (state.view) {
+    case "list":
+      return (
+        <RecurringList
+          onSelectTemplate={(id) => setState({ view: "detail", templateId: id })}
+          onCreateTemplate={() => setState({ view: "create" })}
+        />
+      );
+
+    case "detail":
+      return (
+        <RecurringDetail templateId={state.templateId} onBack={() => setState({ view: "list" })} />
+      );
+
+    case "create":
+      return (
+        <>
+          <RecurringList
+            onSelectTemplate={(id) => setState({ view: "detail", templateId: id })}
+            onCreateTemplate={() => setState({ view: "create" })}
+          />
+          <CreateRecurringDialog onClose={() => setState({ view: "list" })} />
+        </>
+      );
+  }
+}


### PR DESCRIPTION
## Overview

Recurring template management and notes browsing in Electron GUI — Phase 2, Slice 5.

## What's New

### Recurring Template Views
- **RecurringList** — table with human-readable schedules (via `describeSchedule`), project, priority, next due, pause status. Filter by active/paused and project.
- **RecurringDetail** — inline edit (title, description, schedule via preset picker), priority/project dropdowns, pause/resume toggle, upcoming occurrences (30-day projection) with per-date "Generate" button for early materialization, skipped dates list.
- **CreateRecurringDialog** — full form: title, schedule preset picker, project, priority, start/end date, description.
- **RecurringView** — router managing list → detail → create navigation.

### Notes Views
- **NoteList** — all notes with type filter (all/standalone/task/project/habit), tag filter dropdown, entity navigation links (clickable "task: Fix login" links), delete with confirmation.
- **CreateNoteDialog** — standalone journal note with comma-separated tags.
- **NotesView** — router with entity navigation callback.

### Shared Components
- **SchedulePresetPicker** — daily/weekdays/weekly (pick day)/monthly (pick date) presets + custom RRULE input. Reusable for Habit views (#1625).
- **describeSchedule** — browser-safe RRULE-to-human-readable description (mirrors engine implementation without `node:module` dependency).

### React Query Hooks (9 new)
`useRecurringList`, `useRecurringDetail`, `useUpcoming`, `useCreateRecurring`, `useUpdateRecurring`, `useDeleteRecurring`, `usePauseRecurring`, `useResumeRecurring`, `useGenerateOccurrence`

### App Integration
- Recurring and Notes views wired into ViewRouter
- Entity navigation: clicking entity-attached notes navigates to the target view (tasks/projects/habits)

## Acceptance Criteria

- [x] Recurring template list shows all templates with human-readable schedules
- [x] Can create template with schedule preset or custom RRULE
- [x] Can edit template title, schedule, project, priority, labels, dates
- [x] Can pause and resume templates
- [x] Can delete templates with confirmation
- [x] Template detail shows upcoming occurrences (virtual, no tasks created)
- [x] "Generate" button creates a task for a future date
- [x] Skip list displayed on template detail
- [x] Notes list shows all notes with type and tag filtering
- [x] Can create standalone journal notes
- [x] Can delete notes with confirmation
- [x] Clicking an entity-attached note navigates to the parent entity
- [x] Loading and empty states for all views

## Files Changed (12 files, +1565 / -5)

| Area | Files |
|------|-------|
| Recurring Views | `RecurringView.tsx`, `RecurringList.tsx`, `RecurringDetail.tsx`, `CreateRecurringDialog.tsx` |
| Notes Views | `NotesView.tsx`, `NoteList.tsx`, `CreateNoteDialog.tsx` |
| Shared | `SchedulePresetPicker.tsx`, `describe-schedule.ts` |
| Hooks | `useTodu.ts` (9 recurring hooks) |
| App | `App.tsx` (routing + entity navigation) |
| Styles | `styles.css` (schedule picker, recurring detail, notes, entity links) |

Task: #1587