### PR TITLE
Fix Escape key not closing CreateTaskDialog (#1764)

### DIFF
--- a/packages/electron/src/renderer/views/CreateTaskDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateTaskDialog.tsx
@@ -47,7 +47,13 @@ export function CreateTaskDialog({
   };
 
   return (
-    <div className="dialog-overlay" onClick={onClose} onKeyDown={undefined}>
+    <div
+      className="dialog-overlay"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
       <div
         className="dialog dialog-wide"
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary

CreateTaskDialog overlay had `onKeyDown={undefined}` instead of handling Escape. All other dialogs handle it correctly.

## Fix

Added Escape key handler to the overlay, matching the pattern in CreateProjectDialog and all other dialogs:

```tsx
onKeyDown={(e) => {
  if (e.key === "Escape") onClose();
}}
```

## Testing

- ✅ Ctrl+N → Escape closes the dialog
- ✅ `make check` passes

Task: #1764