### PR TITLE
feat: update cli-note integration tests with Electron sync verification

### DIFF
--- a/integration-tests/cli-note/README.md
+++ b/integration-tests/cli-note/README.md
@@ -1,17 +1,31 @@
 # CLI Note Integration Tests
 
-Tests for `toduai note` commands. Notes can be standalone (journal entries) or attached to entities (tasks, projects).
+Tests for `toduai note` commands with Electron sync verification. Notes can be standalone (journal entries) or attached to entities (tasks, projects).
 
 ## Setup
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+# Launch Electron with shared data dir
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
 ```
 
 ## Tests
 
-- [add-journal.md](add-journal.md) — Standalone journal entries
+- [add-journal.md](add-journal.md) — Standalone journal entries, verify in Electron
 - [add-attached.md](add-attached.md) — Notes attached to tasks and projects
-- [list-filters.md](list-filters.md) — Filter by task, project, tag, author
-- [delete.md](delete.md) — Delete notes
-- [errors.md](errors.md) — Missing entities, invalid inputs
+- [list-filters.md](list-filters.md) — Filter by type, tag; verify Electron filters
+- [delete.md](delete.md) — Delete notes, verify removal in Electron
+- [errors.md](errors.md) — Missing entities, invalid inputs, Electron validation
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
+rm -rf "$TODU_DATA_DIR"
+```

--- a/integration-tests/cli-note/add-attached.md
+++ b/integration-tests/cli-note/add-attached.md
@@ -6,12 +6,19 @@ Notes attached to tasks or projects.
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
+
 toduai project create --name "My App"
 TASK=$(toduai --format json task create --title "Fix bug" --project "My App")
 TASK_ID=$(echo "$TASK" | jq -r .id)
 ```
 
-## Note Attached to Task
+## 1. Note Attached to Task (CLI)
 
 ```bash
 toduai note add "Found the root cause — null pointer in auth module" --task "$TASK_ID"
@@ -29,7 +36,7 @@ Entity:  task:task-XXXXXXXX
 Found the root cause — null pointer in auth module
 ```
 
-## Note Attached to Project (by Name)
+## 2. Note Attached to Project by Name (CLI)
 
 ```bash
 toduai note add "Architecture decision: use Automerge for sync" --project "My App"
@@ -47,7 +54,7 @@ Entity:  project:proj-XXXXXXXX
 Architecture decision: use Automerge for sync
 ```
 
-## Attached Note with Tags
+## 3. Attached Note with Tags (CLI)
 
 ```bash
 toduai note add "Blocked on API key" --task "$TASK_ID" --tag blocker
@@ -55,7 +62,7 @@ toduai note add "Blocked on API key" --task "$TASK_ID" --tag blocker
 
 **Expected:** Shows entity and tags.
 
-## Verify Task Notes
+## 4. Verify Task Notes (CLI)
 
 ```bash
 toduai note list --task "$TASK_ID" --no-color
@@ -63,7 +70,7 @@ toduai note list --task "$TASK_ID" --no-color
 
 **Expected:** Shows 2 notes attached to the task.
 
-## Verify Project Notes
+## 5. Verify Project Notes (CLI)
 
 ```bash
 toduai note list --project "My App" --no-color
@@ -71,8 +78,86 @@ toduai note list --project "My App" --no-color
 
 **Expected:** Shows 1 note attached to the project.
 
-## Cleanup
+## 6. Verify Electron Shows Attached Notes
 
 ```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Table shows all 3 notes:
+- "Found the root cause..." with Attached To = "task: Fix bug"
+- "Architecture decision..." with Attached To = "project: My App"
+- "Blocked on API key" with Attached To = "task: Fix bug", Tags: blocker
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-attached-list.png
+```
+
+## 7. Verify Electron Entity Type Filter
+
+```bash
+# Filter to "Task comments" only
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[0];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'task');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    return sel.value;
+  })()
+"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 3000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Only 2 task-attached notes shown.
+
+```bash
+# Filter to "Project comments"
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[0];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'project');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    return sel.value;
+  })()
+"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 3000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Only 1 project-attached note ("Architecture decision...").
+
+```bash
+# Reset filter
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[0];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'all');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  })()
+"
+```
+
+## 8. Verify Entity Link Navigation
+
+Click the entity link to navigate to the attached task.
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click ".entity-link >> nth=0"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".detail-title" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".detail-title"
+```
+
+**Expected:** Navigates to task detail view showing "Fix bug".
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
 rm -rf "$TODU_DATA_DIR"
 ```

--- a/integration-tests/cli-note/add-journal.md
+++ b/integration-tests/cli-note/add-journal.md
@@ -4,9 +4,15 @@
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
 ```
 
-## Simple Journal Entry
+## 1. Simple Journal Entry (CLI)
 
 ```bash
 toduai note add "Today I shipped the login feature"
@@ -23,7 +29,7 @@ Created: YYYY-MM-DDTHH:MM:SS.MMMZ
 Today I shipped the login feature
 ```
 
-## Journal Entry with Tags
+## 2. Journal Entry with Tags (CLI)
 
 ```bash
 toduai note add "Sprint retrospective went well" --tag retro --tag weekly
@@ -41,7 +47,7 @@ Tags:    retro, weekly
 Sprint retrospective went well
 ```
 
-## Journal Entry with Author
+## 3. Journal Entry with Author (CLI)
 
 ```bash
 toduai note add "Reviewed the PR" --author "agent"
@@ -58,25 +64,15 @@ Created: YYYY-MM-DDTHH:MM:SS.MMMZ
 Reviewed the PR
 ```
 
-## Journal Entry with JSON Output
+## 4. Journal Entry with JSON Output (CLI)
 
 ```bash
 toduai --format json note add "Quick thought"
 ```
 
-**Expected:**
+**Expected:** JSON object with id, content, author, tags, createdAt.
 
-```json
-{
-  "id": "note-XXXXXXXX",
-  "content": "Quick thought",
-  "author": "user",
-  "tags": [],
-  "createdAt": "YYYY-MM-DDTHH:MM:SS.MMMZ"
-}
-```
-
-## Verify
+## 5. Verify CLI List
 
 ```bash
 toduai note list --no-color
@@ -84,8 +80,80 @@ toduai note list --no-color
 
 **Expected:** All 4 notes listed.
 
-## Cleanup
+## 6. Verify Electron Shows CLI-Created Notes
 
 ```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Table shows all 4 notes with columns: Date, Author, Content, Attached To, Tags, Actions.
+- "Today I shipped..." with Author=user, Attached To=Standalone
+- "Sprint retrospective..." with Tags: retro, weekly
+- "Reviewed the PR" with Author=agent
+- "Quick thought" with Author=user
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-journal-list.png
+```
+
+## 7. Create Journal Note in Electron
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "text=+ New Note"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".dialog" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-create-dialog.png
+```
+
+**Expected:** "New Journal Note" dialog with Content textarea and Tags input.
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "#note-content"
+NODE_PATH=$NODE_PATH node $INTERACT type "Created from Electron UI"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-content').value"
+```
+
+**Expected:** Returns `"Created from Electron UI"`.
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "#note-tags"
+NODE_PATH=$NODE_PATH node $INTERACT type "electron, test"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-tags').value"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-content').value"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-create-typed.png
+```
+
+**Expected:**
+- Tags returns `"electron, test"`
+- Content still returns `"Created from Electron UI"` (unchanged)
+- If content got corrupted, confirms focus-stealing bug (#1762)
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click ".dialog-actions .btn-primary"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Dialog closes. Table now shows 5 notes including "Created from Electron UI" with tags: electron, test.
+
+## 8. Verify CLI Sees Electron-Created Note
+
+```bash
+toduai note list --no-color
+```
+
+**Expected:** Five notes shown, including "Created from Electron UI".
+
+```bash
+toduai note list --tag electron --no-color
+```
+
+**Expected:** Only "Created from Electron UI".
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
 rm -rf "$TODU_DATA_DIR"
 ```

--- a/integration-tests/cli-note/delete.md
+++ b/integration-tests/cli-note/delete.md
@@ -4,14 +4,25 @@
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
-NOTE=$(toduai --format json note add "Delete me")
-NOTE_ID=$(echo "$NOTE" | jq -r .id)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
+
+NOTE1=$(toduai --format json note add "Delete me")
+NOTE1_ID=$(echo "$NOTE1" | jq -r .id)
+NOTE2=$(toduai --format json note add "Keep me")
+NOTE2_ID=$(echo "$NOTE2" | jq -r .id)
+NOTE3=$(toduai --format json note add "Electron delete target")
+NOTE3_ID=$(echo "$NOTE3" | jq -r .id)
 ```
 
-## Delete Note
+## 1. Delete Note (CLI)
 
 ```bash
-toduai note delete "$NOTE_ID"
+toduai note delete "$NOTE1_ID"
 ```
 
 **Expected:**
@@ -20,32 +31,71 @@ toduai note delete "$NOTE_ID"
 Deleted note: note-XXXXXXXX
 ```
 
-## Verify Deleted
+## 2. Verify Deleted (CLI)
 
 ```bash
 toduai note list --no-color
 ```
 
-**Expected:**
+**Expected:** Only "Keep me" and "Electron delete target" shown.
 
-```
-No results.
-```
-
-## Delete Nonexistent Note
+## 3. Verify Electron Reflects CLI Deletion
 
 ```bash
-toduai note delete "note-nonexistent"
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
 ```
 
-**Expected:**
-
-```
-Error: note not found: note-nonexistent
-```
-
-## Cleanup
+**Expected:** Only "Keep me" and "Electron delete target" in table.
 
 ```bash
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-delete-cli.png
+```
+
+## 4. Delete Note from Electron
+
+```bash
+# Click Delete on the last row ("Electron delete target")
+NODE_PATH=$NODE_PATH node $INTERACT click ".cell-actions .btn-danger >> nth=1"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".dialog" --timeout 3000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".dialog"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-delete-confirm.png
+```
+
+**Expected:** ConfirmDialog: "Delete note 'Electron delete target...'? This cannot be undone."
+
+```bash
+# Confirm deletion
+NODE_PATH=$NODE_PATH node $INTERACT click ".dialog-actions .btn-danger"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Only "Keep me" remains.
+
+## 5. Verify CLI Sees Electron Deletion
+
+```bash
+toduai note list --no-color
+```
+
+**Expected:** Only "Keep me" shown.
+
+## 6. Delete Last Note — Empty State
+
+```bash
+toduai note delete "$NOTE2_ID"
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".empty-state" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".empty-state"
+```
+
+**Expected:** "No notes found"
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
 rm -rf "$TODU_DATA_DIR"
 ```

--- a/integration-tests/cli-note/errors.md
+++ b/integration-tests/cli-note/errors.md
@@ -4,9 +4,15 @@
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
 ```
 
-## Add Note to Nonexistent Task
+## 1. Add Note to Nonexistent Task (CLI)
 
 ```bash
 toduai note add "Orphan note" --task "task-nonexistent"
@@ -20,44 +26,85 @@ Error: task not found: task-nonexistent
 
 Exit code: 1
 
-## Add Note to Nonexistent Project
+## 2. Add Note to Nonexistent Project (CLI)
 
 ```bash
 toduai note add "Orphan note" --project "Nonexistent"
 ```
 
-**Expected:**
+**Expected:** `Project not found: Nonexistent`
 
-```
-Project not found: Nonexistent
-```
-
-## List Notes for Nonexistent Project
+## 3. List Notes for Nonexistent Project (CLI)
 
 ```bash
 toduai note list --project "Nonexistent"
 ```
 
-**Expected:**
+**Expected:** `Project not found: Nonexistent`
 
-```
-Project not found: Nonexistent
-```
-
-## Delete Nonexistent Note
+## 4. Delete Nonexistent Note (CLI)
 
 ```bash
 toduai note delete "note-nonexistent"
 ```
 
-**Expected:**
+**Expected:** `Error: note not found: note-nonexistent`
 
-```
-Error: note not found: note-nonexistent
-```
-
-## Cleanup
+## 5. Electron Create — Empty Content Validation
 
 ```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".content-area" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT click "text=+ New Note"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".dialog" --timeout 5000
+
+# Try to create without entering content
+NODE_PATH=$NODE_PATH node $INTERACT click ".dialog-actions .btn-primary"
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".dialog"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-errors-empty.png
+```
+
+**Expected:** Error message "Content is required" shown in dialog. Dialog stays open.
+
+## 6. Electron Create Button Disabled Without Content
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('.dialog-actions .btn-primary').disabled"
+```
+
+**Expected:** Returns `true` — Create Note button is disabled when content is empty.
+
+## 7. Electron Multi-Field Typing — Focus-Stealing Detection
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "#note-content"
+NODE_PATH=$NODE_PATH node $INTERACT type "Test note content"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-content').value"
+```
+
+**Expected:** Returns `"Test note content"`.
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "#note-tags"
+NODE_PATH=$NODE_PATH node $INTERACT type "tag1, tag2"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-tags').value"
+NODE_PATH=$NODE_PATH node $INTERACT eval "document.querySelector('#note-content').value"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-errors-typing.png
+```
+
+**Expected:**
+- Tags returns `"tag1, tag2"`
+- Content still returns `"Test note content"` (unchanged)
+- If content got corrupted, confirms focus-stealing bug (#1762) in CreateNoteDialog
+
+```bash
+# Close dialog
+NODE_PATH=$NODE_PATH node $INTERACT click ".dialog-actions .btn-secondary"
+```
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
 rm -rf "$TODU_DATA_DIR"
 ```

--- a/integration-tests/cli-note/list-filters.md
+++ b/integration-tests/cli-note/list-filters.md
@@ -4,6 +4,13 @@
 
 ```bash
 export TODU_DATA_DIR=$(mktemp -d)
+export NODE_PATH=$(find ~/.npm/_npx -path "*/node_modules/playwright" -type d 2>/dev/null | head -1 | xargs dirname)
+export INTERACT=~/.pi/agent/skills/electron-testing/scripts/interact.js
+
+~/.pi/agent/skills/electron-testing/scripts/launch.sh \
+  --app-path ./packages/electron/dist/main/index.js \
+  --env "TODU_DATA_DIR=$TODU_DATA_DIR"
+
 toduai project create --name "App"
 toduai project create --name "Infra"
 TASK=$(toduai --format json task create --title "Fix bug" --project "App")
@@ -17,7 +24,7 @@ toduai note add "Agent review" --author agent --tag review
 toduai note add "Infra note" --project "Infra"
 ```
 
-## List All
+## 1. List All (CLI)
 
 ```bash
 toduai note list --no-color
@@ -25,7 +32,7 @@ toduai note list --no-color
 
 **Expected:** All 5 notes shown.
 
-## Filter by Task
+## 2. Filter by Task (CLI)
 
 ```bash
 toduai note list --task "$TASK_ID" --no-color
@@ -33,7 +40,7 @@ toduai note list --task "$TASK_ID" --no-color
 
 **Expected:** Only "Task progress".
 
-## Filter by Project
+## 3. Filter by Project (CLI)
 
 ```bash
 toduai note list --project "App" --no-color
@@ -41,7 +48,7 @@ toduai note list --project "App" --no-color
 
 **Expected:** Only "Project decision".
 
-## Filter by Tag
+## 4. Filter by Tag (CLI)
 
 ```bash
 toduai note list --tag daily --no-color
@@ -49,7 +56,7 @@ toduai note list --tag daily --no-color
 
 **Expected:** Only "Journal entry".
 
-## Filter by Author
+## 5. Filter by Author (CLI)
 
 ```bash
 toduai note list --author agent --no-color
@@ -57,7 +64,7 @@ toduai note list --author agent --no-color
 
 **Expected:** Only "Agent review".
 
-## List as JSON
+## 6. List as JSON (CLI)
 
 ```bash
 toduai --format json note list
@@ -65,20 +72,95 @@ toduai --format json note list
 
 **Expected:** JSON array of all note objects.
 
-## Empty Results
+## 7. Empty Results (CLI)
 
 ```bash
 toduai note list --tag nonexistent --no-color
 ```
 
-**Expected:**
+**Expected:** `No results.`
 
-```
-No results.
-```
-
-## Cleanup
+## 8. Verify Electron Shows All Notes
 
 ```bash
+NODE_PATH=$NODE_PATH node $INTERACT click "text=Notes"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 5000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+```
+
+**Expected:** Table shows all 5 notes with Date, Author, Content, Attached To, Tags columns.
+
+```bash
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-filters-all.png
+```
+
+## 9. Verify Electron Type Filter
+
+```bash
+# Filter to "Standalone" notes only
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[0];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'standalone');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    return sel.value;
+  })()
+"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 3000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-filters-standalone.png
+```
+
+**Expected:** Only standalone notes shown (Journal entry, Agent review — no entity attachment).
+
+```bash
+# Reset to all
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[0];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'all');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  })()
+"
+```
+
+## 10. Verify Electron Tag Filter
+
+```bash
+# Filter by tag "daily"
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[1];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, 'daily');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    return sel.value;
+  })()
+"
+NODE_PATH=$NODE_PATH node $INTERACT wait ".data-table" --timeout 3000
+NODE_PATH=$NODE_PATH node $INTERACT text --selector ".data-table"
+NODE_PATH=$NODE_PATH node $INTERACT screenshot --output /tmp/test-note-filters-tag.png
+```
+
+**Expected:** Only "Journal entry" shown (tagged with "daily").
+
+```bash
+# Reset tag filter
+NODE_PATH=$NODE_PATH node $INTERACT eval "
+  (() => {
+    const sel = document.querySelectorAll('.filter-select')[1];
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value').set;
+    setter.call(sel, '');
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  })()
+"
+```
+
+## Teardown
+
+```bash
+~/.pi/agent/skills/electron-testing/scripts/stop.sh
 rm -rf "$TODU_DATA_DIR"
 ```


### PR DESCRIPTION
## Task #1757

Update all 5 note integration test files to include Electron app verification alongside existing CLI checks.

### Changes
All tests updated with:
- Wait-based synchronization (no blind sleeps)
- Bidirectional sync verification (CLI→Electron, Electron→CLI)
- IIFE-wrapped eval blocks (fixes bare `return` SyntaxError in Playwright evaluate)

**Test files (5):** add-journal, add-attached, list-filters, delete, errors

### Electron-Specific Tests Added
- Create journal note via CreateNoteDialog (content + tags)
- Type filter dropdown (all/standalone/task/project/habit)
- Tag filter dropdown
- Entity link navigation (click to navigate to attached task/project)
- Delete with ConfirmDialog
- Empty content validation
- Create button disabled state
- Multi-field typing focus-stealing detection

### Verified
- CLI-created notes appear in Electron ✅
- Electron type filter works (standalone, task, project) ✅
- Electron-created notes visible in CLI ✅
- Electron delete with confirmation reflected in CLI ✅
- Focus-stealing bug #1762 confirmed in CreateNoteDialog ✅

### Bugs Referenced
- **#1762** (existing): focus-stealing confirmed in CreateNoteDialog — content textarea has `ref={(el) => el?.focus()}`, corrupts content when typing in tags field