### PR TITLE
feat: add baseline events subscribe/unsubscribe channel (#1931)

### DIFF
--- a/docs/plans/phase-1-daemon-foundation.md
+++ b/docs/plans/phase-1-daemon-foundation.md
@@ -201,3 +201,22 @@ Every task must include a documentation step in the same PR (or explicitly justi
   - router unit coverage for `daemon.ping` and `daemon.status`
   - runtime UDS integration coverage for ping/status requests
 - Updated handshake capability reporting to include implemented baseline daemon methods.
+
+### 2026-02-22 — Task #1931
+
+- Added baseline event channel methods `events.subscribe` and `events.unsubscribe` in `packages/daemon/src/rpc.ts`.
+- Added per-connection subscription tracking (connection-scoped registries; no shared global subscription state across clients).
+- Added unsupported-event reporting via structured `UNSUPPORTED_CAPABILITY` with supported/unsupported event lists.
+- Added event dispatch baseline through protocol event frames (`{ event, payload, ts }`) with best-effort delivery.
+- Wired runtime emitters for baseline events:
+  - `data.changed` via `todu.onChange(...)`
+  - `sync.statusChanged` via `todu.sync.onStatusChange(...)`
+- Best-effort semantics documented/implemented for baseline:
+  - no durable replay buffer in this phase
+  - disconnected clients may miss events
+  - reconnecting clients are expected to re-subscribe and refresh current state
+- Expanded tests:
+  - router coverage for subscribe/unsubscribe validation and unsupported events
+  - dispatch integration coverage for connection-scoped subscription delivery
+  - runtime routing coverage for subscribe/unsubscribe methods over UDS
+- Updated `daemon.hello` capability reporting to include event channel methods/events.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -25,8 +25,10 @@ export {
 
 export {
   createDaemonRpcRouter,
+  DAEMON_CAPABILITY_EVENTS,
   DAEMON_CAPABILITY_METHODS,
   DAEMON_PROTOCOL_VERSION,
+  type DaemonCapabilityEvent,
   type DaemonHelloResult,
   type DaemonPingResult,
   type DaemonRpcContext,
@@ -35,6 +37,8 @@ export {
   type DaemonStatusResult,
   type DaemonStatusTransport,
   DEFAULT_DAEMON_VERSION,
+  type EventsSubscribeResult,
+  type EventsUnsubscribeResult,
 } from "./rpc.js";
 
 export {

--- a/packages/daemon/src/rpc.test.ts
+++ b/packages/daemon/src/rpc.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import net, { type Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createDaemonRpcRouter,
+  DAEMON_CAPABILITY_EVENTS,
   DAEMON_CAPABILITY_METHODS,
   DAEMON_PROTOCOL_VERSION,
   type DaemonRpcContext,
@@ -46,7 +51,7 @@ describe("createDaemonRpcRouter", () => {
       role: "authority",
       capabilities: {
         methods: DAEMON_CAPABILITY_METHODS,
-        events: [],
+        events: [...DAEMON_CAPABILITY_EVENTS],
       },
       catalog: {
         id: "catalog-123",
@@ -182,3 +187,224 @@ describe("createDaemonRpcRouter", () => {
     expect(response.error.code).toBe("BAD_REQUEST");
   });
 });
+
+describe("events.subscribe/events.unsubscribe dispatch", () => {
+  let tmpDir: string;
+  let socketPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-rpc-test-"));
+    socketPath = path.join(tmpDir, "daemon.sock");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("tracks subscriptions per connection and dispatches best-effort event frames", async () => {
+    const router = createDaemonRpcRouter();
+
+    const context: DaemonRpcContext = {
+      daemonVersion: DEFAULT_DAEMON_VERSION,
+      role: "node",
+      catalogId: "catalog-123",
+      runtimeState: "running",
+      startedAt: "2026-02-22T23:00:00.000Z",
+      transport: {
+        kind: "uds",
+        path: socketPath,
+        mode: 0o600,
+      },
+    };
+
+    const server = net.createServer(router.createConnectionHandler(() => context));
+    await listenServer(server, socketPath);
+
+    const client = net.createConnection(socketPath);
+    client.setEncoding("utf8");
+
+    await waitForConnect(client);
+    const nextFrame = createJsonLineReader(client);
+
+    client.write(
+      `${JSON.stringify({
+        id: "sub-1",
+        method: "events.subscribe",
+        params: { events: ["data.changed"] },
+      })}\n`,
+    );
+
+    const subscribeResponse = await nextFrame();
+    expect(subscribeResponse).toEqual({
+      id: "sub-1",
+      result: {
+        subscribed: ["data.changed"],
+      },
+    });
+
+    const delivered = router.dispatchEvent(
+      "data.changed",
+      { scope: "task" },
+      "2026-02-22T00:00:00.000Z",
+    );
+    expect(delivered).toBe(1);
+
+    const eventFrame = await nextFrame();
+    expect(eventFrame).toEqual({
+      event: "data.changed",
+      payload: { scope: "task" },
+      ts: "2026-02-22T00:00:00.000Z",
+    });
+
+    client.write(
+      `${JSON.stringify({
+        id: "unsub-1",
+        method: "events.unsubscribe",
+        params: { events: ["data.changed"] },
+      })}\n`,
+    );
+
+    const unsubscribeResponse = await nextFrame();
+    expect(unsubscribeResponse).toEqual({
+      id: "unsub-1",
+      result: {
+        unsubscribed: ["data.changed"],
+      },
+    });
+
+    const deliveredAfterUnsubscribe = router.dispatchEvent("data.changed", {
+      scope: "task",
+      after: true,
+    });
+    expect(deliveredAfterUnsubscribe).toBe(0);
+
+    await expect(nextFrame(150)).rejects.toThrow("Timed out waiting for frame");
+
+    client.end();
+    await closeServer(server);
+  });
+
+  it("returns UNSUPPORTED_CAPABILITY for unsupported event names", async () => {
+    const router = createDaemonRpcRouter();
+
+    const context: DaemonRpcContext = {
+      daemonVersion: DEFAULT_DAEMON_VERSION,
+      role: "node",
+      catalogId: null,
+      runtimeState: "running",
+      startedAt: "2026-02-22T23:00:00.000Z",
+      transport: {
+        kind: "uds",
+        path: socketPath,
+        mode: 0o600,
+      },
+    };
+
+    const server = net.createServer(router.createConnectionHandler(() => context));
+    await listenServer(server, socketPath);
+
+    const client = net.createConnection(socketPath);
+    client.setEncoding("utf8");
+
+    await waitForConnect(client);
+    const nextFrame = createJsonLineReader(client);
+
+    client.write(
+      `${JSON.stringify({
+        id: "sub-1",
+        method: "events.subscribe",
+        params: { events: ["unsupported.event"] },
+      })}\n`,
+    );
+
+    const response = await nextFrame();
+    expect(response.id).toBe("sub-1");
+    expect(response.error?.code).toBe("UNSUPPORTED_CAPABILITY");
+    expect(response.error?.details).toEqual({
+      unsupported: ["unsupported.event"],
+      supported: [...DAEMON_CAPABILITY_EVENTS],
+    });
+
+    client.end();
+    await closeServer(server);
+  });
+});
+
+function listenServer(server: net.Server, socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function waitForConnect(socket: Socket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("error", reject);
+    socket.once("connect", () => {
+      socket.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function createJsonLineReader(
+  client: Socket,
+): (timeoutMs?: number) => Promise<Record<string, unknown>> {
+  let buffer = "";
+  const queuedLines: string[] = [];
+  const waiters: Array<(line: string) => void> = [];
+
+  client.on("data", (chunk: string) => {
+    buffer += chunk;
+
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) {
+        continue;
+      }
+
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter(trimmed);
+      } else {
+        queuedLines.push(trimmed);
+      }
+    }
+  });
+
+  return async (timeoutMs: number = 1000): Promise<Record<string, unknown>> => {
+    if (queuedLines.length > 0) {
+      return JSON.parse(queuedLines.shift() ?? "{}");
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const index = waiters.indexOf(onLine);
+        if (index >= 0) {
+          waiters.splice(index, 1);
+        }
+
+        reject(new Error("Timed out waiting for frame"));
+      }, timeoutMs);
+
+      const onLine = (line: string) => {
+        clearTimeout(timeout);
+        resolve(JSON.parse(line) as Record<string, unknown>);
+      };
+
+      waiters.push(onLine);
+    });
+  };
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -2,7 +2,9 @@ import type { Socket } from "node:net";
 import {
   createProtocolError,
   createProtocolErrorFrame,
+  createProtocolEventFrame,
   createProtocolSuccessFrame,
+  type ProtocolError,
   type ProtocolErrorFrame,
   type ProtocolRequestFrame,
   type ProtocolSuccessFrame,
@@ -11,7 +13,16 @@ import {
 
 export const DAEMON_PROTOCOL_VERSION = "1";
 export const DEFAULT_DAEMON_VERSION = "dev";
-export const DAEMON_CAPABILITY_METHODS = ["daemon.hello", "daemon.ping", "daemon.status"];
+export const DAEMON_CAPABILITY_METHODS = [
+  "daemon.hello",
+  "daemon.ping",
+  "daemon.status",
+  "events.subscribe",
+  "events.unsubscribe",
+];
+export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] as const;
+
+export type DaemonCapabilityEvent = (typeof DAEMON_CAPABILITY_EVENTS)[number];
 
 export interface DaemonHelloResult {
   protocolVersion: string;
@@ -52,6 +63,14 @@ export interface DaemonStatusResult {
   };
 }
 
+export interface EventsSubscribeResult {
+  subscribed: DaemonCapabilityEvent[];
+}
+
+export interface EventsUnsubscribeResult {
+  unsubscribed: DaemonCapabilityEvent[];
+}
+
 export interface DaemonRpcContext {
   daemonVersion: string;
   role: "node" | "authority";
@@ -61,21 +80,36 @@ export interface DaemonRpcContext {
   transport: DaemonStatusTransport | null;
 }
 
+interface DaemonConnection {
+  socket: Socket;
+  subscriptions: Set<DaemonCapabilityEvent>;
+  closed: boolean;
+}
+
 export interface DaemonRpcRouter {
   handleRequest(
     request: ProtocolRequestFrame,
     context: DaemonRpcContext,
+    connection?: DaemonConnection,
   ): ProtocolSuccessFrame<unknown> | ProtocolErrorFrame;
   handlePayload(
     payload: string,
     context: DaemonRpcContext,
+    connection?: DaemonConnection,
   ): ProtocolSuccessFrame<unknown> | ProtocolErrorFrame;
   createConnectionHandler(contextProvider: () => DaemonRpcContext): (socket: Socket) => void;
+  dispatchEvent(event: DaemonCapabilityEvent, payload: unknown, ts?: string): number;
 }
 
 export function createDaemonRpcRouter(): DaemonRpcRouter {
+  const connections = new Set<DaemonConnection>();
+
   return {
-    handleRequest(request: ProtocolRequestFrame, context: DaemonRpcContext) {
+    handleRequest(
+      request: ProtocolRequestFrame,
+      context: DaemonRpcContext,
+      connection?: DaemonConnection,
+    ) {
       if (request.method === "daemon.hello") {
         return handleDaemonHello(request, context);
       }
@@ -88,6 +122,14 @@ export function createDaemonRpcRouter(): DaemonRpcRouter {
         return handleDaemonStatus(request, context);
       }
 
+      if (request.method === "events.subscribe") {
+        return handleEventsSubscribe(request, connection);
+      }
+
+      if (request.method === "events.unsubscribe") {
+        return handleEventsUnsubscribe(request, connection);
+      }
+
       return createProtocolErrorFrame(
         request.id,
         createProtocolError("METHOD_NOT_FOUND", `Unknown method: ${request.method}`, {
@@ -96,23 +138,41 @@ export function createDaemonRpcRouter(): DaemonRpcRouter {
       );
     },
 
-    handlePayload(payload: string, context: DaemonRpcContext) {
+    handlePayload(payload: string, context: DaemonRpcContext, connection?: DaemonConnection) {
       const parsed = parseProtocolRequestJson(payload);
       if (!parsed.ok) {
         return createProtocolErrorFrame(null, parsed.error);
       }
 
-      return this.handleRequest(parsed.value, context);
+      return this.handleRequest(parsed.value, context, connection);
     },
 
     createConnectionHandler(contextProvider: () => DaemonRpcContext) {
       return (socket: Socket) => {
         let buffer = "";
 
+        const connection: DaemonConnection = {
+          socket,
+          subscriptions: new Set(),
+          closed: false,
+        };
+
+        const closeConnection = () => {
+          if (connection.closed) {
+            return;
+          }
+
+          connection.closed = true;
+          connection.subscriptions.clear();
+          connections.delete(connection);
+        };
+
+        connections.add(connection);
+
         socket.setEncoding("utf8");
-        socket.on("error", () => {
-          // avoid unhandled socket errors from disconnected clients
-        });
+        socket.on("error", closeConnection);
+        socket.on("close", closeConnection);
+        socket.on("end", closeConnection);
 
         socket.on("data", (chunk: string) => {
           buffer += chunk;
@@ -126,11 +186,46 @@ export function createDaemonRpcRouter(): DaemonRpcRouter {
               continue;
             }
 
-            const response = this.handlePayload(trimmed, contextProvider());
-            socket.write(`${JSON.stringify(response)}\n`);
+            const response = this.handlePayload(trimmed, contextProvider(), connection);
+            try {
+              socket.write(`${JSON.stringify(response)}\n`);
+            } catch {
+              closeConnection();
+            }
           }
         });
       };
+    },
+
+    dispatchEvent(
+      event: DaemonCapabilityEvent,
+      payload: unknown,
+      ts: string = new Date().toISOString(),
+    ): number {
+      const frame = createProtocolEventFrame(event, payload, ts);
+      let delivered = 0;
+
+      for (const connection of connections) {
+        if (connection.closed) {
+          connections.delete(connection);
+          continue;
+        }
+
+        if (!connection.subscriptions.has(event)) {
+          continue;
+        }
+
+        try {
+          connection.socket.write(`${JSON.stringify(frame)}\n`);
+          delivered++;
+        } catch {
+          connection.closed = true;
+          connection.subscriptions.clear();
+          connections.delete(connection);
+        }
+      }
+
+      return delivered;
     },
   };
 }
@@ -166,7 +261,7 @@ function handleDaemonHello(
     role: context.role,
     capabilities: {
       methods: DAEMON_CAPABILITY_METHODS.slice(),
-      events: [],
+      events: [...DAEMON_CAPABILITY_EVENTS],
     },
     catalog: {
       id: context.catalogId,
@@ -197,4 +292,119 @@ function handleDaemonStatus(
       id: context.catalogId,
     },
   });
+}
+
+function handleEventsSubscribe(
+  request: ProtocolRequestFrame,
+  connection?: DaemonConnection,
+): ProtocolSuccessFrame<EventsSubscribeResult> | ProtocolErrorFrame {
+  if (!connection || connection.closed) {
+    return createProtocolErrorFrame(
+      request.id,
+      createProtocolError("INTERNAL_ERROR", "events.subscribe requires active connection context"),
+    );
+  }
+
+  const parsed = parseRequestedEvents(request);
+  if (!parsed.ok) {
+    return createProtocolErrorFrame(request.id, parsed.error);
+  }
+
+  for (const event of parsed.events) {
+    connection.subscriptions.add(event);
+  }
+
+  return createProtocolSuccessFrame(request.id, {
+    subscribed: parsed.events,
+  });
+}
+
+function handleEventsUnsubscribe(
+  request: ProtocolRequestFrame,
+  connection?: DaemonConnection,
+): ProtocolSuccessFrame<EventsUnsubscribeResult> | ProtocolErrorFrame {
+  if (!connection || connection.closed) {
+    return createProtocolErrorFrame(
+      request.id,
+      createProtocolError(
+        "INTERNAL_ERROR",
+        "events.unsubscribe requires active connection context",
+      ),
+    );
+  }
+
+  const parsed = parseRequestedEvents(request);
+  if (!parsed.ok) {
+    return createProtocolErrorFrame(request.id, parsed.error);
+  }
+
+  const unsubscribed: DaemonCapabilityEvent[] = [];
+  for (const event of parsed.events) {
+    if (connection.subscriptions.delete(event)) {
+      unsubscribed.push(event);
+    }
+  }
+
+  return createProtocolSuccessFrame(request.id, {
+    unsubscribed,
+  });
+}
+
+function parseRequestedEvents(
+  request: ProtocolRequestFrame,
+): { ok: true; events: DaemonCapabilityEvent[] } | { ok: false; error: ProtocolError } {
+  const eventsValue = request.params.events;
+
+  if (!Array.isArray(eventsValue) || eventsValue.length === 0) {
+    return {
+      ok: false,
+      error: createProtocolError(
+        "BAD_REQUEST",
+        `${request.method} requires params.events as a non-empty string array`,
+        { field: "events" },
+      ),
+    };
+  }
+
+  const normalized: string[] = [];
+  for (const event of eventsValue) {
+    if (typeof event !== "string" || event.trim().length === 0) {
+      return {
+        ok: false,
+        error: createProtocolError(
+          "BAD_REQUEST",
+          `${request.method} requires params.events as a non-empty string array`,
+          { field: "events" },
+        ),
+      };
+    }
+
+    normalized.push(event.trim());
+  }
+
+  const uniqueEvents = [...new Set(normalized)];
+  const unsupported = uniqueEvents.filter((event) => !isDaemonCapabilityEvent(event));
+
+  if (unsupported.length > 0) {
+    return {
+      ok: false,
+      error: createProtocolError(
+        "UNSUPPORTED_CAPABILITY",
+        "Unsupported event subscriptions requested",
+        {
+          unsupported,
+          supported: [...DAEMON_CAPABILITY_EVENTS],
+        },
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    events: uniqueEvents as DaemonCapabilityEvent[],
+  };
+}
+
+function isDaemonCapabilityEvent(value: string): value is DaemonCapabilityEvent {
+  return (DAEMON_CAPABILITY_EVENTS as readonly string[]).includes(value);
 }

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -3,7 +3,11 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DAEMON_CAPABILITY_METHODS, DAEMON_PROTOCOL_VERSION } from "./rpc.js";
+import {
+  DAEMON_CAPABILITY_EVENTS,
+  DAEMON_CAPABILITY_METHODS,
+  DAEMON_PROTOCOL_VERSION,
+} from "./rpc.js";
 import { createDaemonRuntime } from "./runtime.js";
 
 describe("createDaemonRuntime", () => {
@@ -66,7 +70,7 @@ describe("createDaemonRuntime", () => {
       role: "authority",
       capabilities: {
         methods: DAEMON_CAPABILITY_METHODS,
-        events: [],
+        events: [...DAEMON_CAPABILITY_EVENTS],
       },
       catalog: {
         id: runtime.status().catalogId,
@@ -127,6 +131,59 @@ describe("createDaemonRuntime", () => {
       },
       catalog: {
         id: runtimeStatus.catalogId,
+      },
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes events.subscribe and events.unsubscribe over UDS", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const subscribeResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sub-1",
+      method: "events.subscribe",
+      params: {
+        events: ["data.changed", "sync.statusChanged"],
+      },
+    });
+
+    expect(subscribeResponse).toEqual({
+      id: "sub-1",
+      result: {
+        subscribed: ["data.changed", "sync.statusChanged"],
+      },
+    });
+
+    const unsupportedSubscribeResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sub-2",
+      method: "events.subscribe",
+      params: {
+        events: ["unsupported.event"],
+      },
+    });
+
+    expect(unsupportedSubscribeResponse.id).toBe("sub-2");
+    expect(unsupportedSubscribeResponse.error).toMatchObject({
+      code: "UNSUPPORTED_CAPABILITY",
+    });
+
+    // sendRequest opens a new connection per call, so this unsubscribe call
+    // intentionally validates routing/shape only (not same-connection state).
+    const unsubscribeResponse = await sendRequest(runtime.config().socketPath, {
+      id: "unsub-1",
+      method: "events.unsubscribe",
+      params: {
+        events: ["data.changed"],
+      },
+    });
+
+    expect(unsubscribeResponse).toEqual({
+      id: "unsub-1",
+      result: {
+        unsubscribed: [],
       },
     });
 

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -68,6 +68,8 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   let todu: Todu | null = null;
   let startPromise: Promise<DaemonRuntimeStatus> | null = null;
   let stopPromise: Promise<void> | null = null;
+  let changeSubscriptionCleanup: (() => void) | null = null;
+  let syncStatusSubscriptionCleanup: (() => void) | null = null;
 
   const runtimeStatus: DaemonRuntimeStatus = {
     state: "stopped",
@@ -96,6 +98,18 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     })),
   });
 
+  function clearEventSubscriptions(): void {
+    if (changeSubscriptionCleanup) {
+      changeSubscriptionCleanup();
+      changeSubscriptionCleanup = null;
+    }
+
+    if (syncStatusSubscriptionCleanup) {
+      syncStatusSubscriptionCleanup();
+      syncStatusSubscriptionCleanup = null;
+    }
+  }
+
   function cloneStatus(): DaemonRuntimeStatus {
     return {
       state: runtimeStatus.state,
@@ -122,8 +136,21 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       runtimeStatus.catalogId = todu.sync.getCatalogId();
       runtimeStatus.transport = endpoint;
 
+      changeSubscriptionCleanup = todu.onChange(() => {
+        rpcRouter.dispatchEvent("data.changed", {
+          catalog: {
+            id: todu?.sync.getCatalogId() ?? runtimeStatus.catalogId ?? null,
+          },
+        });
+      });
+
+      syncStatusSubscriptionCleanup = todu.sync.onStatusChange((status) => {
+        rpcRouter.dispatchEvent("sync.statusChanged", status);
+      });
+
       return cloneStatus();
     } catch (error) {
+      clearEventSubscriptions();
       await safeStopTransport(transport);
       runtimeStatus.state = "stopped";
       runtimeStatus.startedAt = undefined;
@@ -169,6 +196,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
 
         const currentTodu = todu;
         todu = null;
+        clearEventSubscriptions();
 
         try {
           await transport.stop();


### PR DESCRIPTION
Summary
- add baseline event channel methods `events.subscribe` and `events.unsubscribe`
- implement per-connection subscription tracking in daemon RPC router
- implement best-effort event frame dispatch (`{ event, payload, ts }`)
- wire runtime emitters for `data.changed` and `sync.statusChanged`
- return structured `UNSUPPORTED_CAPABILITY` for unsupported events
- update `daemon.hello` capability reporting for event methods/events
- update phase-1 documentation with best-effort and reconnect expectations

Verification
- ./scripts/pre-pr.sh
- router tests cover:
  - subscribe/unsubscribe behavior
  - unsupported-event error behavior
  - event dispatch frame shape and per-connection delivery
- runtime tests cover:
  - UDS routing for subscribe/unsubscribe
  - updated handshake capability surface

Task: #1931
