### PR TITLE
fix: install scripts fail silently when dependencies missing

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -3,7 +3,7 @@
 # Run from the project root after `make dist`.
 set -euo pipefail
 
-APPIMAGE=$(ls dist/installers/toduai-*-linux-x86_64.AppImage 2>/dev/null | sort -V | tail -1)
+APPIMAGE=$(find dist/installers -name 'toduai-*-linux-x86_64.AppImage' 2>/dev/null | sort -V | tail -1 || true)
 if [[ -z "$APPIMAGE" ]]; then
   echo "error: no AppImage found in dist/installers/ — run 'make dist' first"
   exit 1

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -3,7 +3,7 @@
 # Run from the project root after `make dist`.
 set -euo pipefail
 
-DMG=$(ls dist/installers/toduai-*-mac*.dmg 2>/dev/null | sort -V | tail -1)
+DMG=$(find dist/installers -name 'toduai-*-mac*.dmg' 2>/dev/null | sort -V | tail -1 || true)
 if [[ -z "$DMG" ]]; then
   echo "error: no .dmg found in dist/installers/ — run 'make dist' first"
   exit 1
@@ -11,8 +11,14 @@ fi
 
 echo "Installing toduai from $DMG..."
 
-MOUNT=$(hdiutil attach "$DMG" -nobrowse -quiet | awk 'END {print $NF}')
+MOUNT=$(hdiutil attach "$DMG" -nobrowse | awk '/Apple_HFS/ {print substr($0, index($0, "/Volumes"))}')
+if [[ -z "$MOUNT" ]]; then
+  echo "error: failed to mount $DMG"
+  exit 1
+fi
+
+trap 'hdiutil detach "$MOUNT" -quiet 2>/dev/null || true' EXIT
+
 cp -R "$MOUNT/toduai.app" /Applications/
-hdiutil detach "$MOUNT" -quiet
 
 echo "Installed: /Applications/toduai.app"


### PR DESCRIPTION
## Summary

Fixes `make install` failing silently on macOS (and same latent bug on Linux).

## Root Cause

Two bugs in `scripts/install-mac.sh`:

1. **Silent exit when no .dmg exists** — `ls` glob returns non-zero when nothing matches, and `set -euo pipefail` exits before reaching the helpful error message
2. **Empty mount point** — `hdiutil attach -quiet` suppresses output that `awk` needs to parse the mount point, so `MOUNT` is always empty → `cp /toduai.app` fails

`scripts/install-linux.sh` had the same `ls` glob issue (#1).

## Changes

### install-mac.sh
- Replace `ls` glob with `find ... || true` so empty results reach the `if` check
- Remove `-quiet` from `hdiutil attach` so `awk` can parse mount point
- Parse mount point using `Apple_HFS` line (more reliable than `awk END`)
- Add mount point validation with clear error
- Use `trap` for reliable cleanup on exit

### install-linux.sh
- Replace `ls` glob with `find ... || true` (same fix)

## Testing

- Verified `make install` succeeds end-to-end on macOS (dmg mounts, app copies to /Applications)
- Verified missing .dmg shows clear error: `error: no .dmg found in dist/installers/ — run 'make dist' first`

## Electron console warning

The `representedObject is not a WeakPtrToElectronMenuModelAsNSObject` warning is an upstream Electron bug on macOS — not caused by our code. Our only menu code (`tray.ts`) uses standard Electron APIs correctly. No fix possible on our side.

Task: #1866