### PR TITLE
feat: redesign recurring detail with compressed metadata and tabbed content

### DIFF
--- a/packages/electron/src/renderer/views/RecurringDetail.tsx
+++ b/packages/electron/src/renderer/views/RecurringDetail.tsx
@@ -1,5 +1,5 @@
 import { type RecurringId, createProjectId } from "@todu/core/browser";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { CommentThread } from "../components/CommentThread.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { MarkdownEditor } from "../components/MarkdownEditor.js";
@@ -130,12 +130,6 @@ export function RecurringDetail({
   const [scheduleValue, setScheduleValue] = useState("");
   const [editingDescription, setEditingDescription] = useState(false);
   const [activeTab, setActiveTab] = useState("description");
-
-  const projectMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const p of projects ?? []) map.set(p.id, p.name);
-    return map;
-  }, [projects]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

Redesign the recurring template detail view following the established pattern.

### Changes

**Compressed metadata (2 rows)**
- Row 1: Schedule (click-to-edit preset picker), Priority chip + selector, Project selector
- Row 2: Start/End dates, Next due, Timezone, Labels

**Tabbed content (Description | Upcoming | Comments)**
- **Description tab** (default): TipTap MarkdownEditor with click-to-edit
- **Upcoming tab**: 30-day occurrence table with generate buttons + skipped dates list
- **Comments tab**: CommentThread (newly added — was missing from old view)

**Code cleanup**
- Replaced generic `handleInlineEdit`/`handleInlineSave` with specific handlers
- Removed unused `projectMap` variable (was computed but never used)

Task: #1777