### PR TITLE
feat: implement daemon.status and daemon.ping baseline methods (#1930)

### DIFF
--- a/docs/plans/phase-1-daemon-foundation.md
+++ b/docs/plans/phase-1-daemon-foundation.md
@@ -183,3 +183,21 @@ Every task must include a documentation step in the same PR (or explicitly justi
 - Added handshake tests:
   - router unit tests in `packages/daemon/src/rpc.test.ts`
   - runtime UDS routing handshake verification in `packages/daemon/src/runtime.test.ts`.
+
+### 2026-02-22 — Task #1930
+
+- Added baseline daemon methods `daemon.ping` and `daemon.status` in `packages/daemon/src/rpc.ts`.
+- `daemon.ping` now returns a stable health response (`ok`, `ts`) for liveness checks.
+- `daemon.status` now returns baseline metadata for thin clients:
+  - `protocolVersion`
+  - `daemonVersion`
+  - daemon `role`
+  - runtime `state` and derived `healthy` flag
+  - `startedAt`
+  - transport endpoint metadata (`kind`, `path`, `mode`)
+  - catalog context (`catalog.id`)
+- Extended daemon RPC context wiring in runtime so status reflects current runtime and transport state.
+- Expanded tests:
+  - router unit coverage for `daemon.ping` and `daemon.status`
+  - runtime UDS integration coverage for ping/status requests
+- Updated handshake capability reporting to include implemented baseline daemon methods.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -25,10 +25,15 @@ export {
 
 export {
   createDaemonRpcRouter,
+  DAEMON_CAPABILITY_METHODS,
   DAEMON_PROTOCOL_VERSION,
   type DaemonHelloResult,
+  type DaemonPingResult,
   type DaemonRpcContext,
   type DaemonRpcRouter,
+  type DaemonRuntimeStateSnapshot,
+  type DaemonStatusResult,
+  type DaemonStatusTransport,
   DEFAULT_DAEMON_VERSION,
 } from "./rpc.js";
 

--- a/packages/daemon/src/rpc.test.ts
+++ b/packages/daemon/src/rpc.test.ts
@@ -1,8 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { createDaemonRpcRouter, DAEMON_PROTOCOL_VERSION, DEFAULT_DAEMON_VERSION } from "./rpc.js";
+import {
+  createDaemonRpcRouter,
+  DAEMON_CAPABILITY_METHODS,
+  DAEMON_PROTOCOL_VERSION,
+  type DaemonRpcContext,
+  DEFAULT_DAEMON_VERSION,
+} from "./rpc.js";
 
 describe("createDaemonRpcRouter", () => {
   const router = createDaemonRpcRouter();
+
+  const context: DaemonRpcContext = {
+    daemonVersion: DEFAULT_DAEMON_VERSION,
+    role: "authority",
+    catalogId: "catalog-123",
+    runtimeState: "running",
+    startedAt: "2026-02-22T23:00:00.000Z",
+    transport: {
+      kind: "uds",
+      path: "/tmp/todu-daemon.sock",
+      mode: 0o600,
+    },
+  };
 
   it("returns daemon.hello handshake payload with deterministic capabilities", () => {
     const response = router.handleRequest(
@@ -13,11 +32,7 @@ describe("createDaemonRpcRouter", () => {
           protocolVersion: DAEMON_PROTOCOL_VERSION,
         },
       },
-      {
-        daemonVersion: DEFAULT_DAEMON_VERSION,
-        role: "authority",
-        catalogId: "catalog-123",
-      },
+      context,
     );
 
     expect("result" in response).toBe(true);
@@ -30,8 +45,64 @@ describe("createDaemonRpcRouter", () => {
       daemonVersion: DEFAULT_DAEMON_VERSION,
       role: "authority",
       capabilities: {
-        methods: ["daemon.hello"],
+        methods: DAEMON_CAPABILITY_METHODS,
         events: [],
+      },
+      catalog: {
+        id: "catalog-123",
+      },
+    });
+  });
+
+  it("returns daemon.ping healthy response", () => {
+    const response = router.handleRequest(
+      {
+        id: "ping-1",
+        method: "daemon.ping",
+        params: {},
+      },
+      context,
+    );
+
+    expect("result" in response).toBe(true);
+    if (!("result" in response)) {
+      throw new Error("Expected ping success response");
+    }
+
+    expect(response.result).toMatchObject({
+      ok: true,
+    });
+
+    expect(typeof response.result.ts).toBe("string");
+    expect(Number.isNaN(Date.parse(response.result.ts))).toBe(false);
+  });
+
+  it("returns daemon.status baseline metadata", () => {
+    const response = router.handleRequest(
+      {
+        id: "status-1",
+        method: "daemon.status",
+        params: {},
+      },
+      context,
+    );
+
+    expect("result" in response).toBe(true);
+    if (!("result" in response)) {
+      throw new Error("Expected status success response");
+    }
+
+    expect(response.result).toEqual({
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonVersion: DEFAULT_DAEMON_VERSION,
+      role: "authority",
+      state: "running",
+      healthy: true,
+      startedAt: "2026-02-22T23:00:00.000Z",
+      transport: {
+        kind: "uds",
+        path: "/tmp/todu-daemon.sock",
+        mode: 0o600,
       },
       catalog: {
         id: "catalog-123",
@@ -48,11 +119,7 @@ describe("createDaemonRpcRouter", () => {
           protocolVersion: "999",
         },
       },
-      {
-        daemonVersion: DEFAULT_DAEMON_VERSION,
-        role: "node",
-        catalogId: null,
-      },
+      context,
     );
 
     expect("error" in response).toBe(true);
@@ -74,11 +141,7 @@ describe("createDaemonRpcRouter", () => {
         method: "daemon.hello",
         params: {},
       },
-      {
-        daemonVersion: DEFAULT_DAEMON_VERSION,
-        role: "node",
-        catalogId: null,
-      },
+      context,
     );
 
     expect("error" in response).toBe(true);
@@ -97,11 +160,7 @@ describe("createDaemonRpcRouter", () => {
         method: "unknown.method",
         params: {},
       },
-      {
-        daemonVersion: DEFAULT_DAEMON_VERSION,
-        role: "node",
-        catalogId: null,
-      },
+      context,
     );
 
     expect("error" in response).toBe(true);
@@ -113,11 +172,7 @@ describe("createDaemonRpcRouter", () => {
   });
 
   it("maps invalid JSON payloads to BAD_REQUEST through handlePayload", () => {
-    const response = router.handlePayload("{ invalid-json }", {
-      daemonVersion: DEFAULT_DAEMON_VERSION,
-      role: "node",
-      catalogId: null,
-    });
+    const response = router.handlePayload("{ invalid-json }", context);
 
     expect("error" in response).toBe(true);
     if (!("error" in response)) {

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -11,6 +11,7 @@ import {
 
 export const DAEMON_PROTOCOL_VERSION = "1";
 export const DEFAULT_DAEMON_VERSION = "dev";
+export const DAEMON_CAPABILITY_METHODS = ["daemon.hello", "daemon.ping", "daemon.status"];
 
 export interface DaemonHelloResult {
   protocolVersion: string;
@@ -25,10 +26,39 @@ export interface DaemonHelloResult {
   };
 }
 
+export interface DaemonPingResult {
+  ok: true;
+  ts: string;
+}
+
+export interface DaemonStatusTransport {
+  kind: "uds";
+  path: string;
+  mode: number;
+}
+
+export type DaemonRuntimeStateSnapshot = "stopped" | "starting" | "running" | "stopping";
+
+export interface DaemonStatusResult {
+  protocolVersion: string;
+  daemonVersion: string;
+  role: "node" | "authority";
+  state: DaemonRuntimeStateSnapshot;
+  healthy: boolean;
+  startedAt: string | null;
+  transport: DaemonStatusTransport | null;
+  catalog: {
+    id: string | null;
+  };
+}
+
 export interface DaemonRpcContext {
   daemonVersion: string;
   role: "node" | "authority";
   catalogId: string | null;
+  runtimeState: DaemonRuntimeStateSnapshot;
+  startedAt: string | null;
+  transport: DaemonStatusTransport | null;
 }
 
 export interface DaemonRpcRouter {
@@ -48,6 +78,14 @@ export function createDaemonRpcRouter(): DaemonRpcRouter {
     handleRequest(request: ProtocolRequestFrame, context: DaemonRpcContext) {
       if (request.method === "daemon.hello") {
         return handleDaemonHello(request, context);
+      }
+
+      if (request.method === "daemon.ping") {
+        return handleDaemonPing(request);
+      }
+
+      if (request.method === "daemon.status") {
+        return handleDaemonStatus(request, context);
       }
 
       return createProtocolErrorFrame(
@@ -127,9 +165,34 @@ function handleDaemonHello(
     daemonVersion: context.daemonVersion,
     role: context.role,
     capabilities: {
-      methods: ["daemon.hello"],
+      methods: DAEMON_CAPABILITY_METHODS.slice(),
       events: [],
     },
+    catalog: {
+      id: context.catalogId,
+    },
+  });
+}
+
+function handleDaemonPing(request: ProtocolRequestFrame): ProtocolSuccessFrame<DaemonPingResult> {
+  return createProtocolSuccessFrame(request.id, {
+    ok: true,
+    ts: new Date().toISOString(),
+  });
+}
+
+function handleDaemonStatus(
+  request: ProtocolRequestFrame,
+  context: DaemonRpcContext,
+): ProtocolSuccessFrame<DaemonStatusResult> {
+  return createProtocolSuccessFrame(request.id, {
+    protocolVersion: DAEMON_PROTOCOL_VERSION,
+    daemonVersion: context.daemonVersion,
+    role: context.role,
+    state: context.runtimeState,
+    healthy: context.runtimeState === "running",
+    startedAt: context.startedAt,
+    transport: context.transport,
     catalog: {
       id: context.catalogId,
     },

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -3,7 +3,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DAEMON_PROTOCOL_VERSION } from "./rpc.js";
+import { DAEMON_CAPABILITY_METHODS, DAEMON_PROTOCOL_VERSION } from "./rpc.js";
 import { createDaemonRuntime } from "./runtime.js";
 
 describe("createDaemonRuntime", () => {
@@ -65,11 +65,68 @@ describe("createDaemonRuntime", () => {
       daemonVersion: "1.2.3",
       role: "authority",
       capabilities: {
-        methods: ["daemon.hello"],
+        methods: DAEMON_CAPABILITY_METHODS,
         events: [],
       },
       catalog: {
         id: runtime.status().catalogId,
+      },
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes daemon.ping and daemon.status over UDS", async () => {
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      role: "authority",
+      daemonVersion: "2.0.0",
+    });
+
+    await runtime.start();
+
+    const pingResponse = await sendRequest(runtime.config().socketPath, {
+      id: "ping-1",
+      method: "daemon.ping",
+      params: {},
+    });
+
+    expect(pingResponse.id).toBe("ping-1");
+    expect(pingResponse.result).toMatchObject({
+      ok: true,
+    });
+
+    if (!pingResponse.result || typeof pingResponse.result !== "object") {
+      throw new Error("Expected ping result object");
+    }
+
+    const pingResult = pingResponse.result as { ts?: unknown };
+    expect(typeof pingResult.ts).toBe("string");
+    expect(Number.isNaN(Date.parse(pingResult.ts as string))).toBe(false);
+
+    const statusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "status-1",
+      method: "daemon.status",
+      params: {},
+    });
+
+    const runtimeStatus = runtime.status();
+
+    expect(statusResponse.id).toBe("status-1");
+    expect(statusResponse.result).toEqual({
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonVersion: "2.0.0",
+      role: "authority",
+      state: "running",
+      healthy: true,
+      startedAt: runtimeStatus.startedAt,
+      transport: {
+        kind: "uds",
+        path: runtime.config().socketPath,
+        mode: runtime.config().socketMode,
+      },
+      catalog: {
+        id: runtimeStatus.catalogId,
       },
     });
 

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -84,6 +84,15 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       daemonVersion: resolvedConfig.daemonVersion,
       role: runtimeStatus.role,
       catalogId: todu?.sync.getCatalogId() ?? runtimeStatus.catalogId ?? null,
+      runtimeState: runtimeStatus.state,
+      startedAt: runtimeStatus.startedAt ?? null,
+      transport: runtimeStatus.transport
+        ? {
+            kind: runtimeStatus.transport.kind,
+            path: runtimeStatus.transport.path,
+            mode: runtimeStatus.transport.mode,
+          }
+        : null,
     })),
   });
 


### PR DESCRIPTION
Summary
- add baseline daemon methods `daemon.ping` and `daemon.status`
- extend daemon RPC context so status responses include runtime state and UDS endpoint metadata
- include new methods in `daemon.hello` capability reporting
- add router and runtime integration tests for ping/status
- update phase-1 progress notes for Task #1930

Behavior
- `daemon.ping` returns `{ ok: true, ts }`
- `daemon.status` returns baseline metadata:
  - protocolVersion
  - daemonVersion
  - role
  - state + healthy
  - startedAt
  - transport (kind/path/mode)
  - catalog context

Verification
- ./scripts/pre-pr.sh
- targeted daemon tests for rpc/runtime method routing

Task: #1930
