### PR TITLE
feat: Standalone CLI binary builds via bun compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test check check-ci typecheck pre-pr run clean help dev-electron build-electron
+.PHONY: build test check check-ci typecheck pre-pr run clean help dev-electron build-electron build-cli-binary build-cli-binaries
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -28,7 +28,26 @@ pre-pr: ## Run pre-PR checks (check + test + build)
 	npm run build
 
 clean: ## Remove build artifacts
-	rm -rf packages/*/dist packages/*/*.tsbuildinfo
+	rm -rf packages/*/dist packages/*/*.tsbuildinfo dist/cli
+
+# =============================================================================
+# CLI Binary Builds
+# =============================================================================
+
+build-cli-binary: build ## Build standalone CLI binary for current platform
+	@mkdir -p dist/cli
+	bun build --compile packages/cli/src/index.ts --outfile dist/cli/todu
+	@echo "Built: dist/cli/todu ($$(ls -lh dist/cli/todu | awk '{print $$5}'))"
+
+build-cli-binaries: build ## Build standalone CLI binaries for all platforms
+	@mkdir -p dist/cli
+	bun build --compile --target=bun-linux-x64-baseline packages/cli/src/index.ts --outfile dist/cli/todu-cli-linux-x64
+	bun build --compile --target=bun-linux-arm64 packages/cli/src/index.ts --outfile dist/cli/todu-cli-linux-arm64
+	bun build --compile --target=bun-darwin-x64 packages/cli/src/index.ts --outfile dist/cli/todu-cli-darwin-x64
+	bun build --compile --target=bun-darwin-arm64 packages/cli/src/index.ts --outfile dist/cli/todu-cli-darwin-arm64
+	bun build --compile --target=bun-windows-x64-baseline packages/cli/src/index.ts --outfile dist/cli/todu-cli-windows-x64.exe
+	@echo "Built all CLI binaries:"
+	@ls -lh dist/cli/
 
 # =============================================================================
 # Development

--- a/packages/engine/src/schedule.ts
+++ b/packages/engine/src/schedule.ts
@@ -1,13 +1,16 @@
-import { createRequire } from "node:module";
 import {
   validateRRule as coreValidateRRule,
   type ValidationError,
   validationError,
 } from "@todu/core";
 
-// rrule is a CJS package — use createRequire for ESM compatibility
-const require = createRequire(import.meta.url);
-const rruleModule = require("rrule");
+// rrule is CJS. Node wraps it in { default: ... }, Bun resolves ESM named exports.
+// Use namespace import and unwrap at runtime to support both.
+import * as rruleNs from "rrule";
+
+// biome-ignore lint/suspicious/noExplicitAny: CJS/ESM interop requires runtime detection
+const rruleMod = (rruleNs as any).default ?? rruleNs;
+const RRule = rruleMod.RRule as typeof rruleNs.RRule;
 
 /** Internal RRule instance type (not exposed in public API) */
 interface RRuleInstance {
@@ -17,12 +20,12 @@ interface RRuleInstance {
 
 /** Internal: create an RRule from parsed options */
 function createRRule(options: Record<string, unknown>): RRuleInstance {
-  return new rruleModule.RRule(options) as RRuleInstance;
+  return new RRule(options) as unknown as RRuleInstance;
 }
 
 /** Internal: parse an RRULE string into options */
 function parseRRuleString(rule: string): Record<string, unknown> {
-  return rruleModule.RRule.parseString(rule) as Record<string, unknown>;
+  return RRule.parseString(rule) as Record<string, unknown>;
 }
 
 // ============================================================================

--- a/packages/engine/src/sync-server.ts
+++ b/packages/engine/src/sync-server.ts
@@ -1,13 +1,7 @@
-import { createRequire } from "node:module";
 import type { Repo } from "@automerge/automerge-repo";
 import { WebSocketServerAdapter } from "@automerge/automerge-repo-network-websocket";
 import type { WebSocketServer as IsoWebSocketServer } from "isomorphic-ws";
-
-// ws is CJS, use createRequire for interop
-const require = createRequire(import.meta.url);
-const { WebSocketServer } = require("ws") as {
-  WebSocketServer: new (opts: { host: string; port: number }) => IsoWebSocketServer;
-};
+import { WebSocketServer } from "ws";
 
 export const DEFAULT_SYNC_PORT = 24377;
 
@@ -22,7 +16,7 @@ export interface SyncServer {
  */
 export function startSyncServer(repo: Repo, port: number = DEFAULT_SYNC_PORT): SyncServer {
   const wss = new WebSocketServer({ host: "127.0.0.1", port });
-  const adapter = new WebSocketServerAdapter(wss);
+  const adapter = new WebSocketServerAdapter(wss as unknown as IsoWebSocketServer);
   repo.networkSubsystem.addNetworkAdapter(adapter);
 
   return {


### PR DESCRIPTION
## Summary

Cross-platform standalone CLI binaries using `bun build --compile`. Single executable, zero runtime dependencies.

### Targets
| Platform | Size |
|----------|------|
| linux-x64 | 98MB |
| linux-arm64 | 92MB |
| darwin-x64 | 63MB |
| darwin-arm64 | 57MB |
| windows-x64 | 109MB |

### Makefile
- `make build-cli-binary` — current platform
- `make build-cli-binaries` — all 5 platforms

## Changes

### `Makefile`
- Added `build-cli-binary` and `build-cli-binaries` targets
- `clean` now removes `dist/cli/`

### `packages/engine/src/schedule.ts`
- Replaced `createRequire` + `require('rrule')` with namespace import
- CJS/ESM interop detection: works in both Node (CJS) and Bun (ESM)

### `packages/engine/src/sync-server.ts`
- Replaced `createRequire` + `require('ws')` with direct ESM import

## Verified
- Binary runs without Node/Bun: `--help`, `--version`, project create, task create, task list
- Automerge CRDT operations work in compiled mode
- All 669 tests pass (Node path unchanged)

Closes #1817