### PR TITLE
fix: agentProjectFilter not destructured in ViewRouter crashes app

### DIFF
--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -24,6 +24,7 @@ function ViewRouter({
   onNavigateToEntity,
   triggerCreateTask,
   agentTaskFilter,
+  agentProjectFilter,
   themePreference,
   onThemeChange,
 }: {


### PR DESCRIPTION
## Problem

When the agent calls `list_projects`, the renderer crashes with `agentProjectFilter is not defined` — blank screen.

## Root Cause

`agentProjectFilter` was declared in the `ViewRouter` props type but missing from the destructuring pattern. Used in the JSX body → ReferenceError at runtime.

## Fix

One-line fix: add `agentProjectFilter` to the destructuring.

## Verified

Tested with Electron + Playwright — "show me active projects" now navigates to Projects view with filter applied correctly.

Closes #1795