### PR TITLE
feat: Taller agent chat input and keep focus after send

### DIFF
--- a/packages/electron/src/renderer/views/AgentView.tsx
+++ b/packages/electron/src/renderer/views/AgentView.tsx
@@ -273,6 +273,9 @@ export function AgentView({ onClose }: AgentViewProps): ReactNode {
     setItems((prev) => [...prev, { kind: "user", text }]);
     scrollToBottom();
 
+    // Keep focus in the input after sending
+    inputRef.current?.focus();
+
     try {
       await window.todu.agent.send(text);
     } catch (err) {
@@ -391,7 +394,7 @@ export function AgentView({ onClose }: AgentViewProps): ReactNode {
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Type a message..."
-          rows={1}
+          rows={3}
           disabled={isStreaming}
         />
         {isStreaming ? (


### PR DESCRIPTION
## Summary

Two UX improvements to the agent chat input:

1. **Taller textarea** — increased from 1 row to 3 rows so users can see more of what they're typing
2. **Keep focus after send** — textarea stays focused after pressing Enter or clicking Send, so the user can immediately type a follow-up

## Changes

Single file: `AgentView.tsx`
- `rows={1}` → `rows={3}`
- `inputRef.current?.focus()` after clearing input value

669 tests pass, 43 files.

Closes #1804