### PR TITLE
feat: Configure all packages for npm publishing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@todu/cli",
   "version": "0.0.1",
+  "description": "CLI for todu task management — create, track, and sync tasks from the terminal",
   "type": "module",
   "bin": {
-    "toduai": "./dist/index.js"
+    "todu": "./dist/index.js"
   },
   "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsgo -p tsconfig.build.json",
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
@@ -15,5 +19,24 @@
     "commander": "^14.0.3",
     "picocolors": "^1.1.1",
     "yaml": "^2.8.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evcraddock/todu.git",
+    "directory": "packages/cli"
+  },
+  "license": "MIT",
+  "keywords": [
+    "todu",
+    "task-management",
+    "cli",
+    "todo",
+    "productivity"
+  ],
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -65,6 +65,6 @@ export function registerConfigCommands(program: Command): void {
       }
       console.log("");
       console.log("Usage:");
-      console.log(`  toduai --config ${configPath} task list`);
+      console.log(`  todu --config ${configPath} task list`);
     });
 }

--- a/packages/cli/src/commands/habit.test.ts
+++ b/packages/cli/src/commands/habit.test.ts
@@ -30,7 +30,7 @@ describe("habit CLI commands", { timeout: 30000 }, () => {
       const error = e as { stdout?: string; stderr?: string };
       if (expectFail) return (error.stderr || error.stdout || "").toString();
       throw new Error(
-        `Command failed: toduai ${args}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+        `Command failed: todu ${args}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
       );
     }
   }

--- a/packages/cli/src/commands/recurring.test.ts
+++ b/packages/cli/src/commands/recurring.test.ts
@@ -34,7 +34,7 @@ describe("recurring CLI commands", { timeout: 30000 }, () => {
         return (error.stderr || error.stdout || "").toString();
       }
       throw new Error(
-        `Command failed: toduai ${args}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
+        `Command failed: todu ${args}\nstdout: ${error.stdout}\nstderr: ${error.stderr}`,
       );
     }
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ import { setColorEnabled } from "./format.js";
 const program = new Command();
 
 program
-  .name("toduai")
+  .name("todu")
   .description("Local-first task management")
   .version("0.0.1")
   .option("--format <type>", "output format (text or json)", "text")

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@todu/core",
   "version": "0.0.1",
+  "description": "Core types, validation, and schemas for todu task management",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,8 +15,29 @@
       "types": "./dist/browser.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsgo -p tsconfig.build.json",
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evcraddock/todu.git",
+    "directory": "packages/core"
+  },
+  "license": "MIT",
+  "keywords": [
+    "todu",
+    "task-management",
+    "types",
+    "validation"
+  ],
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@todu/engine",
   "version": "0.0.1",
+  "description": "Task management engine with offline-first CRDT storage and sync",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,12 +11,15 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsgo -p tsconfig.build.json",
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.2.3",
+    "@automerge/automerge": "^3.2.4",
     "@automerge/automerge-repo": "^2.5.1",
     "@automerge/automerge-repo-network-websocket": "^2.5.1",
     "@automerge/automerge-repo-storage-nodefs": "^2.5.1",
@@ -25,5 +29,24 @@
   },
   "devDependencies": {
     "@types/ws": "^8.18.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evcraddock/todu.git",
+    "directory": "packages/engine"
+  },
+  "license": "MIT",
+  "keywords": [
+    "todu",
+    "task-management",
+    "crdt",
+    "automerge",
+    "offline-first"
+  ],
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary

Prepares `@todu/core`, `@todu/engine`, and `@todu/cli` for publishing to npm. All three packages will be published together at the same version.

### Install paths after publishing:
- `npm install @todu/core` — types, validation, schemas
- `npm install @todu/engine` — CRDT storage, sync, task management engine
- `npm install -g @todu/cli` — CLI tool (`todu` command)

## Changes

### Package metadata (all three packages)
- `description`, `keywords`, `license` (MIT)
- `files: ["dist"]` — only dist output in published package
- `publishConfig: { access: "public" }` — required for scoped packages
- `repository` field with monorepo directory
- `engines: { node: ">=20" }`

### CLI rename
- Bin command: `toduai` → `todu`
- Program name: `.name("toduai")` → `.name("todu")"
- Updated all source and test references

## Verified
- `npm pack` produces clean tarballs: core 16KB, engine 42KB, cli 22KB
- Fresh install from tarballs: `todu --help`, `todu --version` work
- No source files or tests leak into published packages
- 669 tests pass, 43 files

## What's NOT in this PR
- npm org setup (needs manual `npm login` + org creation)
- NPM_TOKEN GitHub secret (manual setup)
- CI publish step (task #1819)

Closes #1816