### PR TITLE
feat: Release agent skill — conversational changelog and versioning

### DIFF
--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: release
+description: Release todu with conversational changelog. Use when user says "release todu", "create a release", "new version", "bump version", "ship it", "cut a release", or similar.
+---
+
+# Release todu
+
+Guide the release process through conversation. Draft a changelog collaboratively, bump versions, tag, and push to trigger the CI pipeline.
+
+## Quick Reference
+
+```bash
+# Release script handles: version bump, commit, tag, push, verify
+# Path relative to this skill directory
+.pi/skills/release/scripts/release.sh <version>  # e.g. 1.2.0
+```
+
+## Workflow
+
+### 1. Pre-flight
+
+Verify readiness — stop and report if any check fails.
+
+```bash
+git branch --show-current          # must be main
+git fetch origin main
+git log origin/main..HEAD --oneline  # must be empty
+gh pr list --state open --json number,title  # warn if any open
+make check-ci                      # lint + typecheck
+make test                          # all tests must pass
+make version-check                 # all packages must match
+```
+
+### 2. Determine current version
+
+```bash
+LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+```
+
+If no tags exist, current version is `0.0.0`.
+
+### 3. Gather changes
+
+Collect all changes since the last tag:
+
+```bash
+git log ${LATEST_TAG}..HEAD --oneline --no-merges
+gh pr list --state merged --search "merged:>=$(git log -1 --format=%ci $LATEST_TAG | cut -d' ' -f1)" --json number,title,labels
+```
+
+Cross-reference task IDs from commit messages (patterns: `#1234`, `Task: #1234`, `Closes #1234`). Look up task titles with `todu task show <id>` for richer context.
+
+### 4. Recommend version bump
+
+Analyze commit prefixes:
+- `feat!:` or `BREAKING CHANGE:` → **major**
+- `feat:` → **minor**
+- `fix:` → **patch**
+
+Present recommendation with reasoning. User confirms or overrides.
+
+### 5. Draft changelog (conversational)
+
+Generate a draft in Keep a Changelog format, grouped by category:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+Summary paragraph.
+
+### Added
+- Feature description (#PR)
+
+### Fixed
+- Bug fix description (#PR)
+
+### Changed
+- Change description (#PR)
+```
+
+**Be opinionated** — write human-readable descriptions, not raw commit messages. Present the draft and ask for feedback. The user may:
+- Reword entries
+- Combine or split entries
+- Remove trivial entries
+- Add entries not captured by commits
+- Add or edit the summary paragraph
+- Reorder entries
+
+Iterate until the user approves.
+
+### 6. Update CHANGELOG.md
+
+If CHANGELOG.md doesn't exist, create it with the header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+```
+
+Prepend the approved changelog entry below `## [Unreleased]`.
+
+### 7. Run release script
+
+Once the changelog is finalized:
+
+```bash
+.pi/skills/release/scripts/release.sh <version>
+```
+
+The script handles:
+1. Validate on main with no unpushed commits
+2. Update version in all package.json files (root + packages/*)
+3. Commit CHANGELOG.md + all package.json files
+4. Create annotated tag `v<version>`
+5. Push commit and tag
+6. Verify tag exists on remote
+
+**Do not run the script until the user has approved the changelog.**
+
+### 8. Post-release
+
+After the script succeeds:
+
+```bash
+gh run list --limit 1 --json databaseId,status,event --jq '.[0]'
+```
+
+Report that GitHub Actions is building the release. Optionally wait for completion:
+
+```bash
+gh run watch <run-id>
+```
+
+## Important
+
+- NEVER force push or use `--force` flags
+- NEVER run the release script without user approval of the changelog
+- The script verifies the tag was pushed — if it fails, read the error
+- If anything fails, stop and report — do not retry blindly

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Release todu: bump versions, commit, tag, push, verify.
+#
+# Usage:
+#   ./release.sh <version>   (e.g., 1.2.0)
+#
+# This script handles the mechanical release steps:
+#   1. Validate on main with no unpushed commits
+#   2. Update version in all package.json files
+#   3. Commit CHANGELOG.md + package.json files
+#   4. Create annotated tag
+#   5. Push commit and tag
+#   6. Verify tag exists on remote
+#
+# Prerequisites:
+#   - CHANGELOG.md must already be updated (agent does this conversationally)
+#   - All checks must pass (agent verifies in pre-flight)
+#
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+die() { echo -e "${RED}Error: $1${NC}" >&2; exit 1; }
+info() { echo -e "${GREEN}$1${NC}"; }
+warn() { echo -e "${YELLOW}$1${NC}"; }
+
+# --- Validate arguments ---
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 1.2.0"
+  exit 1
+fi
+
+NEW_VERSION="$1"
+NEW_TAG="v${NEW_VERSION}"
+
+# Validate version format
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  die "Invalid version format: $NEW_VERSION (expected X.Y.Z or X.Y.Z-suffix)"
+fi
+
+# --- Step 1: Validate branch and state ---
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  die "Must be on main branch (currently on '$CURRENT_BRANCH')"
+fi
+
+git fetch origin main --quiet
+UNPUSHED=$(git log origin/main..HEAD --oneline)
+if [[ -n "$UNPUSHED" ]]; then
+  die "Unpushed commits on main:\n$UNPUSHED\n\nPush these first."
+fi
+
+# Check tag doesn't already exist
+if git tag --list | grep -q "^${NEW_TAG}$"; then
+  die "Tag $NEW_TAG already exists locally"
+fi
+if git ls-remote --tags origin | grep -q "refs/tags/${NEW_TAG}$"; then
+  die "Tag $NEW_TAG already exists on remote"
+fi
+
+info "Releasing: $NEW_TAG"
+
+# --- Step 2: Update versions in all package.json files ---
+PACKAGES=(
+  "package.json"
+  "packages/core/package.json"
+  "packages/engine/package.json"
+  "packages/cli/package.json"
+  "packages/electron/package.json"
+)
+
+for pkg in "${PACKAGES[@]}"; do
+  if [[ ! -f "$pkg" ]]; then
+    die "$pkg not found"
+  fi
+  CURRENT=$(node -p "require('./$pkg').version")
+  if [[ "$CURRENT" != "$NEW_VERSION" ]]; then
+    info "Updating $pkg: $CURRENT -> $NEW_VERSION"
+    node -e "
+      const fs = require('fs');
+      const pkg = JSON.parse(fs.readFileSync('$pkg', 'utf8'));
+      pkg.version = '$NEW_VERSION';
+      fs.writeFileSync('$pkg', JSON.stringify(pkg, null, 2) + '\n');
+    "
+  else
+    warn "$pkg already at $NEW_VERSION"
+  fi
+done
+
+# Also update electron-builder electronVersion if needed
+# (this stays pinned to the installed electron version, not the app version)
+
+# --- Step 3: Commit ---
+git add CHANGELOG.md
+for pkg in "${PACKAGES[@]}"; do
+  git add "$pkg"
+done
+
+# Check if there are changes to commit
+if git diff --cached --quiet; then
+  warn "No changes to commit"
+else
+  git commit -m "chore: release v${NEW_VERSION}" --no-verify
+  info "Committed release v${NEW_VERSION}"
+fi
+
+# --- Step 4: Create annotated tag ---
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+info "Created tag: $NEW_TAG"
+
+# --- Step 5: Push ---
+info "Pushing to origin..."
+git push origin main --follow-tags
+
+# --- Step 6: Verify tag on remote ---
+info "Verifying tag on remote..."
+sleep 2
+
+if ! git ls-remote --tags origin | grep -q "refs/tags/${NEW_TAG}$"; then
+  die "Tag $NEW_TAG was NOT pushed to remote!\n\nManually push with: git push origin $NEW_TAG"
+fi
+
+info ""
+info "✅ Released $NEW_TAG"
+info "✅ Tag verified on remote"
+info ""
+info "GitHub Actions will now build artifacts and create the release."
+info "Monitor at: gh run list --limit 1"


### PR DESCRIPTION
## Summary

Agent skill for releasing todu. User says "release todu" → agent collaborates on changelog, bumps versions, tags, and pushes to trigger the CI pipeline.

## Files

### `.pi/skills/release/SKILL.md`
Skill instructions — 8-step workflow:
1. Pre-flight checks (branch, tests, versions)
2. Determine current version from latest tag
3. Gather commits/PRs/tasks since last tag
4. Recommend version bump from commit prefixes
5. **Draft changelog conversationally** — user iterates until approved
6. Update CHANGELOG.md (Keep a Changelog format)
7. Run release script
8. Report CI status

### `.pi/skills/release/scripts/release.sh`
Mechanical release steps:
- Validates branch state and tag uniqueness
- Bumps version in all 5 package.json files
- Commits CHANGELOG.md + package.json files
- Creates annotated tag, pushes, verifies on remote
- Uses `--no-verify` on commit (pre-flight already ran checks)

## Triggers
`release todu`, `create a release`, `new version`, `bump version`, `ship it`, `cut a release`

## Safety
- Never runs without user approval of changelog
- Never force pushes
- Verifies tag exists on remote after push

Closes #1820