### PR TITLE
docs(agents): enforce strict request-review skill workflow (task #1918)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,18 @@ Non-stable versions (canary, beta, alpha, rc) can have bugs or incomplete featur
 6. Use the `request-review` skill to spawn a separate agent to review the PR
 7. **Wait for human approval** before merging
 
+### `request-review` Skill Enforcement (MANDATORY)
+
+When requesting PR review, follow the `request-review` skill **exactly as written**.
+
+- **No substitutions** and **no custom review flow**
+- **Do NOT use `pi -p`** (or any non-interactive shortcut) for the reviewer session
+- Use tmux session + `wait-for` signaling exactly as documented in the skill
+- Wait for completion signal before reporting results
+- After completion, fetch and report the latest PR review comment
+- If a task ID is present, ensure the review is also posted to the task
+- If you must deviate for any reason, **stop and ask the human first**
+
 ### Wait for CI Before Requesting Review
 
 After creating a PR, CI runs automatically. **Do not request a review until CI passes.**


### PR DESCRIPTION
## Summary
- add a mandatory `request-review` enforcement section to `AGENTS.md`
- require exact skill flow for PR reviews (no custom substitutions)
- explicitly forbid `pi -p` for reviewer sessions
- require tmux `wait-for` completion + reporting latest PR review comment and task comment
- require explicit human approval before any deviation

## Why
This prevents review-process drift and makes PR review execution auditable and consistent.

## Verification
- pre-commit checks passed during commit
- pre-push test suite passed during push

Task: #1918
