### PR TITLE
feat: implement secure UDS daemon transport (#1927)

### DIFF
--- a/docs/plans/phase-1-daemon-foundation.md
+++ b/docs/plans/phase-1-daemon-foundation.md
@@ -136,3 +136,17 @@ Every task must include a documentation step in the same PR (or explicitly justi
   - `toduai-daemon` entrypoint script for local development runs
 - Runtime config/status now represent daemon role (`node` / `authority`).
 - Scope intentionally excludes domain RPC method implementation and CLI/Electron migration.
+
+### 2026-02-22 — Task #1927
+
+- Added UDS transport listener implementation (`createUdsTransport`) in `packages/daemon/src/transport.ts`.
+- Added socket path convention:
+  - default socket path: `<storagePath>/daemon.sock`
+  - optional override via runtime config / `TODUAI_DAEMON_SOCKET`
+- Enforced local trust baseline with socket file mode `0600` after bind.
+- Implemented startup safety behavior:
+  - detect and remove stale socket files (existing socket path with no active listener)
+  - refuse startup if socket path is active
+  - refuse replacing non-socket files at socket path
+- Implemented shutdown cleanup: closes listener and removes socket file.
+- Added automated transport/runtime/process tests for bind/connect/permissions/stale handling/cleanup.

--- a/packages/daemon/src/entrypoint.ts
+++ b/packages/daemon/src/entrypoint.ts
@@ -18,17 +18,21 @@ function parseDaemonRole(value: string | undefined): DaemonRole {
 
 export async function runDaemonEntrypoint(): Promise<void> {
   const daemonRole = parseDaemonRole(process.env.TODUAI_DAEMON_ROLE);
+  const daemonSocketPath = process.env.TODUAI_DAEMON_SOCKET;
   const remoteSync = resolveRemoteSyncConfig({});
 
   const daemon = await startDaemonProcess(
     {
       role: daemonRole,
+      socketPath: daemonSocketPath,
       remoteSync: remoteSync ?? undefined,
     },
     {
       hooks: {
         onStarted: (status) => {
-          console.log(`[daemon] running role=${status.role} catalog=${status.catalogId ?? "-"}`);
+          console.log(
+            `[daemon] running role=${status.role} socket=${status.transport?.path ?? "-"} catalog=${status.catalogId ?? "-"}`,
+          );
         },
         onStopping: (reason) => {
           console.log(`[daemon] stopping (${reason})`);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -16,3 +16,13 @@ export {
   isDaemonRole,
   type ResolvedDaemonRuntimeConfig,
 } from "./runtime.js";
+
+export {
+  createUdsTransport,
+  DEFAULT_DAEMON_SOCKET_FILENAME,
+  DEFAULT_DAEMON_SOCKET_MODE,
+  resolveUdsSocketPath,
+  type UdsEndpoint,
+  type UdsTransport,
+  type UdsTransportConfig,
+} from "./transport.js";

--- a/packages/daemon/src/process.test.ts
+++ b/packages/daemon/src/process.test.ts
@@ -38,10 +38,14 @@ describe("startDaemonProcess", () => {
 
     expect(daemon.runtime.status().state).toBe("running");
 
+    const socketPath = daemon.runtime.config().socketPath;
+    expect(fs.existsSync(socketPath)).toBe(true);
+
     await daemon.stop("test");
     await daemon.waitForShutdown();
 
     expect(daemon.runtime.status().state).toBe("stopped");
+    expect(fs.existsSync(socketPath)).toBe(false);
     expect(events).toEqual(["started:authority", "stopping:test", "stopped"]);
   });
 });

--- a/packages/daemon/src/process.ts
+++ b/packages/daemon/src/process.ts
@@ -13,7 +13,6 @@ export interface DaemonProcessHooks {
 
 export interface StartDaemonProcessOptions {
   registerSignalHandlers?: boolean;
-  keepAliveIntervalMs?: number;
   hooks?: DaemonProcessHooks;
 }
 
@@ -28,11 +27,7 @@ export async function startDaemonProcess(
   options: StartDaemonProcessOptions = {},
 ): Promise<DaemonProcess> {
   const runtime = createDaemonRuntime(config);
-  const { hooks, registerSignalHandlers = true, keepAliveIntervalMs = 60_000 } = options;
-
-  const keepAliveTimer = setInterval(() => {
-    // Keep event loop alive until transport listeners are added.
-  }, keepAliveIntervalMs);
+  const { hooks, registerSignalHandlers = true } = options;
 
   let stopPromise: Promise<void> | null = null;
   let resolveShutdown: (() => void) | null = null;
@@ -63,7 +58,6 @@ export async function startDaemonProcess(
     stopPromise = (async () => {
       hooks?.onStopping?.(reason);
       unregisterSignalHandlers();
-      clearInterval(keepAliveTimer);
 
       try {
         await runtime.stop();
@@ -95,7 +89,6 @@ export async function startDaemonProcess(
     hooks?.onStarted?.(started);
   } catch (error) {
     unregisterSignalHandlers();
-    clearInterval(keepAliveTimer);
     throw error;
   }
 

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -23,7 +23,7 @@ describe("createDaemonRuntime", () => {
     expect(runtime.status().state).toBe("stopped");
   });
 
-  it("starts and reports running status with catalog id", async () => {
+  it("starts and reports running status with catalog id and UDS endpoint", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir, role: "authority" });
 
     const status = await runtime.start();
@@ -32,6 +32,9 @@ describe("createDaemonRuntime", () => {
     expect(status.role).toBe("authority");
     expect(status.startedAt).toBeDefined();
     expect(status.catalogId).toBeTruthy();
+    expect(status.transport?.kind).toBe("uds");
+    expect(status.transport?.path).toBe(runtime.config().socketPath);
+    expect(fs.existsSync(runtime.config().socketPath)).toBe(true);
 
     await runtime.stop();
   });
@@ -40,12 +43,15 @@ describe("createDaemonRuntime", () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
     await runtime.start();
+    const socketPath = runtime.config().socketPath;
     await runtime.stop();
 
     const status = runtime.status();
     expect(status.state).toBe("stopped");
     expect(status.startedAt).toBeUndefined();
     expect(status.catalogId).toBeUndefined();
+    expect(status.transport).toBeUndefined();
+    expect(fs.existsSync(socketPath)).toBe(false);
   });
 
   it("treats repeated start and stop calls as safe no-ops", async () => {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,5 +1,11 @@
 import { type RemoteSyncConfig, resolveStoragePath } from "@todu/core";
 import { createTodu, type Todu } from "@todu/engine";
+import {
+  createUdsTransport,
+  resolveUdsSocketPath,
+  type UdsEndpoint,
+  type UdsTransport,
+} from "./transport.js";
 
 export const DAEMON_ROLES = ["node", "authority"] as const;
 
@@ -15,12 +21,16 @@ export interface DaemonRuntimeConfig {
   storagePath?: string;
   role?: DaemonRole;
   remoteSync?: RemoteSyncConfig;
+  socketPath?: string;
+  socketMode?: number;
 }
 
 export interface ResolvedDaemonRuntimeConfig {
   storagePath: string;
   role: DaemonRole;
   remoteSync?: RemoteSyncConfig;
+  socketPath: string;
+  socketMode: number;
 }
 
 export interface DaemonRuntimeStatus {
@@ -28,6 +38,7 @@ export interface DaemonRuntimeStatus {
   role: DaemonRole;
   startedAt?: string;
   catalogId?: string;
+  transport?: UdsEndpoint;
 }
 
 export interface DaemonRuntime {
@@ -38,11 +49,22 @@ export interface DaemonRuntime {
 }
 
 export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRuntime {
+  const resolvedStoragePath = config.storagePath ?? resolveStoragePath();
+  const resolvedSocketPath = resolveUdsSocketPath(resolvedStoragePath, config.socketPath);
+
   const resolvedConfig: ResolvedDaemonRuntimeConfig = {
-    storagePath: config.storagePath ?? resolveStoragePath(),
+    storagePath: resolvedStoragePath,
     role: config.role ?? "node",
     remoteSync: config.remoteSync,
+    socketPath: resolvedSocketPath,
+    socketMode: config.socketMode ?? 0o600,
   };
+
+  const transport = createUdsTransport({
+    storagePath: resolvedConfig.storagePath,
+    socketPath: resolvedConfig.socketPath,
+    socketMode: resolvedConfig.socketMode,
+  });
 
   let todu: Todu | null = null;
   let startPromise: Promise<DaemonRuntimeStatus> | null = null;
@@ -59,6 +81,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       role: runtimeStatus.role,
       startedAt: runtimeStatus.startedAt,
       catalogId: runtimeStatus.catalogId,
+      transport: runtimeStatus.transport,
     };
   }
 
@@ -66,6 +89,8 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     runtimeStatus.state = "starting";
 
     try {
+      const endpoint = await transport.start();
+
       todu = await createTodu({
         storagePath: resolvedConfig.storagePath,
         remoteSync: resolvedConfig.remoteSync,
@@ -74,12 +99,15 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       runtimeStatus.state = "running";
       runtimeStatus.startedAt = new Date().toISOString();
       runtimeStatus.catalogId = todu.sync.getCatalogId();
+      runtimeStatus.transport = endpoint;
 
       return cloneStatus();
     } catch (error) {
+      await safeStopTransport(transport);
       runtimeStatus.state = "stopped";
       runtimeStatus.startedAt = undefined;
       runtimeStatus.catalogId = undefined;
+      runtimeStatus.transport = undefined;
       todu = null;
       throw error;
     }
@@ -116,24 +144,22 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
           }
         }
 
-        if (!todu) {
-          runtimeStatus.state = "stopped";
-          runtimeStatus.startedAt = undefined;
-          runtimeStatus.catalogId = undefined;
-          return;
-        }
-
         runtimeStatus.state = "stopping";
 
-        const current = todu;
+        const currentTodu = todu;
         todu = null;
 
         try {
-          await current.close();
+          await transport.stop();
+
+          if (currentTodu) {
+            await currentTodu.close();
+          }
         } finally {
           runtimeStatus.state = "stopped";
           runtimeStatus.startedAt = undefined;
           runtimeStatus.catalogId = undefined;
+          runtimeStatus.transport = undefined;
         }
       })().finally(() => {
         stopPromise = null;
@@ -151,7 +177,17 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         storagePath: resolvedConfig.storagePath,
         role: resolvedConfig.role,
         remoteSync: resolvedConfig.remoteSync,
+        socketPath: resolvedConfig.socketPath,
+        socketMode: resolvedConfig.socketMode,
       };
     },
   };
+}
+
+async function safeStopTransport(transport: UdsTransport): Promise<void> {
+  try {
+    await transport.stop();
+  } catch {
+    // best-effort cleanup path after start() failures
+  }
 }

--- a/packages/daemon/src/transport.test.ts
+++ b/packages/daemon/src/transport.test.ts
@@ -1,0 +1,142 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createUdsTransport,
+  DEFAULT_DAEMON_SOCKET_FILENAME,
+  DEFAULT_DAEMON_SOCKET_MODE,
+  resolveUdsSocketPath,
+} from "./transport.js";
+
+const describeOnUnix = process.platform === "win32" ? describe.skip : describe;
+
+describeOnUnix("createUdsTransport", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-uds-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("binds to a UDS endpoint and accepts local connections", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+    const transport = createUdsTransport({ storagePath: tmpDir, socketPath });
+
+    const endpoint = await transport.start();
+
+    expect(endpoint.kind).toBe("uds");
+    expect(endpoint.path).toBe(socketPath);
+    expect(fs.existsSync(socketPath)).toBe(true);
+
+    await new Promise<void>((resolve, reject) => {
+      const client = net.createConnection(socketPath, () => {
+        client.end();
+        resolve();
+      });
+      client.once("error", reject);
+    });
+
+    await transport.stop();
+  });
+
+  it("sets strict socket file permissions", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+    const transport = createUdsTransport({ storagePath: tmpDir, socketPath });
+
+    await transport.start();
+
+    const stats = fs.statSync(socketPath);
+    expect(stats.mode & 0o777).toBe(DEFAULT_DAEMON_SOCKET_MODE);
+
+    await transport.stop();
+  });
+
+  it("cleans up stale socket files on startup", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+
+    const staleSocketResult = spawnSync(
+      "python3",
+      [
+        "-c",
+        [
+          "import socket, sys",
+          "sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
+          "sock.bind(sys.argv[1])",
+          "sock.listen(1)",
+          "sock.close()",
+        ].join("; "),
+        socketPath,
+      ],
+      { encoding: "utf-8" },
+    );
+
+    if (staleSocketResult.status !== 0) {
+      throw new Error(`Failed to create stale UDS socket in test: ${staleSocketResult.stderr}`);
+    }
+
+    expect(fs.existsSync(socketPath)).toBe(true);
+
+    const transport = createUdsTransport({ storagePath: tmpDir, socketPath });
+    await transport.start();
+
+    await new Promise<void>((resolve, reject) => {
+      const client = net.createConnection(socketPath, () => {
+        client.end();
+        resolve();
+      });
+      client.once("error", reject);
+    });
+
+    await transport.stop();
+  });
+
+  it("refuses to replace non-socket files at socket path", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+    fs.writeFileSync(socketPath, "not-a-socket", "utf-8");
+
+    const transport = createUdsTransport({ storagePath: tmpDir, socketPath });
+    await expect(transport.start()).rejects.toThrow("Refusing to replace non-socket path");
+  });
+
+  it("fails startup when socket path is already in use", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+    const first = createUdsTransport({ storagePath: tmpDir, socketPath });
+    await first.start();
+
+    const second = createUdsTransport({ storagePath: tmpDir, socketPath });
+    await expect(second.start()).rejects.toThrow("Daemon socket already in use");
+
+    await first.stop();
+  });
+
+  it("removes the socket file during shutdown", async () => {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+    const transport = createUdsTransport({ storagePath: tmpDir, socketPath });
+
+    await transport.start();
+    expect(fs.existsSync(socketPath)).toBe(true);
+
+    await transport.stop();
+    expect(fs.existsSync(socketPath)).toBe(false);
+  });
+});
+
+describe("resolveUdsSocketPath", () => {
+  it("uses daemon.sock inside storage path by default", () => {
+    const storagePath = "/tmp/todu-daemon";
+    const resolved = resolveUdsSocketPath(storagePath);
+
+    expect(resolved).toBe(path.join(storagePath, DEFAULT_DAEMON_SOCKET_FILENAME));
+  });
+
+  it("resolves relative socket paths to absolute paths", () => {
+    const resolved = resolveUdsSocketPath("/tmp/todu-daemon", "./custom.sock");
+    expect(path.isAbsolute(resolved)).toBe(true);
+  });
+});

--- a/packages/daemon/src/transport.ts
+++ b/packages/daemon/src/transport.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import net, { type Server, type Socket } from "node:net";
+import path from "node:path";
+
+export const DEFAULT_DAEMON_SOCKET_FILENAME = "daemon.sock";
+export const DEFAULT_DAEMON_SOCKET_MODE = 0o600;
+
+export interface UdsTransportConfig {
+  storagePath: string;
+  socketPath?: string;
+  socketMode?: number;
+  onConnection?: (socket: Socket) => void;
+}
+
+export interface UdsEndpoint {
+  kind: "uds";
+  path: string;
+  mode: number;
+}
+
+export interface UdsTransport {
+  start(): Promise<UdsEndpoint>;
+  stop(): Promise<void>;
+  endpoint(): UdsEndpoint;
+}
+
+export function resolveUdsSocketPath(storagePath: string, socketPath?: string): string {
+  if (!socketPath) {
+    return path.join(storagePath, DEFAULT_DAEMON_SOCKET_FILENAME);
+  }
+
+  return path.isAbsolute(socketPath) ? socketPath : path.resolve(socketPath);
+}
+
+export function createUdsTransport(config: UdsTransportConfig): UdsTransport {
+  const endpoint: UdsEndpoint = {
+    kind: "uds",
+    path: resolveUdsSocketPath(config.storagePath, config.socketPath),
+    mode: config.socketMode ?? DEFAULT_DAEMON_SOCKET_MODE,
+  };
+
+  let server: Server | null = null;
+  let startPromise: Promise<UdsEndpoint> | null = null;
+  let stopPromise: Promise<void> | null = null;
+
+  async function ensureSocketDirectory(): Promise<void> {
+    await fs.promises.mkdir(path.dirname(endpoint.path), { recursive: true, mode: 0o700 });
+  }
+
+  async function ensureSocketAvailable(): Promise<void> {
+    try {
+      const stats = await fs.promises.lstat(endpoint.path);
+      if (!stats.isSocket()) {
+        throw new Error(`Refusing to replace non-socket path: ${endpoint.path}`);
+      }
+
+      const state = await probeSocket(endpoint.path);
+      if (state === "active") {
+        throw new Error(`Daemon socket already in use: ${endpoint.path}`);
+      }
+
+      await fs.promises.unlink(endpoint.path);
+    } catch (error) {
+      const code = errorCode(error);
+      if (code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  async function startServer(): Promise<UdsEndpoint> {
+    if (process.platform === "win32") {
+      throw new Error("UDS transport is not supported on win32");
+    }
+
+    await ensureSocketDirectory();
+    await ensureSocketAvailable();
+
+    const created = net.createServer((socket) => {
+      config.onConnection?.(socket);
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        created.once("error", reject);
+        created.listen(endpoint.path, () => {
+          created.off("error", reject);
+          resolve();
+        });
+      });
+
+      await fs.promises.chmod(endpoint.path, endpoint.mode);
+      server = created;
+      return endpoint;
+    } catch (error) {
+      await closeServer(created);
+      await unlinkSocketIfExists(endpoint.path);
+      throw error;
+    }
+  }
+
+  return {
+    async start(): Promise<UdsEndpoint> {
+      if (server) {
+        return endpoint;
+      }
+
+      if (startPromise) {
+        return startPromise;
+      }
+
+      startPromise = startServer().finally(() => {
+        startPromise = null;
+      });
+
+      return startPromise;
+    },
+
+    async stop(): Promise<void> {
+      if (stopPromise) {
+        return stopPromise;
+      }
+
+      stopPromise = (async () => {
+        if (startPromise) {
+          try {
+            await startPromise;
+          } catch {
+            // start() error already handled cleanup
+          }
+        }
+
+        const current = server;
+        server = null;
+
+        if (current) {
+          await closeServer(current);
+        }
+
+        await unlinkSocketIfExists(endpoint.path);
+      })().finally(() => {
+        stopPromise = null;
+      });
+
+      return stopPromise;
+    },
+
+    endpoint(): UdsEndpoint {
+      return {
+        kind: endpoint.kind,
+        path: endpoint.path,
+        mode: endpoint.mode,
+      };
+    },
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function unlinkSocketIfExists(socketPath: string): Promise<void> {
+  try {
+    const stats = await fs.promises.lstat(socketPath);
+    if (!stats.isSocket()) {
+      return;
+    }
+
+    await fs.promises.unlink(socketPath);
+  } catch (error) {
+    const code = errorCode(error);
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+type SocketProbeState = "active" | "stale";
+
+async function probeSocket(socketPath: string): Promise<SocketProbeState> {
+  return new Promise<SocketProbeState>((resolve, reject) => {
+    const client = net.createConnection(socketPath);
+
+    const onConnect = () => {
+      cleanup();
+      client.end();
+      resolve("active");
+    };
+
+    const onError = (error: unknown) => {
+      cleanup();
+      const code = errorCode(error);
+
+      if (code === "ECONNREFUSED") {
+        resolve("stale");
+        return;
+      }
+
+      reject(error);
+    };
+
+    const cleanup = () => {
+      client.off("connect", onConnect);
+      client.off("error", onError);
+    };
+
+    client.once("connect", onConnect);
+    client.once("error", onError);
+  });
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  if (!("code" in error)) {
+    return undefined;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}


### PR DESCRIPTION
Summary
- add daemon UDS transport listener and lifecycle integration
- default socket convention: <storagePath>/daemon.sock with optional override support
- enforce local trust baseline with socket file mode 0600
- handle stale socket cleanup on startup and socket cleanup on shutdown
- detect active socket collisions and refuse replacing non-socket paths
- expose transport endpoint info in daemon runtime status
- add daemon entrypoint socket override env (TODUAI_DAEMON_SOCKET)
- add transport/runtime/process tests and phase-1 progress note update

Verification
- make pre-pr
- manual local connection verification:
  - start daemon with TODUAI_DAEMON_SOCKET pointing to temp socket
  - connect via node net client over UDS
  - SIGTERM shutdown removes socket file

Scope guard
- no domain RPC methods implemented
- no CLI/Electron migration included

Task: #1927
