### PR TITLE
fix(cli): suppress noisy TimeoutNegativeWarning on startup (task #1918)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,17 +1,5 @@
 #!/usr/bin/env node
 
-// Suppress Node.js TimeoutNegativeWarning caused by @automerge/automerge-repo's
-// throttle helper passing negative delays to setTimeout. This is an upstream bug
-// (automerge-repo ≤2.5.3) — harmless, but noisy on stderr.
-const _origEmitWarning = process.emitWarning;
-process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
-  if (typeof warning === "string" && warning.includes("is a negative number")) {
-    return;
-  }
-  // biome-ignore lint/suspicious/noExplicitAny: overriding built-in with pass-through
-  return (_origEmitWarning as any).call(process, warning, ...args);
-}) as typeof process.emitWarning;
-
 import { resolveRemoteSyncConfig } from "@todu/core";
 import { createTodu, isSyncServerAvailable } from "@todu/engine";
 import { Command } from "commander";
@@ -27,6 +15,11 @@ import { registerTaskCommands } from "./commands/task.js";
 import { getConfigPath, loadConfig, resolveDataDir } from "./config.js";
 import { setColorEnabled } from "./format.js";
 import { VERSION } from "./version.js";
+import { installTimeoutNegativeWarningFilter } from "./warnings.js";
+
+// Suppress noisy Node.js TimeoutNegativeWarning caused by
+// @automerge/automerge-repo passing negative delays to setTimeout.
+installTimeoutNegativeWarningFilter();
 
 const program = new Command();
 

--- a/packages/cli/src/warnings.test.ts
+++ b/packages/cli/src/warnings.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { installTimeoutNegativeWarningFilter } from "./warnings.js";
+
+type EmitWarningCall = [warning: string | Error, ...args: unknown[]];
+
+type WarningProcess = {
+  emitWarning: NodeJS.Process["emitWarning"];
+};
+
+function createWarningProcessStub(): {
+  warningProcess: WarningProcess;
+  calls: EmitWarningCall[];
+} {
+  const calls: EmitWarningCall[] = [];
+
+  const warningProcess: WarningProcess = {
+    emitWarning: ((warning: string | Error, ...args: unknown[]) => {
+      calls.push([warning, ...args]);
+    }) as NodeJS.Process["emitWarning"],
+  };
+
+  return { warningProcess, calls };
+}
+
+describe("installTimeoutNegativeWarningFilter", () => {
+  it("suppresses TimeoutNegativeWarning emitted as string + type", () => {
+    const { warningProcess, calls } = createWarningProcessStub();
+    installTimeoutNegativeWarningFilter(warningProcess);
+
+    warningProcess.emitWarning("-1 is a negative number.", "TimeoutNegativeWarning");
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("suppresses TimeoutNegativeWarning emitted as Error instance", () => {
+    const { warningProcess, calls } = createWarningProcessStub();
+    installTimeoutNegativeWarningFilter(warningProcess);
+
+    const warning = new Error("-1 is a negative number.");
+    warning.name = "TimeoutNegativeWarning";
+    warningProcess.emitWarning(warning);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it("preserves unrelated warnings", () => {
+    const { warningProcess, calls } = createWarningProcessStub();
+    installTimeoutNegativeWarningFilter(warningProcess);
+
+    warningProcess.emitWarning("this is a negative number", "SomeOtherWarning");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["this is a negative number", "SomeOtherWarning"]);
+  });
+});

--- a/packages/cli/src/warnings.ts
+++ b/packages/cli/src/warnings.ts
@@ -1,0 +1,38 @@
+const TIMEOUT_WARNING_TYPE = "TimeoutNegativeWarning";
+const NEGATIVE_DELAY_MESSAGE = "is a negative number";
+
+type EmitWarning = NodeJS.Process["emitWarning"];
+
+type WarningProcess = {
+  emitWarning: EmitWarning;
+};
+
+function isTimeoutNegativeWarning(warning: string | Error, args: unknown[]): boolean {
+  const message = typeof warning === "string" ? warning : warning.message;
+  const type =
+    typeof warning === "string"
+      ? typeof args[0] === "string"
+        ? args[0]
+        : undefined
+      : warning.name;
+
+  return type === TIMEOUT_WARNING_TYPE && message.includes(NEGATIVE_DELAY_MESSAGE);
+}
+
+export function installTimeoutNegativeWarningFilter(
+  warningProcess: WarningProcess = process,
+): void {
+  const originalEmitWarning = warningProcess.emitWarning;
+
+  warningProcess.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+    if (isTimeoutNegativeWarning(warning, args)) {
+      return;
+    }
+
+    Reflect.apply(
+      originalEmitWarning as unknown as (...forwarded: unknown[]) => void,
+      warningProcess,
+      [warning, ...args],
+    );
+  }) as EmitWarning;
+}


### PR DESCRIPTION
## Summary
- suppress noisy Node.js `TimeoutNegativeWarning` output in the CLI startup path
- add a targeted filter that ignores warning strings containing `is a negative number`
- leave all other warnings untouched

## Verification
- `make pre-pr`
- pre-commit hook (`npm run check`)
- pre-push hook (`npm test`)

Task: #1918
