### PR TITLE
feat: add recurring habit sync daemon rpc adapters

### DIFF
--- a/docs/plans/phase-2-core-rpc-parity.md
+++ b/docs/plans/phase-2-core-rpc-parity.md
@@ -126,7 +126,20 @@ Every task must include a documentation step in the same PR (or explicitly justi
   - successful `Result` values map to protocol success frames
   - domain errors map through protocol error taxonomy (`NOT_FOUND`, `VALIDATION_ERROR`, etc.)
 - Normalized void success results (`Result<void>`) to `result: null` to preserve protocol success envelope shape.
-- Added/expanded runtime + conformance coverage for:
-  - callable project/task/label/note methods
-  - domain and request validation error mapping
-  - unchanged fallback `UNSUPPORTED_CAPABILITY` behavior for still-unadapted namespaces (for example `recurring.*`).
+- Added/expanded runtime + conformance coverage for callable methods and error mapping.
+
+### 2026-02-22 — Task #1936
+
+- Extended daemon adapters in `packages/daemon/src/core-rpc-adapters.ts` to cover:
+  - `recurring.*`
+  - `habit.*`
+  - `sync.*`
+- Updated runtime default namespace wiring to use full core adapter set (project/task/label/note/recurring/habit/sync).
+- Updated capability reporting so `daemon.hello` method capabilities include the full core method surface.
+- Added reserved namespace handling for `worker.*`:
+  - returns structured `UNSUPPORTED_CAPABILITY` (reserved, not implemented)
+  - preserves `METHOD_NOT_FOUND` for unknown non-reserved methods
+- Added/expanded runtime and conformance coverage for:
+  - recurring/habit/sync method availability
+  - capability list coverage for newly implemented namespaces
+  - reserved namespace error behavior (`worker.*`)

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -1,21 +1,30 @@
 import {
+  type CreateHabitInput,
   type CreateLabelInput,
   type CreateNoteInput,
   type CreateProjectInput,
+  type CreateRecurringInput,
   type CreateTaskInput,
+  createHabitId,
   createLabelId,
   createNoteId,
   createProjectId,
+  createRecurringId,
   createTaskId,
+  type HabitFilter,
   type NoteFilter,
+  ok,
   type ProjectFilter,
+  type RecurringFilter,
   type Result,
   type TaskFilter,
   type TaskSortOptions,
   type ToduError,
+  type UpdateHabitInput,
   type UpdateLabelInput,
   type UpdateNoteInput,
   type UpdateProjectInput,
+  type UpdateRecurringInput,
   type UpdateTaskInput,
 } from "@todu/core";
 import type { Todu } from "@todu/engine";
@@ -27,12 +36,12 @@ import {
 } from "./protocol.js";
 import type { DaemonRpcMethodHandler, DaemonRpcNamespaceHandlers } from "./rpc.js";
 
-export interface CreateProjectTaskLabelNoteNamespaceHandlersOptions {
+export interface CreateCoreNamespaceHandlersOptions {
   getTodu: () => Todu | null;
 }
 
-export function createProjectTaskLabelNoteNamespaceHandlers(
-  options: CreateProjectTaskLabelNoteNamespaceHandlersOptions,
+export function createCoreNamespaceHandlers(
+  options: CreateCoreNamespaceHandlersOptions,
 ): DaemonRpcNamespaceHandlers {
   const method = createMethodExecutor(options.getTodu);
 
@@ -130,7 +139,135 @@ export function createProjectTaskLabelNoteNamespaceHandlers(
         return todu.note.delete(id);
       }),
     },
+    recurring: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateRecurringInput>(request, "input");
+        return todu.recurring.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<RecurringFilter>(request, "filter");
+        return todu.recurring.list(filter);
+      }),
+      get: method(async (request, todu) => {
+        const id = createRecurringId(getRequiredStringParam(request, "id"));
+        return todu.recurring.get(id);
+      }),
+      update: method(async (request, todu) => {
+        const id = createRecurringId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateRecurringInput>(request, "input");
+        return todu.recurring.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createRecurringId(getRequiredStringParam(request, "id"));
+        return todu.recurring.delete(id);
+      }),
+      pause: method(async (request, todu) => {
+        const id = createRecurringId(getRequiredStringParam(request, "id"));
+        return todu.recurring.pause(id);
+      }),
+      resume: method(async (request, todu) => {
+        const id = createRecurringId(getRequiredStringParam(request, "id"));
+        return todu.recurring.resume(id);
+      }),
+      upcoming: method(async (request, todu) => {
+        const rawOptions = getOptionalObjectParam<{ templateId?: string; days?: number }>(
+          request,
+          "options",
+        );
+
+        const options = rawOptions
+          ? {
+              ...rawOptions,
+              templateId:
+                rawOptions.templateId !== undefined
+                  ? createRecurringId(rawOptions.templateId)
+                  : undefined,
+            }
+          : undefined;
+
+        return todu.recurring.upcoming(options);
+      }),
+      generate: method(async (request, todu) => {
+        const templateId = createRecurringId(getRequiredStringParam(request, "templateId"));
+        const date = getRequiredStringParam(request, "date");
+        return todu.recurring.generate(templateId, date);
+      }),
+      process: method(async (_request, todu) => {
+        return todu.recurring.process();
+      }),
+    },
+    habit: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateHabitInput>(request, "input");
+        return todu.habit.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<HabitFilter>(request, "filter");
+        return todu.habit.list(filter);
+      }),
+      get: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.get(id);
+      }),
+      update: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateHabitInput>(request, "input");
+        return todu.habit.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.delete(id);
+      }),
+      pause: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.pause(id);
+      }),
+      resume: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.resume(id);
+      }),
+      check: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.check(id);
+      }),
+      uncheck: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.uncheck(id);
+      }),
+      streak: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        return todu.habit.streak(id);
+      }),
+      history: method(async (request, todu) => {
+        const id = createHabitId(getRequiredStringParam(request, "id"));
+        const days = getOptionalNumberParam(request, "days");
+        return todu.habit.history(id, days);
+      }),
+    },
+    sync: {
+      start: method(async (_request, todu) => {
+        await todu.sync.start();
+        return ok(undefined);
+      }),
+      stop: method(async (_request, todu) => {
+        await todu.sync.stop();
+        return ok(undefined);
+      }),
+      status: method(async (_request, todu) => {
+        return ok(todu.sync.status());
+      }),
+      catalogId: method(async (_request, todu) => {
+        return ok(todu.sync.getCatalogId());
+      }),
+    },
   };
+}
+
+// Kept for compatibility with previously merged code/tests.
+export function createProjectTaskLabelNoteNamespaceHandlers(
+  options: CreateCoreNamespaceHandlersOptions,
+): DaemonRpcNamespaceHandlers {
+  return createCoreNamespaceHandlers(options);
 }
 
 function createMethodExecutor(
@@ -175,6 +312,23 @@ function getRequiredStringParam(request: ProtocolRequestFrame, field: string): s
   }
 
   return value;
+}
+
+function getOptionalNumberParam(request: ProtocolRequestFrame, field: string): number | undefined {
+  const value = request.params[field];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    throw createProtocolError(
+      "BAD_REQUEST",
+      `${request.method} requires params.${field} as a positive number`,
+      { field },
+    );
+  }
+
+  return Math.floor(value);
 }
 
 function getRequiredObjectParam<T extends object>(request: ProtocolRequestFrame, field: string): T {

--- a/packages/daemon/src/protocol-conformance.test.ts
+++ b/packages/daemon/src/protocol-conformance.test.ts
@@ -167,23 +167,98 @@ describe("daemon protocol conformance suite", () => {
     });
   });
 
-  it("returns UNSUPPORTED_CAPABILITY for namespaces not yet adapted", async () => {
+  it("routes recurring/habit/sync methods through default runtime adapters", async () => {
+    await withRunningRuntime({}, async (runtime) => {
+      const projectResponse = await sendRequest(runtime.config().socketPath, {
+        id: "project-for-recurring",
+        method: "project.create",
+        params: {
+          input: {
+            name: "Conformance Recurring",
+          },
+        },
+      });
+
+      const projectId = (projectResponse.result as { id: string }).id;
+
+      const recurringResponse = await sendRequest(runtime.config().socketPath, {
+        id: "recurring-create-conformance",
+        method: "recurring.create",
+        params: {
+          input: {
+            title: "Daily check",
+            schedule: "FREQ=DAILY",
+            timezone: "America/Chicago",
+            startDate: "2026-02-01",
+            projectId,
+          },
+        },
+      });
+
+      expect(recurringResponse.id).toBe("recurring-create-conformance");
+      expect(recurringResponse.result).toMatchObject({
+        title: "Daily check",
+        projectId,
+      });
+
+      const habitResponse = await sendRequest(runtime.config().socketPath, {
+        id: "habit-create-conformance",
+        method: "habit.create",
+        params: {
+          input: {
+            title: "Stretch",
+            schedule: "FREQ=DAILY",
+            timezone: "America/Chicago",
+            startDate: "2026-02-01",
+          },
+        },
+      });
+
+      expect(habitResponse.id).toBe("habit-create-conformance");
+      expect(habitResponse.result).toMatchObject({
+        title: "Stretch",
+      });
+
+      const syncStatus = await sendRequest(runtime.config().socketPath, {
+        id: "sync-status-conformance",
+        method: "sync.status",
+        params: {},
+      });
+
+      expect(syncStatus.id).toBe("sync-status-conformance");
+      expect(syncStatus.result).toMatchObject({
+        local: {
+          mode: "standalone",
+        },
+      });
+
+      const syncCatalog = await sendRequest(runtime.config().socketPath, {
+        id: "sync-catalog-conformance",
+        method: "sync.catalogId",
+        params: {},
+      });
+
+      expect(typeof syncCatalog.result).toBe("string");
+      expect((syncCatalog.result as string).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("returns UNSUPPORTED_CAPABILITY for reserved worker namespace methods", async () => {
     await withRunningRuntime({}, async (runtime) => {
       const response = await sendRequest(runtime.config().socketPath, {
-        id: "recurring-list-unsupported",
-        method: "recurring.list",
+        id: "worker-status-unsupported",
+        method: "worker.status",
         params: {},
       });
 
       expect(response).toEqual({
-        id: "recurring-list-unsupported",
+        id: "worker-status-unsupported",
         error: {
           code: "UNSUPPORTED_CAPABILITY",
-          message: "Method is not implemented: recurring.list",
+          message: "Namespace is reserved but not implemented: worker",
           details: {
-            namespace: "recurring",
-            method: "recurring.list",
-            capability: "recurring.list",
+            namespace: "worker",
+            method: "worker.status",
           },
         },
       });

--- a/packages/daemon/src/rpc.test.ts
+++ b/packages/daemon/src/rpc.test.ts
@@ -244,6 +244,33 @@ describe("createDaemonRpcRouter", () => {
     });
   });
 
+  it("returns UNSUPPORTED_CAPABILITY for reserved worker namespace methods", async () => {
+    const router = createDaemonRpcRouter();
+
+    const response = await router.handleRequest(
+      {
+        id: "worker-status-1",
+        method: "worker.status",
+        params: {},
+      },
+      context,
+    );
+
+    expect("error" in response).toBe(true);
+    if (!("error" in response)) {
+      throw new Error("Expected unsupported capability response");
+    }
+
+    expect(response.error).toEqual({
+      code: "UNSUPPORTED_CAPABILITY",
+      message: "Namespace is reserved but not implemented: worker",
+      details: {
+        namespace: "worker",
+        method: "worker.status",
+      },
+    });
+  });
+
   it("maps invalid JSON payloads to BAD_REQUEST through handlePayload", async () => {
     const router = createDaemonRpcRouter();
 

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -14,13 +14,13 @@ import {
 export const DAEMON_PROTOCOL_VERSION = "1";
 export const DEFAULT_DAEMON_VERSION = "dev";
 export const DEFAULT_DAEMON_REQUEST_TIMEOUT_MS = 30_000;
-export const DAEMON_CAPABILITY_METHODS = [
+export const DAEMON_BASE_METHODS = [
   "daemon.hello",
   "daemon.ping",
   "daemon.status",
   "events.subscribe",
   "events.unsubscribe",
-];
+] as const;
 export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] as const;
 
 export const CORE_DAEMON_NAMESPACE_METHODS = {
@@ -56,10 +56,22 @@ export const CORE_DAEMON_NAMESPACE_METHODS = {
   sync: ["start", "stop", "status", "catalogId"],
 } as const;
 
+export const RESERVED_DAEMON_NAMESPACES = ["worker"] as const;
+
+export const DAEMON_CAPABILITY_METHODS = [
+  ...DAEMON_BASE_METHODS,
+  ...listCoreNamespaceMethods(),
+] as const;
+
 export type DaemonCapabilityEvent = (typeof DAEMON_CAPABILITY_EVENTS)[number];
 export type CoreDaemonNamespace = keyof typeof CORE_DAEMON_NAMESPACE_METHODS;
+export type ReservedDaemonNamespace = (typeof RESERVED_DAEMON_NAMESPACES)[number];
 
-export type DaemonRpcNamespace = "daemon" | "events" | CoreDaemonNamespace;
+export type DaemonRpcNamespace =
+  | "daemon"
+  | "events"
+  | CoreDaemonNamespace
+  | ReservedDaemonNamespace;
 export type DaemonRpcNamespaceMethodTable = Record<string, DaemonRpcMethodHandler>;
 export type DaemonRpcNamespaceHandlers = Partial<
   Record<DaemonRpcNamespace, DaemonRpcNamespaceMethodTable>
@@ -182,6 +194,21 @@ export function createDaemonRpcRouter(options: CreateDaemonRpcRouterOptions = {}
     const handler = resolveMethodHandler(request.method, namespaceHandlers, methodHandlers);
 
     if (!handler) {
+      const parsedMethod = parseMethod(request.method);
+      if (parsedMethod && isReservedDaemonNamespace(parsedMethod.namespace)) {
+        return createProtocolErrorFrame(
+          request.id,
+          createProtocolError(
+            "UNSUPPORTED_CAPABILITY",
+            `Namespace is reserved but not implemented: ${parsedMethod.namespace}`,
+            {
+              namespace: parsedMethod.namespace,
+              method: request.method,
+            },
+          ),
+        );
+      }
+
       return createProtocolErrorFrame(
         request.id,
         createProtocolError("METHOD_NOT_FOUND", `Unknown method: ${request.method}`, {
@@ -367,6 +394,19 @@ export function createDaemonRpcRouter(options: CreateDaemonRpcRouterOptions = {}
   };
 }
 
+function listCoreNamespaceMethods(): string[] {
+  const methods: string[] = [];
+
+  const namespaces = Object.keys(CORE_DAEMON_NAMESPACE_METHODS).sort() as CoreDaemonNamespace[];
+  for (const namespace of namespaces) {
+    for (const methodName of CORE_DAEMON_NAMESPACE_METHODS[namespace]) {
+      methods.push(`${namespace}.${methodName}`);
+    }
+  }
+
+  return methods;
+}
+
 function createDefaultNamespaceHandlers(): DaemonRpcNamespaceHandlers {
   return {
     daemon: {
@@ -489,7 +529,15 @@ function isDaemonRpcNamespace(value: string): value is DaemonRpcNamespace {
     return true;
   }
 
+  if (isReservedDaemonNamespace(value)) {
+    return true;
+  }
+
   return value in CORE_DAEMON_NAMESPACE_METHODS;
+}
+
+function isReservedDaemonNamespace(value: string): value is ReservedDaemonNamespace {
+  return (RESERVED_DAEMON_NAMESPACES as readonly string[]).includes(value);
 }
 
 function handleDaemonHello(

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -79,6 +79,10 @@ describe("createDaemonRuntime", () => {
       },
     });
 
+    expect(DAEMON_CAPABILITY_METHODS).toEqual(
+      expect.arrayContaining(["recurring.process", "habit.history", "sync.catalogId"]),
+    );
+
     await runtime.stop();
   });
 
@@ -505,7 +509,343 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
-  it("maps domain and request validation errors for project/task/label/note methods", async () => {
+  it("routes recurring namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const createProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-recurring-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Recurring Project",
+        },
+      },
+    });
+
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
+    const createRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-create-1",
+      method: "recurring.create",
+      params: {
+        input: {
+          title: "Daily standup",
+          schedule: "FREQ=DAILY",
+          timezone: "America/Chicago",
+          startDate: "2026-02-01",
+          projectId,
+        },
+      },
+    });
+
+    const recurringId = (createRecurringResponse.result as { id: string }).id;
+
+    const listRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-list-1",
+      method: "recurring.list",
+      params: {
+        filter: {
+          projectId,
+        },
+      },
+    });
+
+    expect(listRecurringResponse.result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: recurringId, title: "Daily standup" }),
+      ]),
+    );
+
+    const getRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-get-1",
+      method: "recurring.get",
+      params: {
+        id: recurringId,
+      },
+    });
+
+    expect(getRecurringResponse.result).toEqual(
+      expect.objectContaining({ id: recurringId, projectId }),
+    );
+
+    const updateRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-update-1",
+      method: "recurring.update",
+      params: {
+        id: recurringId,
+        input: {
+          title: "Daily standup updated",
+          priority: "high",
+        },
+      },
+    });
+
+    expect(updateRecurringResponse.result).toEqual(
+      expect.objectContaining({
+        id: recurringId,
+        title: "Daily standup updated",
+        priority: "high",
+      }),
+    );
+
+    const pauseRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-pause-1",
+      method: "recurring.pause",
+      params: {
+        id: recurringId,
+      },
+    });
+
+    expect(pauseRecurringResponse.result).toEqual(
+      expect.objectContaining({ id: recurringId, paused: true }),
+    );
+
+    const resumeRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-resume-1",
+      method: "recurring.resume",
+      params: {
+        id: recurringId,
+      },
+    });
+
+    expect(resumeRecurringResponse.result).toEqual(
+      expect.objectContaining({ id: recurringId, paused: false }),
+    );
+
+    const upcomingRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-upcoming-1",
+      method: "recurring.upcoming",
+      params: {
+        options: {
+          templateId: recurringId,
+          days: 14,
+        },
+      },
+    });
+
+    expect(Array.isArray(upcomingRecurringResponse.result)).toBe(true);
+
+    const generateRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-generate-1",
+      method: "recurring.generate",
+      params: {
+        templateId: recurringId,
+        date: "2026-02-15",
+      },
+    });
+
+    expect(generateRecurringResponse.result).toEqual(
+      expect.objectContaining({ projectId, templateId: recurringId }),
+    );
+
+    const processRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-process-1",
+      method: "recurring.process",
+      params: {},
+    });
+
+    expect(Array.isArray(processRecurringResponse.result)).toBe(true);
+
+    const deleteRecurringResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-delete-1",
+      method: "recurring.delete",
+      params: {
+        id: recurringId,
+      },
+    });
+
+    expect(deleteRecurringResponse).toEqual({
+      id: "recurring-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes habit and sync namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const createHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-create-1",
+      method: "habit.create",
+      params: {
+        input: {
+          title: "Meditate",
+          schedule: "FREQ=DAILY",
+          timezone: "America/Chicago",
+          startDate: "2026-02-01",
+        },
+      },
+    });
+
+    const habitId = (createHabitResponse.result as { id: string }).id;
+
+    const listHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-list-1",
+      method: "habit.list",
+      params: {},
+    });
+
+    expect(listHabitResponse.result).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: habitId, title: "Meditate" })]),
+    );
+
+    const getHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-get-1",
+      method: "habit.get",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(getHabitResponse.result).toEqual(expect.objectContaining({ id: habitId }));
+
+    const updateHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-update-1",
+      method: "habit.update",
+      params: {
+        id: habitId,
+        input: {
+          title: "Meditate daily",
+        },
+      },
+    });
+
+    expect(updateHabitResponse.result).toEqual(
+      expect.objectContaining({ id: habitId, title: "Meditate daily" }),
+    );
+
+    const checkHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-check-1",
+      method: "habit.check",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(checkHabitResponse.result).toEqual(expect.objectContaining({ completed: true }));
+
+    const streakHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-streak-1",
+      method: "habit.streak",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(streakHabitResponse.result).toEqual(expect.objectContaining({ totalCheckins: 1 }));
+
+    const historyHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-history-1",
+      method: "habit.history",
+      params: {
+        id: habitId,
+        days: 7,
+      },
+    });
+
+    expect(Array.isArray(historyHabitResponse.result)).toBe(true);
+
+    const uncheckHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-uncheck-1",
+      method: "habit.uncheck",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(uncheckHabitResponse).toEqual({
+      id: "habit-uncheck-1",
+      result: null,
+    });
+
+    const pauseHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-pause-1",
+      method: "habit.pause",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(pauseHabitResponse.result).toEqual(
+      expect.objectContaining({ id: habitId, paused: true }),
+    );
+
+    const resumeHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-resume-1",
+      method: "habit.resume",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(resumeHabitResponse.result).toEqual(
+      expect.objectContaining({ id: habitId, paused: false }),
+    );
+
+    const syncStatusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-status-1",
+      method: "sync.status",
+      params: {},
+    });
+
+    expect(syncStatusResponse.result).toEqual(
+      expect.objectContaining({
+        local: expect.objectContaining({ mode: "standalone" }),
+      }),
+    );
+
+    const syncCatalogIdResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-catalog-id-1",
+      method: "sync.catalogId",
+      params: {},
+    });
+
+    expect(syncCatalogIdResponse.result).toBe(runtime.status().catalogId);
+
+    const syncStartResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-start-1",
+      method: "sync.start",
+      params: {},
+    });
+
+    expect(syncStartResponse).toEqual({
+      id: "sync-start-1",
+      result: null,
+    });
+
+    const syncStopResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-stop-1",
+      method: "sync.stop",
+      params: {},
+    });
+
+    expect(syncStopResponse).toEqual({
+      id: "sync-stop-1",
+      result: null,
+    });
+
+    const deleteHabitResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-delete-1",
+      method: "habit.delete",
+      params: {
+        id: habitId,
+      },
+    });
+
+    expect(deleteHabitResponse).toEqual({
+      id: "habit-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("maps domain and request validation errors for project/task/label/note/recurring/habit/sync methods", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
     await runtime.start();
@@ -578,6 +918,91 @@ describe("createDaemonRuntime", () => {
       details: {
         entity: "project",
         id: "proj-missing",
+      },
+    });
+
+    const recurringBadRequestResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-get-bad-request",
+      method: "recurring.get",
+      params: {
+        id: 99,
+      },
+    });
+
+    expect(recurringBadRequestResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "recurring.get requires params.id as a non-empty string",
+      details: {
+        field: "id",
+      },
+    });
+
+    const recurringNotFoundResponse = await sendRequest(runtime.config().socketPath, {
+      id: "recurring-get-not-found",
+      method: "recurring.get",
+      params: {
+        id: "rec-missing",
+      },
+    });
+
+    expect(recurringNotFoundResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "recurring template not found: rec-missing",
+      details: {
+        entity: "recurring template",
+        id: "rec-missing",
+      },
+    });
+
+    const habitValidationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-create-validation",
+      method: "habit.create",
+      params: {
+        input: {
+          title: "Bad Habit",
+          schedule: "FREQ=HOURLY",
+          timezone: "UTC",
+          startDate: "2026-02-01",
+        },
+      },
+    });
+
+    expect(habitValidationResponse.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      details: {
+        field: "schedule",
+      },
+    });
+
+    const habitHistoryBadRequestResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-history-bad-request",
+      method: "habit.history",
+      params: {
+        id: "hab-missing",
+        days: "7",
+      },
+    });
+
+    expect(habitHistoryBadRequestResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "habit.history requires params.days as a positive number",
+      details: {
+        field: "days",
+      },
+    });
+
+    const reservedNamespaceResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-unsupported",
+      method: "worker.status",
+      params: {},
+    });
+
+    expect(reservedNamespaceResponse.error).toEqual({
+      code: "UNSUPPORTED_CAPABILITY",
+      message: "Namespace is reserved but not implemented: worker",
+      details: {
+        namespace: "worker",
+        method: "worker.status",
       },
     });
 

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,9 +1,6 @@
 import { type RemoteSyncConfig, resolveStoragePath } from "@todu/core";
 import { createTodu, type Todu } from "@todu/engine";
-import {
-  createProjectTaskLabelNoteNamespaceHandlers,
-  mergeNamespaceHandlerSets,
-} from "./core-rpc-adapters.js";
+import { createCoreNamespaceHandlers, mergeNamespaceHandlerSets } from "./core-rpc-adapters.js";
 import {
   createDaemonRpcRouter,
   type DaemonRpcMethodHandler,
@@ -94,7 +91,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     role: resolvedConfig.role,
   };
 
-  const defaultNamespaceHandlers = createProjectTaskLabelNoteNamespaceHandlers({
+  const defaultNamespaceHandlers = createCoreNamespaceHandlers({
     getTodu: () => todu,
   });
 


### PR DESCRIPTION
## Summary
- extend daemon core adapters to include `recurring.*`, `habit.*`, and `sync.*` methods
- wire runtime defaults to full core namespace adapter set
- update handshake capability reporting to include full implemented core method surface
- reserve `worker.*` namespace with explicit `UNSUPPORTED_CAPABILITY` responses
- expand rpc/runtime/conformance coverage for new namespace methods and reserved namespace behavior
- update phase 2 progress notes for task #1936

## Testing
- npm run check
- npm run test -- packages/daemon/src/*.test.ts
- make pre-pr

Task: #1936