### PR TITLE
feat: Agent list_recurring emits ui-action to navigate and filter Recurring view

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -358,6 +358,7 @@ export interface UpdateRecurringInput {
 export interface RecurringFilter {
   paused?: boolean;
   projectId?: ProjectId;
+  search?: string;
 }
 
 // ============================================================================

--- a/packages/electron/src/main/tools.test.ts
+++ b/packages/electron/src/main/tools.test.ts
@@ -612,5 +612,59 @@ describe("todu agent tools", () => {
         filter: {},
       });
     });
+
+    it("list_recurring emits show_recurring ui-action with filter", async () => {
+      const sentMessages: Array<{ channel: string; data: unknown }> = [];
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: {
+          send: (channel: string, data: unknown) => {
+            sentMessages.push({ channel, data });
+          },
+        },
+      };
+
+      const toolsWithWindow = createToduTools(
+        todu,
+        mockWindow as unknown as import("electron").BrowserWindow,
+      );
+      const listRecurring = toolsWithWindow.find((t) => t.name === "list_recurring")!;
+
+      await listRecurring.execute("test-call", { paused: false, search: "weekly" });
+
+      const uiActions = sentMessages.filter((m) => m.channel === "todu:ui-action");
+      expect(uiActions).toHaveLength(1);
+      expect(uiActions[0].data).toEqual({
+        action: "show_recurring",
+        filter: { paused: false, search: "weekly" },
+      });
+    });
+
+    it("list_recurring emits empty filter when called without params", async () => {
+      const sentMessages: Array<{ channel: string; data: unknown }> = [];
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: {
+          send: (channel: string, data: unknown) => {
+            sentMessages.push({ channel, data });
+          },
+        },
+      };
+
+      const toolsWithWindow = createToduTools(
+        todu,
+        mockWindow as unknown as import("electron").BrowserWindow,
+      );
+      const listRecurring = toolsWithWindow.find((t) => t.name === "list_recurring")!;
+
+      await listRecurring.execute("test-call", {});
+
+      const uiActions = sentMessages.filter((m) => m.channel === "todu:ui-action");
+      expect(uiActions).toHaveLength(1);
+      expect(uiActions[0].data).toEqual({
+        action: "show_recurring",
+        filter: {},
+      });
+    });
   });
 });

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -216,6 +216,7 @@ const HabitHistoryParams = Type.Object({
 const ListRecurringParams = Type.Object({
   paused: Type.Optional(Type.Boolean({ description: "Filter by paused state" })),
   projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
+  search: Type.Optional(Type.String({ description: "Search recurring templates by title" })),
 });
 
 const RecurringUpcomingParams = Type.Object({
@@ -419,12 +420,22 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     // ── Recurring ────────────────────────────────────────────────────
     {
       name: "list_recurring",
-      description: "List recurring task templates with their schedule and pause status.",
+      description:
+        "List recurring task templates with optional filtering by paused state, project, or title search. Use filter parameters so the UI updates.",
       label: "List Recurring",
       parameters: ListRecurringParams,
       execute: async (_toolCallId, params) => {
         const filter = Object.keys(params).length > 0 ? params : undefined;
-        return formatResult(await todu.recurring.list(filter));
+        const result = await todu.recurring.list(filter);
+
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send("todu:ui-action", {
+            action: "show_recurring",
+            filter: filter ?? {},
+          });
+        }
+
+        return formatResult(result);
       },
     },
     {

--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import type { HabitFilter, ProjectFilter, TaskFilter } from "@todu/core/browser";
+import type { HabitFilter, ProjectFilter, RecurringFilter, TaskFilter } from "@todu/core/browser";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { AgentPane } from "./components/AgentPane.js";
 import { Placeholder } from "./components/Placeholder.js";
@@ -26,6 +26,7 @@ function ViewRouter({
   agentTaskFilter,
   agentProjectFilter,
   agentHabitFilter,
+  agentRecurringFilter,
   themePreference,
   onThemeChange,
 }: {
@@ -35,7 +36,9 @@ function ViewRouter({
   agentTaskFilter: TaskFilter | null;
   agentProjectFilter: ProjectFilter | null;
   agentHabitFilter: HabitFilter | null;
+  agentRecurringFilter: RecurringFilter | null;
   agentHabitFilter: HabitFilter | null;
+  agentRecurringFilter: RecurringFilter | null;
   themePreference: ThemePreference;
   onThemeChange: (pref: ThemePreference) => void;
 }): ReactNode {
@@ -49,7 +52,7 @@ function ViewRouter({
     case "habits":
       return <HabitsView externalFilter={agentHabitFilter} />;
     case "recurring":
-      return <RecurringView />;
+      return <RecurringView externalFilter={agentRecurringFilter} />;
     case "journal":
       return <JournalView />;
     case "labels":
@@ -67,6 +70,7 @@ export function App(): ReactNode {
   const [agentTaskFilter, setAgentTaskFilter] = useState<TaskFilter | null>(null);
   const [agentProjectFilter, setAgentProjectFilter] = useState<ProjectFilter | null>(null);
   const [agentHabitFilter, setAgentHabitFilter] = useState<HabitFilter | null>(null);
+  const [agentRecurringFilter, setAgentRecurringFilter] = useState<RecurringFilter | null>(null);
   const theme = useTheme();
   const sidebar = useSidebar();
   const agentPane = useAgentPane();
@@ -89,6 +93,9 @@ export function App(): ReactNode {
       } else if (uiAction.action === "show_habits") {
         setActiveView("habits");
         setAgentHabitFilter((uiAction.filter as HabitFilter) ?? {});
+      } else if (uiAction.action === "show_recurring") {
+        setActiveView("recurring");
+        setAgentRecurringFilter((uiAction.filter as RecurringFilter) ?? {});
       }
     });
     return cleanup;
@@ -172,6 +179,7 @@ export function App(): ReactNode {
             agentTaskFilter={agentTaskFilter}
             agentProjectFilter={agentProjectFilter}
             agentHabitFilter={agentHabitFilter}
+            agentRecurringFilter={agentRecurringFilter}
             themePreference={theme.preference}
             onThemeChange={theme.setPreference}
           />

--- a/packages/electron/src/renderer/views/RecurringList.tsx
+++ b/packages/electron/src/renderer/views/RecurringList.tsx
@@ -1,5 +1,5 @@
 import type { RecurringFilter } from "@todu/core/browser";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { PriorityChip } from "../components/PriorityChip.js";
 import { useProjects, useRecurringList } from "../hooks/useTodu.js";
 import { describeSchedule } from "../lib/describe-schedule.js";
@@ -7,17 +7,34 @@ import { describeSchedule } from "../lib/describe-schedule.js";
 export function RecurringList({
   onSelectTemplate,
   onCreateTemplate,
+  externalFilter,
 }: {
   onSelectTemplate: (id: string) => void;
   onCreateTemplate: () => void;
+  externalFilter?: RecurringFilter | null;
 }): ReactNode {
   const [filterStatus, setFilterStatus] = useState<"all" | "active" | "paused">("all");
   const [filterProject, setFilterProject] = useState("");
+  const [searchText, setSearchText] = useState("");
+  const appliedExternalRef = useRef<RecurringFilter | null | undefined>(undefined);
+
+  // Apply external filter when it changes (e.g., from agent ui-action)
+  useEffect(() => {
+    if (externalFilter && externalFilter !== appliedExternalRef.current) {
+      appliedExternalRef.current = externalFilter;
+      if (externalFilter.paused === true) setFilterStatus("paused");
+      else if (externalFilter.paused === false) setFilterStatus("active");
+      else setFilterStatus("all");
+      setFilterProject((externalFilter.projectId as string) ?? "");
+      setSearchText(externalFilter.search ?? "");
+    }
+  }, [externalFilter]);
 
   const filter: RecurringFilter = {
     ...(filterStatus === "active" ? { paused: false } : {}),
     ...(filterStatus === "paused" ? { paused: true } : {}),
     ...(filterProject ? { projectId: filterProject as RecurringFilter["projectId"] } : {}),
+    ...(searchText ? { search: searchText } : {}),
   };
 
   const { data: templates, isLoading, isError, error } = useRecurringList(filter);
@@ -65,6 +82,13 @@ export function RecurringList({
 
       <div className="filter-bar">
         <div className="filter-row">
+          <input
+            type="text"
+            className="search-input"
+            placeholder="Search templates…"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+          />
           <select
             className="filter-select"
             value={filterStatus}
@@ -91,7 +115,7 @@ export function RecurringList({
 
       {!templates || templates.length === 0 ? (
         <div className="empty-state">
-          <p>No recurring templates</p>
+          <p>No recurring templates match your filters</p>
         </div>
       ) : (
         <table className="data-table">

--- a/packages/electron/src/renderer/views/RecurringView.tsx
+++ b/packages/electron/src/renderer/views/RecurringView.tsx
@@ -1,3 +1,4 @@
+import type { RecurringFilter } from "@todu/core/browser";
 import { type ReactNode, useState } from "react";
 import { CreateRecurringDialog } from "./CreateRecurringDialog.js";
 import { RecurringDetail } from "./RecurringDetail.js";
@@ -8,7 +9,11 @@ type RecurringViewState =
   | { view: "detail"; templateId: string }
   | { view: "create" };
 
-export function RecurringView(): ReactNode {
+export function RecurringView({
+  externalFilter,
+}: {
+  externalFilter?: RecurringFilter | null;
+}): ReactNode {
   const [state, setState] = useState<RecurringViewState>({ view: "list" });
 
   switch (state.view) {
@@ -17,6 +22,7 @@ export function RecurringView(): ReactNode {
         <RecurringList
           onSelectTemplate={(id) => setState({ view: "detail", templateId: id })}
           onCreateTemplate={() => setState({ view: "create" })}
+          externalFilter={externalFilter}
         />
       );
 
@@ -31,6 +37,7 @@ export function RecurringView(): ReactNode {
           <RecurringList
             onSelectTemplate={(id) => setState({ view: "detail", templateId: id })}
             onCreateTemplate={() => setState({ view: "create" })}
+            externalFilter={externalFilter}
           />
           <CreateRecurringDialog onClose={() => setState({ view: "list" })} />
         </>

--- a/packages/engine/src/recurring.test.ts
+++ b/packages/engine/src/recurring.test.ts
@@ -179,6 +179,30 @@ describe("recurring templates", () => {
       }
     });
 
+    it("filters list by search", async () => {
+      await todu.recurring.create({
+        title: "Weekly Review",
+        projectId,
+        schedule: "FREQ=WEEKLY;BYDAY=FR",
+        timezone: "UTC",
+        startDate: "2026-01-01",
+      });
+      await todu.recurring.create({
+        title: "Daily Standup",
+        projectId,
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-01-01",
+      });
+
+      const result = await todu.recurring.list({ search: "review" });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0].title).toBe("Weekly Review");
+      }
+    });
+
     it("gets a template by ID", async () => {
       const createResult = await todu.recurring.create({
         title: "Get me",

--- a/packages/engine/src/recurring.ts
+++ b/packages/engine/src/recurring.ts
@@ -121,6 +121,10 @@ export function createRecurringNamespace(
       if (filter?.projectId !== undefined) {
         templates = templates.filter((t) => t.projectId === filter.projectId);
       }
+      if (filter?.search) {
+        const lowerQuery = filter.search.toLowerCase();
+        templates = templates.filter((t) => t.title.toLowerCase().includes(lowerQuery));
+      }
 
       return ok(templates);
     },


### PR DESCRIPTION
## Summary

When the agent calls `list_recurring`, it now emits a `todu:ui-action` event that navigates to the Recurring view and applies filter parameters — completing the ui-action pattern across all entity types (tasks, projects, habits, recurring).

## Changes

### Core
- Added `search` field to `RecurringFilter` interface

### Engine
- `recurring.list()` now filters by title search

### Electron - Tools
- `list_recurring` tool has `search` param alongside existing `paused` and `projectId`
- Emits `todu:ui-action` with `action: 'show_recurring'` and filter

### Electron - UI
- `RecurringList` accepts `externalFilter` prop, adds search input to filter bar
- `RecurringView` passes `externalFilter` through
- `App.tsx` handles `show_recurring` action — navigates and applies filter
- Empty state updated to 'No recurring templates match your filters'

## Tests
- Engine test for recurring search filter
- 2 tool tests for ui-action emission from `list_recurring`
- 659 tests pass, 43 files

Closes #1794