### PR TITLE
feat: Navigate to task detail when agent calls get_task

### DIFF
--- a/packages/electron/src/main/tools.test.ts
+++ b/packages/electron/src/main/tools.test.ts
@@ -667,6 +667,59 @@ describe("todu agent tools", () => {
       });
     });
 
+    it("get_task emits show_task_detail ui-action", async () => {
+      const sentMessages: Array<{ channel: string; data: unknown }> = [];
+      const mockWindow = {
+        isDestroyed: () => false,
+        webContents: {
+          send: (channel: string, data: unknown) => {
+            sentMessages.push({ channel, data });
+          },
+        },
+      };
+
+      // Create a task first
+      const created = JSON.parse(
+        (
+          (await exec("create_task", { title: "Get nav test", projectId })).content[0] as {
+            type: "text";
+            text: string;
+          }
+        ).text,
+      );
+
+      const toolsWithWindow = createToduTools(
+        todu,
+        mockWindow as unknown as import("electron").BrowserWindow,
+      );
+      const getTask = toolsWithWindow.find((t) => t.name === "get_task")!;
+
+      await getTask.execute("test-call", { id: created.id });
+
+      const uiActions = sentMessages.filter((m) => m.channel === "todu:ui-action");
+      expect(uiActions).toHaveLength(1);
+      expect(uiActions[0].data).toEqual({
+        action: "show_task_detail",
+        taskId: created.id,
+      });
+    });
+
+    it("get_task does not emit when no mainWindow provided", async () => {
+      const created = JSON.parse(
+        (
+          (await exec("create_task", { title: "No window get test", projectId })).content[0] as {
+            type: "text";
+            text: string;
+          }
+        ).text,
+      );
+
+      const result = await exec("get_task", { id: created.id });
+      const data = JSON.parse((result.content[0] as { type: "text"; text: string }).text);
+      expect(data.title).toBe("No window get test");
+      // No crash, no ui-action emitted (no window)
+    });
+
     it("create_task emits show_task_detail ui-action with task ID", async () => {
       const sentMessages: Array<{ channel: string; data: unknown }> = [];
       const mockWindow = {

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -324,7 +324,18 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
       description: "Get full task details including description.",
       label: "Get Task",
       parameters: GetTaskParams,
-      execute: async (_toolCallId, { id }) => formatResult(await todu.task.get(id)),
+      execute: async (_toolCallId, { id }) => {
+        const result = await todu.task.get(id);
+
+        if (result.ok && mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send("todu:ui-action", {
+            action: "show_task_detail",
+            taskId: id,
+          });
+        }
+
+        return formatResult(result);
+      },
     },
     {
       name: "create_task",


### PR DESCRIPTION
## Summary

When the agent calls `get_task`, the UI now navigates to that task's detail page — same pattern as `create_task`.

This gives the user visual context for the task the agent is describing, and enables follow-up commands via focused entity context (e.g., 'make this high priority').

## Changes

### `tools.ts`
- `get_task` handler emits `todu:ui-action` with `show_task_detail` on success

### `tools.test.ts`
- Test: `get_task` emits `show_task_detail` ui-action with correct task ID
- Test: `get_task` doesn't crash when no mainWindow provided

## No renderer changes needed
`App.tsx` already handles `show_task_detail` from PR #59.

669 tests pass, 43 files.

Closes #1800