### PR TITLE
feat: add RPC adapters for project task label note

### DIFF
--- a/docs/plans/phase-2-core-rpc-parity.md
+++ b/docs/plans/phase-2-core-rpc-parity.md
@@ -116,3 +116,17 @@ Every task must include a documentation step in the same PR (or explicitly justi
   - `packages/daemon/src/rpc.test.ts`
   - `packages/daemon/src/runtime.test.ts`
   - `packages/daemon/src/protocol-conformance.test.ts`
+
+### 2026-02-22 — Task #1935
+
+- Added daemon RPC adapter handlers for `project.*`, `task.*`, `label.*`, and `note.*` in `packages/daemon/src/core-rpc-adapters.ts`.
+- Wired adapters into runtime defaults so these namespaces are callable over daemon protocol without per-task manual registration.
+- Added deterministic request-param validation (`BAD_REQUEST`) for missing/invalid adapter params.
+- Added stable `Result<T, E>` → protocol mapping for adapted domains:
+  - successful `Result` values map to protocol success frames
+  - domain errors map through protocol error taxonomy (`NOT_FOUND`, `VALIDATION_ERROR`, etc.)
+- Normalized void success results (`Result<void>`) to `result: null` to preserve protocol success envelope shape.
+- Added/expanded runtime + conformance coverage for:
+  - callable project/task/label/note methods
+  - domain and request validation error mapping
+  - unchanged fallback `UNSUPPORTED_CAPABILITY` behavior for still-unadapted namespaces (for example `recurring.*`).

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -1,0 +1,237 @@
+import {
+  type CreateLabelInput,
+  type CreateNoteInput,
+  type CreateProjectInput,
+  type CreateTaskInput,
+  createLabelId,
+  createNoteId,
+  createProjectId,
+  createTaskId,
+  type NoteFilter,
+  type ProjectFilter,
+  type Result,
+  type TaskFilter,
+  type TaskSortOptions,
+  type ToduError,
+  type UpdateLabelInput,
+  type UpdateNoteInput,
+  type UpdateProjectInput,
+  type UpdateTaskInput,
+} from "@todu/core";
+import type { Todu } from "@todu/engine";
+import {
+  createProtocolError,
+  createProtocolErrorFrame,
+  createProtocolSuccessFrame,
+  type ProtocolRequestFrame,
+} from "./protocol.js";
+import type { DaemonRpcMethodHandler, DaemonRpcNamespaceHandlers } from "./rpc.js";
+
+export interface CreateProjectTaskLabelNoteNamespaceHandlersOptions {
+  getTodu: () => Todu | null;
+}
+
+export function createProjectTaskLabelNoteNamespaceHandlers(
+  options: CreateProjectTaskLabelNoteNamespaceHandlersOptions,
+): DaemonRpcNamespaceHandlers {
+  const method = createMethodExecutor(options.getTodu);
+
+  return {
+    project: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateProjectInput>(request, "input");
+        return todu.project.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<ProjectFilter>(request, "filter");
+        return todu.project.list(filter);
+      }),
+      get: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        return todu.project.get(id);
+      }),
+      update: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateProjectInput>(request, "input");
+        return todu.project.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        return todu.project.delete(id);
+      }),
+    },
+    task: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateTaskInput>(request, "input");
+        return todu.task.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<TaskFilter>(request, "filter");
+        const sort = getOptionalObjectParam<TaskSortOptions>(request, "sort");
+        return todu.task.list(filter, sort);
+      }),
+      get: method(async (request, todu) => {
+        const id = createTaskId(getRequiredStringParam(request, "id"));
+        return todu.task.get(id);
+      }),
+      update: method(async (request, todu) => {
+        const id = createTaskId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateTaskInput>(request, "input");
+        return todu.task.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createTaskId(getRequiredStringParam(request, "id"));
+        return todu.task.delete(id);
+      }),
+      move: method(async (request, todu) => {
+        const id = createTaskId(getRequiredStringParam(request, "id"));
+        const projectId = createProjectId(getRequiredStringParam(request, "projectId"));
+        return todu.task.move(id, projectId);
+      }),
+      search: method(async (request, todu) => {
+        const query = getRequiredStringParam(request, "query");
+        return todu.task.search(query);
+      }),
+    },
+    label: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateLabelInput>(request, "input");
+        return todu.label.create(input);
+      }),
+      list: method(async (_request, todu) => {
+        return todu.label.list();
+      }),
+      update: method(async (request, todu) => {
+        const id = createLabelId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateLabelInput>(request, "input");
+        return todu.label.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createLabelId(getRequiredStringParam(request, "id"));
+        return todu.label.delete(id);
+      }),
+    },
+    note: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateNoteInput>(request, "input");
+        return todu.note.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<NoteFilter>(request, "filter");
+        return todu.note.list(filter);
+      }),
+      update: method(async (request, todu) => {
+        const id = createNoteId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateNoteInput>(request, "input");
+        return todu.note.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createNoteId(getRequiredStringParam(request, "id"));
+        return todu.note.delete(id);
+      }),
+    },
+  };
+}
+
+function createMethodExecutor(
+  getTodu: () => Todu | null,
+): (
+  operation: (request: ProtocolRequestFrame, todu: Todu) => Promise<Result<unknown, ToduError>>,
+) => DaemonRpcMethodHandler {
+  return (operation) => {
+    return async (request) => {
+      const todu = getTodu();
+      if (!todu) {
+        return createProtocolErrorFrame(
+          request.id,
+          createProtocolError("INTERNAL_ERROR", "Daemon runtime is not ready", {
+            method: request.method,
+          }),
+        );
+      }
+
+      try {
+        const result = await operation(request, todu);
+        if (result.ok) {
+          return createProtocolSuccessFrame(request.id, normalizeSuccessValue(result.value));
+        }
+
+        return createProtocolErrorFrame(request.id, result.error);
+      } catch (error) {
+        return createProtocolErrorFrame(request.id, error);
+      }
+    };
+  };
+}
+
+function getRequiredStringParam(request: ProtocolRequestFrame, field: string): string {
+  const value = request.params[field];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw createProtocolError(
+      "BAD_REQUEST",
+      `${request.method} requires params.${field} as a non-empty string`,
+      { field },
+    );
+  }
+
+  return value;
+}
+
+function getRequiredObjectParam<T extends object>(request: ProtocolRequestFrame, field: string): T {
+  const value = request.params[field];
+  if (!isRecord(value)) {
+    throw createProtocolError("BAD_REQUEST", `${request.method} requires params.${field} object`, {
+      field,
+    });
+  }
+
+  return value as unknown as T;
+}
+
+function getOptionalObjectParam<T extends object>(
+  request: ProtocolRequestFrame,
+  field: string,
+): T | undefined {
+  const value = request.params[field];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw createProtocolError("BAD_REQUEST", `${request.method} requires params.${field} object`, {
+      field,
+    });
+  }
+
+  return value as unknown as T;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeSuccessValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+
+  return value;
+}
+
+export function mergeNamespaceHandlerSets(
+  base: DaemonRpcNamespaceHandlers,
+  overrides: DaemonRpcNamespaceHandlers,
+): DaemonRpcNamespaceHandlers {
+  const merged: DaemonRpcNamespaceHandlers = {};
+  const namespaceNames = new Set([...Object.keys(base), ...Object.keys(overrides)]);
+
+  for (const namespaceName of namespaceNames) {
+    const namespace = namespaceName as keyof DaemonRpcNamespaceHandlers;
+    merged[namespace] = {
+      ...(base[namespace] ?? {}),
+      ...(overrides[namespace] ?? {}),
+    };
+  }
+
+  return merged;
+}

--- a/packages/daemon/src/protocol-conformance.test.ts
+++ b/packages/daemon/src/protocol-conformance.test.ts
@@ -137,23 +137,53 @@ describe("daemon protocol conformance suite", () => {
     );
   });
 
-  it("returns UNSUPPORTED_CAPABILITY for known core methods without adapters", async () => {
+  it("routes project namespace methods through default runtime adapters", async () => {
     await withRunningRuntime({}, async (runtime) => {
-      const response = await sendRequest(runtime.config().socketPath, {
-        id: "project-list-unsupported",
+      const createResponse = await sendRequest(runtime.config().socketPath, {
+        id: "project-create-default",
+        method: "project.create",
+        params: {
+          input: {
+            name: "Conformance",
+          },
+        },
+      });
+
+      expect(createResponse.id).toBe("project-create-default");
+      expect(createResponse.result).toMatchObject({
+        name: "Conformance",
+      });
+
+      const listResponse = await sendRequest(runtime.config().socketPath, {
+        id: "project-list-default",
         method: "project.list",
         params: {},
       });
 
+      expect(listResponse.id).toBe("project-list-default");
+      expect(listResponse.result).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: "Conformance" })]),
+      );
+    });
+  });
+
+  it("returns UNSUPPORTED_CAPABILITY for namespaces not yet adapted", async () => {
+    await withRunningRuntime({}, async (runtime) => {
+      const response = await sendRequest(runtime.config().socketPath, {
+        id: "recurring-list-unsupported",
+        method: "recurring.list",
+        params: {},
+      });
+
       expect(response).toEqual({
-        id: "project-list-unsupported",
+        id: "recurring-list-unsupported",
         error: {
           code: "UNSUPPORTED_CAPABILITY",
-          message: "Method is not implemented: project.list",
+          message: "Method is not implemented: recurring.list",
           details: {
-            namespace: "project",
-            method: "project.list",
-            capability: "project.list",
+            namespace: "recurring",
+            method: "recurring.list",
+            capability: "recurring.list",
           },
         },
       });

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -170,27 +170,414 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
-  it("returns UNSUPPORTED_CAPABILITY for known core methods without runtime adapters", async () => {
+  it("routes project namespace CRUD methods through runtime adapters", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
     await runtime.start();
 
-    const response = await sendRequest(runtime.config().socketPath, {
-      id: "project-list-unsupported",
+    const createResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-create-1",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Work",
+          description: "Initial",
+        },
+      },
+    });
+
+    const createdProject = createResponse.result as { id?: string; name?: string };
+    expect(createResponse.id).toBe("project-create-1");
+    expect(typeof createdProject.id).toBe("string");
+    expect(createdProject.name).toBe("Work");
+
+    const projectId = createdProject.id as string;
+
+    const listResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-list-1",
       method: "project.list",
       params: {},
     });
 
-    expect(response).toEqual({
-      id: "project-list-unsupported",
-      error: {
-        code: "UNSUPPORTED_CAPABILITY",
-        message: "Method is not implemented: project.list",
-        details: {
-          namespace: "project",
-          method: "project.list",
-          capability: "project.list",
+    expect(listResponse.id).toBe("project-list-1");
+    expect(listResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: projectId, name: "Work" })]),
+    );
+
+    const getResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-get-1",
+      method: "project.get",
+      params: {
+        id: projectId,
+      },
+    });
+
+    expect(getResponse.id).toBe("project-get-1");
+    expect(getResponse.result).toEqual(expect.objectContaining({ id: projectId, name: "Work" }));
+
+    const updateResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-update-1",
+      method: "project.update",
+      params: {
+        id: projectId,
+        input: {
+          name: "Work Updated",
+          priority: "high",
         },
+      },
+    });
+
+    expect(updateResponse.id).toBe("project-update-1");
+    expect(updateResponse.result).toEqual(
+      expect.objectContaining({ id: projectId, name: "Work Updated", priority: "high" }),
+    );
+
+    const deleteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-delete-1",
+      method: "project.delete",
+      params: {
+        id: projectId,
+      },
+    });
+
+    expect(deleteResponse).toEqual({
+      id: "project-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes task namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const sourceProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-source-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Source Project",
+        },
+      },
+    });
+
+    const targetProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-target-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Target Project",
+        },
+      },
+    });
+
+    const sourceProjectId = (sourceProjectResponse.result as { id: string }).id;
+    const targetProjectId = (targetProjectResponse.result as { id: string }).id;
+
+    const createTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-create-1",
+      method: "task.create",
+      params: {
+        input: {
+          title: "Ship feature",
+          projectId: sourceProjectId,
+          description: "Route through daemon",
+          labels: ["phase2"],
+        },
+      },
+    });
+
+    const createdTask = createTaskResponse.result as { id: string };
+    const taskId = createdTask.id;
+
+    const listTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-list-1",
+      method: "task.list",
+      params: {
+        filter: {
+          projectId: sourceProjectId,
+        },
+      },
+    });
+
+    expect(listTaskResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: taskId, title: "Ship feature" })]),
+    );
+
+    const getTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-get-1",
+      method: "task.get",
+      params: {
+        id: taskId,
+      },
+    });
+
+    expect(getTaskResponse.result).toEqual(
+      expect.objectContaining({ id: taskId, description: "Route through daemon" }),
+    );
+
+    const updateTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-update-1",
+      method: "task.update",
+      params: {
+        id: taskId,
+        input: {
+          status: "inprogress",
+          priority: "high",
+        },
+      },
+    });
+
+    expect(updateTaskResponse.result).toEqual(
+      expect.objectContaining({ id: taskId, status: "inprogress", priority: "high" }),
+    );
+
+    const moveTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-move-1",
+      method: "task.move",
+      params: {
+        id: taskId,
+        projectId: targetProjectId,
+      },
+    });
+
+    expect(moveTaskResponse.result).toEqual(
+      expect.objectContaining({ id: taskId, projectId: targetProjectId }),
+    );
+
+    const searchTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-search-1",
+      method: "task.search",
+      params: {
+        query: "ship",
+      },
+    });
+
+    expect(searchTaskResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: taskId })]),
+    );
+
+    const deleteTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-delete-1",
+      method: "task.delete",
+      params: {
+        id: taskId,
+      },
+    });
+
+    expect(deleteTaskResponse).toEqual({
+      id: "task-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes label and note namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const createLabelResponse = await sendRequest(runtime.config().socketPath, {
+      id: "label-create-1",
+      method: "label.create",
+      params: {
+        input: {
+          name: "blocked",
+          color: "#ff0000",
+        },
+      },
+    });
+
+    const labelId = (createLabelResponse.result as { id: string }).id;
+
+    const listLabelResponse = await sendRequest(runtime.config().socketPath, {
+      id: "label-list-1",
+      method: "label.list",
+      params: {},
+    });
+
+    expect(listLabelResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: labelId, name: "blocked" })]),
+    );
+
+    const updateLabelResponse = await sendRequest(runtime.config().socketPath, {
+      id: "label-update-1",
+      method: "label.update",
+      params: {
+        id: labelId,
+        input: {
+          name: "blocked-now",
+        },
+      },
+    });
+
+    expect(updateLabelResponse.result).toEqual(
+      expect.objectContaining({ id: labelId, name: "blocked-now" }),
+    );
+
+    const createProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-note-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Note Project",
+        },
+      },
+    });
+
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
+    const createNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-create-1",
+      method: "note.create",
+      params: {
+        input: {
+          content: "Capture context",
+          author: "agent",
+          entityType: "project",
+          entityId: projectId,
+          tags: ["phase-2"],
+        },
+      },
+    });
+
+    const noteId = (createNoteResponse.result as { id: string }).id;
+
+    const listNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-list-1",
+      method: "note.list",
+      params: {
+        filter: {
+          entityType: "project",
+          entityId: projectId,
+        },
+      },
+    });
+
+    expect(listNoteResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: noteId, content: "Capture context" })]),
+    );
+
+    const updateNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-update-1",
+      method: "note.update",
+      params: {
+        id: noteId,
+        input: {
+          content: "Capture updated context",
+        },
+      },
+    });
+
+    expect(updateNoteResponse.result).toEqual(
+      expect.objectContaining({ id: noteId, content: "Capture updated context" }),
+    );
+
+    const deleteNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-delete-1",
+      method: "note.delete",
+      params: {
+        id: noteId,
+      },
+    });
+
+    expect(deleteNoteResponse).toEqual({
+      id: "note-delete-1",
+      result: null,
+    });
+
+    const deleteLabelResponse = await sendRequest(runtime.config().socketPath, {
+      id: "label-delete-1",
+      method: "label.delete",
+      params: {
+        id: labelId,
+      },
+    });
+
+    expect(deleteLabelResponse).toEqual({
+      id: "label-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("maps domain and request validation errors for project/task/label/note methods", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const badRequestResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-get-bad-request",
+      method: "project.get",
+      params: {
+        id: 42,
+      },
+    });
+
+    expect(badRequestResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "project.get requires params.id as a non-empty string",
+      details: {
+        field: "id",
+      },
+    });
+
+    const notFoundResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-get-not-found",
+      method: "project.get",
+      params: {
+        id: "proj-missing",
+      },
+    });
+
+    expect(notFoundResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "project not found: proj-missing",
+      details: {
+        entity: "project",
+        id: "proj-missing",
+      },
+    });
+
+    const validationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "label-create-validation",
+      method: "label.create",
+      params: {
+        input: {
+          name: "",
+        },
+      },
+    });
+
+    expect(validationResponse.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      details: {
+        field: "name",
+      },
+    });
+
+    const noteNotFoundResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-create-not-found",
+      method: "note.create",
+      params: {
+        input: {
+          content: "Attached note",
+          entityType: "project",
+          entityId: "proj-missing",
+        },
+      },
+    });
+
+    expect(noteNotFoundResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "project not found: proj-missing",
+      details: {
+        entity: "project",
+        id: "proj-missing",
       },
     });
 

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,6 +1,10 @@
 import { type RemoteSyncConfig, resolveStoragePath } from "@todu/core";
 import { createTodu, type Todu } from "@todu/engine";
 import {
+  createProjectTaskLabelNoteNamespaceHandlers,
+  mergeNamespaceHandlerSets,
+} from "./core-rpc-adapters.js";
+import {
   createDaemonRpcRouter,
   type DaemonRpcMethodHandler,
   type DaemonRpcNamespaceHandlers,
@@ -90,9 +94,16 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     role: resolvedConfig.role,
   };
 
+  const defaultNamespaceHandlers = createProjectTaskLabelNoteNamespaceHandlers({
+    getTodu: () => todu,
+  });
+
   const rpcRouter = createDaemonRpcRouter({
     methodHandlers: config.rpcMethodHandlers,
-    namespaceHandlers: config.rpcNamespaceHandlers,
+    namespaceHandlers: mergeNamespaceHandlerSets(
+      defaultNamespaceHandlers,
+      config.rpcNamespaceHandlers ?? {},
+    ),
   });
 
   const transport = createUdsTransport({


### PR DESCRIPTION
## Summary
- add daemon runtime adapters for `project.*`, `task.*`, `label.*`, and `note.*` methods
- map engine `Result<T, E>` outcomes into protocol success/error envelopes with stable error codes
- validate request params and return structured `BAD_REQUEST` for malformed adapter inputs
- normalize void successes to `result: null` for protocol envelope consistency
- add runtime + protocol conformance coverage for callable methods and error mapping
- update phase 2 progress notes for task #1935

## Testing
- npm run check
- npm run test -- packages/daemon/src/*.test.ts
- make pre-pr

Task: #1935