### PR TITLE
feat: Clear agent conversation when switching between entity details

### DIFF
--- a/packages/electron/src/main/agent.ts
+++ b/packages/electron/src/main/agent.ts
@@ -110,6 +110,7 @@ export interface FocusedEntity {
 }
 
 let focusedEntity: FocusedEntity | null = null;
+let previousFocusedEntity: FocusedEntity | null = null;
 let focusGeneration = 0;
 
 export function buildSystemPrompt(focused: FocusedEntity | null, entityData?: string): string {
@@ -240,7 +241,24 @@ export function setupAgent(todu: Todu, mainWindow: BrowserWindow): void {
     async (_event, entityType: string, entityId: string) => {
       const validTypes: FocusedEntityType[] = ["task", "project", "habit", "recurring"];
       if (!validTypes.includes(entityType as FocusedEntityType)) return;
+
+      // Clear conversation when switching between different entities.
+      // previousFocusedEntity persists across list views so that
+      // Task A → list → Task B still clears.
+      if (
+        agent &&
+        previousFocusedEntity &&
+        (previousFocusedEntity.entityType !== entityType ||
+          previousFocusedEntity.entityId !== entityId)
+      ) {
+        agent.clearMessages();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send("todu:agent:event", { type: "messages_cleared" });
+        }
+      }
+
       focusedEntity = { entityType: entityType as FocusedEntityType, entityId };
+      previousFocusedEntity = focusedEntity;
       await updateAgentContext(todu);
     },
   );
@@ -269,6 +287,7 @@ export function teardownAgent(): void {
   ipcMain.removeHandler("todu:agent:clear-focused-entity");
 
   focusedEntity = null;
+  previousFocusedEntity = null;
   focusGeneration = 0;
   agent = null;
 }

--- a/packages/electron/src/renderer/views/AgentView.tsx
+++ b/packages/electron/src/renderer/views/AgentView.tsx
@@ -61,7 +61,8 @@ type AgentEvent =
   | AgentEventToolEnd
   | { type: "turn_start" }
   | { type: "turn_end" }
-  | { type: "tool_execution_update" };
+  | { type: "tool_execution_update" }
+  | { type: "messages_cleared" };
 
 // Simplified message shape from the LLM
 interface ChatMessage {
@@ -131,6 +132,12 @@ export function AgentView({ onClose }: AgentViewProps): ReactNode {
       const event = data as AgentEvent;
 
       switch (event.type) {
+        case "messages_cleared":
+          setItems([]);
+          setSendError(null);
+          setIsStreaming(false);
+          break;
+
         case "agent_start":
           setIsStreaming(true);
           setSendError(null);


### PR DESCRIPTION
## Summary

When navigating from one entity detail to a different entity detail, the agent conversation is cleared so stale context from the previous entity doesn't confuse the user.

## Rules

- **Entity A → Entity B**: Clear (even if going through a list view in between)
- **Entity → list view**: Preserve conversation
- **List → entity**: Preserve conversation (gaining focus is additive)

## How it works

- `previousFocusedEntity` tracks the last entity that was focused, persisting even when the user navigates to a list view (where `focusedEntity` is cleared)
- When `focusEntity` is called with a different entity than `previousFocusedEntity`, call `agent.clearMessages()` and emit `messages_cleared` event to the renderer
- `AgentView` handles the `messages_cleared` event by resetting its display items

## Changes

### Main process (`agent.ts`)
- Added `previousFocusedEntity` tracking
- Clear agent messages + emit `messages_cleared` when entity changes

### Renderer (`AgentView.tsx`)
- Added `messages_cleared` to `AgentEvent` union type
- Handle it by clearing items, error state, and streaming state

## Verified with Electron + Playwright
- Task A chat → back to list → Task B: chat cleared ✅
- Task A chat → back to list: chat preserved ✅
- 667 tests pass, 43 files

Closes #1799