### PR TITLE
feat: add daemon protocol envelope schema primitives (#1928)

### DIFF
--- a/docs/plans/phase-1-daemon-foundation.md
+++ b/docs/plans/phase-1-daemon-foundation.md
@@ -150,3 +150,21 @@ Every task must include a documentation step in the same PR (or explicitly justi
   - refuse replacing non-socket files at socket path
 - Implemented shutdown cleanup: closes listener and removes socket file.
 - Added automated transport/runtime/process tests for bind/connect/permissions/stale handling/cleanup.
+
+### 2026-02-22 — Task #1928
+
+- Added protocol envelope primitives in `packages/daemon/src/protocol.ts`:
+  - request, success, error, and event frame types
+  - centralized protocol error taxonomy constants
+  - helpers for success/error/event frame creation
+- Added parser/validator for incoming request frames:
+  - `parseProtocolRequestFrame`
+  - `parseProtocolRequestJson`
+- Added deterministic malformed-frame error handling:
+  - invalid JSON => `BAD_REQUEST`
+  - invalid frame/id/method/params => structured `BAD_REQUEST`
+- Added centralized error mapping utility (`mapErrorToProtocolError`) with consistent mapping for:
+  - existing domain errors (`not-found`, `validation`, `storage`)
+  - protocol errors passthrough
+  - timeout-like and unknown errors
+- Added protocol unit tests in `packages/daemon/src/protocol.test.ts` for valid/invalid parsing and error mapping behavior.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -4,7 +4,24 @@ export {
   type StartDaemonProcessOptions,
   startDaemonProcess,
 } from "./process.js";
-
+export {
+  createProtocolError,
+  createProtocolErrorFrame,
+  createProtocolEventFrame,
+  createProtocolSuccessFrame,
+  mapErrorToProtocolError,
+  PROTOCOL_ERROR_CODES,
+  type ProtocolError,
+  type ProtocolErrorCode,
+  type ProtocolErrorFrame,
+  type ProtocolEventFrame,
+  type ProtocolFrameId,
+  type ProtocolParams,
+  type ProtocolRequestFrame,
+  type ProtocolSuccessFrame,
+  parseProtocolRequestFrame,
+  parseProtocolRequestJson,
+} from "./protocol.js";
 export {
   createDaemonRuntime,
   DAEMON_ROLES,

--- a/packages/daemon/src/protocol.test.ts
+++ b/packages/daemon/src/protocol.test.ts
@@ -1,0 +1,179 @@
+import { notFound, storageError, validationError } from "@todu/core";
+import { describe, expect, it } from "vitest";
+import {
+  createProtocolError,
+  createProtocolErrorFrame,
+  createProtocolEventFrame,
+  createProtocolSuccessFrame,
+  mapErrorToProtocolError,
+  type ProtocolError,
+  parseProtocolRequestFrame,
+  parseProtocolRequestJson,
+} from "./protocol.js";
+
+describe("parseProtocolRequestFrame", () => {
+  it("parses valid request frames", () => {
+    const parsed = parseProtocolRequestFrame({
+      id: "1",
+      method: "daemon.status",
+      params: { verbose: true },
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("Expected valid frame parse");
+    }
+
+    expect(parsed.value).toEqual({
+      id: "1",
+      method: "daemon.status",
+      params: { verbose: true },
+    });
+  });
+
+  it("defaults missing params to an empty object", () => {
+    const parsed = parseProtocolRequestFrame({
+      id: "2",
+      method: "daemon.ping",
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("Expected valid frame parse");
+    }
+
+    expect(parsed.value.params).toEqual({});
+  });
+
+  it("returns BAD_REQUEST when frame is not an object", () => {
+    const parsed = parseProtocolRequestFrame("not-an-object");
+    expectProtocolError(parsed, "BAD_REQUEST", "Protocol request frame must be an object");
+  });
+
+  it("returns BAD_REQUEST when id is invalid", () => {
+    const parsed = parseProtocolRequestFrame({
+      id: 12,
+      method: "daemon.ping",
+    });
+
+    expectProtocolError(parsed, "BAD_REQUEST", "Protocol request id must be a non-empty string");
+  });
+
+  it("returns BAD_REQUEST when method is invalid", () => {
+    const parsed = parseProtocolRequestFrame({
+      id: "1",
+      method: null,
+    });
+
+    expectProtocolError(
+      parsed,
+      "BAD_REQUEST",
+      "Protocol request method must be a non-empty string",
+    );
+  });
+
+  it("returns BAD_REQUEST when params is not an object", () => {
+    const parsed = parseProtocolRequestFrame({
+      id: "1",
+      method: "daemon.ping",
+      params: "invalid",
+    });
+
+    expectProtocolError(parsed, "BAD_REQUEST", "Protocol request params must be an object");
+  });
+});
+
+describe("parseProtocolRequestJson", () => {
+  it("returns BAD_REQUEST for invalid JSON payloads", () => {
+    const parsed = parseProtocolRequestJson("{ invalid-json }");
+    expectProtocolError(parsed, "BAD_REQUEST", "Protocol payload is not valid JSON");
+  });
+});
+
+describe("mapErrorToProtocolError", () => {
+  it("keeps protocol errors stable", () => {
+    const mapped = mapErrorToProtocolError(
+      createProtocolError("METHOD_NOT_FOUND", "Unknown method", { method: "bad.method" }),
+    );
+
+    expect(mapped).toEqual({
+      code: "METHOD_NOT_FOUND",
+      message: "Unknown method",
+      details: { method: "bad.method" },
+    });
+  });
+
+  it("maps domain not-found errors to NOT_FOUND", () => {
+    const mapped = mapErrorToProtocolError(notFound("task", "123"));
+    expect(mapped.code).toBe("NOT_FOUND");
+    expect(mapped.message).toBe("task not found: 123");
+  });
+
+  it("maps domain validation errors to VALIDATION_ERROR", () => {
+    const mapped = mapErrorToProtocolError(validationError("title", "required"));
+    expect(mapped.code).toBe("VALIDATION_ERROR");
+    expect(mapped.message).toBe("required");
+    expect(mapped.details).toEqual({ field: "title" });
+  });
+
+  it("maps domain storage errors to INTERNAL_ERROR", () => {
+    const mapped = mapErrorToProtocolError(storageError("disk unavailable"));
+    expect(mapped.code).toBe("INTERNAL_ERROR");
+    expect(mapped.message).toBe("disk unavailable");
+  });
+
+  it("maps timeout-like errors to TIMEOUT", () => {
+    const timeoutError = new Error("request timed out");
+    timeoutError.name = "TimeoutError";
+
+    const mapped = mapErrorToProtocolError(timeoutError);
+    expect(mapped.code).toBe("TIMEOUT");
+    expect(mapped.message).toBe("request timed out");
+  });
+
+  it("maps unknown errors to INTERNAL_ERROR", () => {
+    const mapped = mapErrorToProtocolError({ something: "unexpected" });
+    expect(mapped.code).toBe("INTERNAL_ERROR");
+    expect(mapped.message).toBe("Unexpected internal error");
+  });
+});
+
+describe("frame helpers", () => {
+  it("builds success and error response frames", () => {
+    const success = createProtocolSuccessFrame("1", { pong: true });
+    expect(success).toEqual({ id: "1", result: { pong: true } });
+
+    const error = createProtocolErrorFrame("1", validationError("field", "bad"));
+    expect(error.id).toBe("1");
+    expect(error.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("builds reusable event frames", () => {
+    const event = createProtocolEventFrame(
+      "data.changed",
+      { scope: "task" },
+      "2026-02-22T00:00:00.000Z",
+    );
+    expect(event).toEqual({
+      event: "data.changed",
+      payload: { scope: "task" },
+      ts: "2026-02-22T00:00:00.000Z",
+    });
+  });
+});
+
+function expectProtocolError(
+  result:
+    | ReturnType<typeof parseProtocolRequestFrame>
+    | ReturnType<typeof parseProtocolRequestJson>,
+  code: ProtocolError["code"],
+  message: string,
+): void {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("Expected protocol parse error");
+  }
+
+  expect(result.error.code).toBe(code);
+  expect(result.error.message).toBe(message);
+}

--- a/packages/daemon/src/protocol.ts
+++ b/packages/daemon/src/protocol.ts
@@ -1,0 +1,246 @@
+import { err, ok, type Result, type ToduError } from "@todu/core";
+
+export const PROTOCOL_ERROR_CODES = [
+  "PROTOCOL_MISMATCH",
+  "BAD_REQUEST",
+  "METHOD_NOT_FOUND",
+  "UNSUPPORTED_CAPABILITY",
+  "TIMEOUT",
+  "DAEMON_UNAVAILABLE",
+  "VALIDATION_ERROR",
+  "NOT_FOUND",
+  "CONFLICT",
+  "PRECONDITION_FAILED",
+  "JOIN_FAILED",
+  "WORKER_NOT_ASSIGNED",
+  "INTERNAL_ERROR",
+] as const;
+
+export type ProtocolErrorCode = (typeof PROTOCOL_ERROR_CODES)[number];
+
+export type ProtocolFrameId = string;
+export type ProtocolParams = Record<string, unknown>;
+
+export interface ProtocolRequestFrame {
+  id: ProtocolFrameId;
+  method: string;
+  params: ProtocolParams;
+}
+
+export interface ProtocolSuccessFrame<T = unknown> {
+  id: ProtocolFrameId;
+  result: T;
+}
+
+export interface ProtocolError {
+  code: ProtocolErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface ProtocolErrorFrame {
+  id: ProtocolFrameId | null;
+  error: ProtocolError;
+}
+
+export interface ProtocolEventFrame<T = unknown> {
+  event: string;
+  payload: T;
+  ts: string;
+}
+
+export function parseProtocolRequestJson(
+  payload: string,
+): Result<ProtocolRequestFrame, ProtocolError> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(payload);
+  } catch (error) {
+    return err(
+      createProtocolError("BAD_REQUEST", "Protocol payload is not valid JSON", {
+        parseError: getErrorMessage(error),
+      }),
+    );
+  }
+
+  return parseProtocolRequestFrame(parsed);
+}
+
+export function parseProtocolRequestFrame(
+  frame: unknown,
+): Result<ProtocolRequestFrame, ProtocolError> {
+  if (!isRecord(frame)) {
+    return err(
+      createProtocolError("BAD_REQUEST", "Protocol request frame must be an object", {
+        receivedType: describeValueType(frame),
+      }),
+    );
+  }
+
+  const id = frame.id;
+  if (typeof id !== "string" || id.trim().length === 0) {
+    return err(
+      createProtocolError("BAD_REQUEST", "Protocol request id must be a non-empty string", {
+        field: "id",
+      }),
+    );
+  }
+
+  const method = frame.method;
+  if (typeof method !== "string" || method.trim().length === 0) {
+    return err(
+      createProtocolError("BAD_REQUEST", "Protocol request method must be a non-empty string", {
+        field: "method",
+      }),
+    );
+  }
+
+  const rawParams = frame.params;
+  if (rawParams === undefined) {
+    return ok({ id, method, params: {} });
+  }
+
+  if (!isRecord(rawParams)) {
+    return err(
+      createProtocolError("BAD_REQUEST", "Protocol request params must be an object", {
+        field: "params",
+      }),
+    );
+  }
+
+  return ok({ id, method, params: rawParams });
+}
+
+export function createProtocolSuccessFrame<T>(
+  id: ProtocolFrameId,
+  result: T,
+): ProtocolSuccessFrame<T> {
+  return { id, result };
+}
+
+export function createProtocolErrorFrame(
+  id: ProtocolFrameId | null,
+  source: unknown,
+): ProtocolErrorFrame {
+  return {
+    id,
+    error: mapErrorToProtocolError(source),
+  };
+}
+
+export function createProtocolEventFrame<T>(
+  event: string,
+  payload: T,
+  ts: string = new Date().toISOString(),
+): ProtocolEventFrame<T> {
+  return {
+    event,
+    payload,
+    ts,
+  };
+}
+
+export function createProtocolError(
+  code: ProtocolErrorCode,
+  message: string,
+  details?: Record<string, unknown>,
+): ProtocolError {
+  if (details === undefined) {
+    return { code, message };
+  }
+
+  return { code, message, details };
+}
+
+export function mapErrorToProtocolError(source: unknown): ProtocolError {
+  if (isProtocolError(source)) {
+    return source;
+  }
+
+  if (isToduError(source)) {
+    return mapToduError(source);
+  }
+
+  if (isTimeoutLikeError(source)) {
+    return createProtocolError("TIMEOUT", getErrorMessage(source));
+  }
+
+  return createProtocolError("INTERNAL_ERROR", getErrorMessage(source));
+}
+
+function mapToduError(error: ToduError): ProtocolError {
+  switch (error.type) {
+    case "not-found":
+      return createProtocolError("NOT_FOUND", `${error.entity} not found: ${error.id}`, {
+        entity: error.entity,
+        id: error.id,
+      });
+    case "validation":
+      return createProtocolError("VALIDATION_ERROR", error.message, {
+        field: error.field,
+      });
+    case "storage":
+      return createProtocolError("INTERNAL_ERROR", error.message);
+  }
+}
+
+function isProtocolError(value: unknown): value is ProtocolError {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (typeof value.code !== "string" || typeof value.message !== "string") {
+    return false;
+  }
+
+  return isProtocolErrorCode(value.code);
+}
+
+function isProtocolErrorCode(value: string): value is ProtocolErrorCode {
+  return (PROTOCOL_ERROR_CODES as readonly string[]).includes(value);
+}
+
+function isToduError(value: unknown): value is ToduError {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return false;
+  }
+
+  return value.type === "not-found" || value.type === "validation" || value.type === "storage";
+}
+
+function isTimeoutLikeError(value: unknown): boolean {
+  if (!(value instanceof Error)) {
+    return false;
+  }
+
+  return value.name === "TimeoutError";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeValueType(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (Array.isArray(value)) {
+    return "array";
+  }
+
+  return typeof value;
+}
+
+function getErrorMessage(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return "Unexpected internal error";
+}


### PR DESCRIPTION
Summary
- add protocol envelope primitives for daemon request/success/error/event frames
- add protocol request parsing/validation helpers for object/id/method/params checks
- add deterministic BAD_REQUEST mapping for malformed JSON and invalid frames
- add stable protocol error taxonomy constants and mapping utility for domain/protocol errors
- export protocol primitives from daemon package index
- add protocol unit tests and update phase-1 progress notes

Verification
- make pre-pr
- protocol-focused tests validate:
  - valid request parsing
  - invalid frame handling
  - domain/protocol error mapping consistency
  - reusable event/error/success frame helpers

Scope guard
- no RPC method handlers implemented in this PR
- no CLI/Electron migration included

Task: #1928
