### PR TITLE
fix: Clicking task on Home page opens task detail instead of list

### DIFF
--- a/packages/electron/src/renderer/App.tsx
+++ b/packages/electron/src/renderer/App.tsx
@@ -158,9 +158,10 @@ export function App(): ReactNode {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [sidebar.toggleHidden, agentPane.toggle]);
 
-  const handleNavigateToEntity = useCallback((entityType: string, _entityId: string) => {
+  const handleNavigateToEntity = useCallback((entityType: string, entityId: string) => {
     switch (entityType) {
       case "task":
+        setFocusTaskId(entityId);
         setActiveView("tasks");
         break;
       case "project":


### PR DESCRIPTION
## Bug

Clicking a task on the Home page navigated to the Tasks list view instead of opening that task's detail page.

## Cause

`handleNavigateToEntity` ignored the `entityId` parameter — it only called `setActiveView('tasks')` without setting `focusTaskId`.

## Fix

Set `focusTaskId` when navigating to a task entity so `TasksView` opens the detail page directly.

One-line fix in `App.tsx`.

669 tests pass, 43 files.

Closes #1805