### PR TITLE
feat(cli): add daemon start/stop/restart wrappers

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -6,9 +6,28 @@ The legacy `toduai serve` path has been removed.
 
 For always-on daemon startup (recommended), use OS service manager setup from [`daemon-service-operations.md`](daemon-service-operations.md).
 
-## Start the local daemon
+## Start/stop/restart the local daemon
 
-Use the CLI lifecycle command:
+Recommended for persistent operation:
+
+- Use OS service manager setup in [`daemon-service-operations.md`](daemon-service-operations.md)
+- Then control lifecycle through your service manager (`systemctl --user` / `launchctl`)
+
+CLI wrappers are available:
+
+```bash
+toduai daemon start
+toduai daemon stop
+toduai daemon restart
+```
+
+Wrapper behavior:
+
+- **Delegates** to system service managers when configured (`systemd --user` on Linux, `launchd` on macOS).
+- Falls back to **direct managed mode** when no service registration exists.
+- Direct mode tracks a managed PID at `<data_dir>/daemon.pid` and refuses to stop unmanaged daemon processes.
+
+Foreground daemon run (manual/interactive) is still available:
 
 ```bash
 toduai daemon run

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -16,6 +16,33 @@ toduai daemon status
 toduai --format json daemon status
 ```
 
+## CLI lifecycle wrappers (`daemon start|stop|restart`)
+
+`toduai daemon start`, `toduai daemon stop`, and `toduai daemon restart` follow this deterministic order:
+
+1. If `TODUAI_DAEMON_LIFECYCLE_MODE` is set to one of
+   - `systemd-user`
+   - `launchd`
+   - `direct`
+   it uses that mode.
+2. Otherwise (`auto`, default), CLI prefers service-manager delegation when registration exists:
+   - Linux: `~/.config/systemd/user/toduai-daemon.service`
+   - macOS: `~/Library/LaunchAgents/com.todu.daemon.plist`
+3. If no service registration is detected, CLI uses direct managed fallback mode.
+
+Direct managed fallback mode:
+
+- starts daemon as a detached local process
+- writes managed PID to `<data_dir>/daemon.pid`
+- stops only managed direct-mode daemon processes
+- refuses to stop unmanaged daemon processes (safe fallback behavior)
+
+To force a specific behavior (for scripting/testing):
+
+```bash
+export TODUAI_DAEMON_LIFECYCLE_MODE=direct # or systemd-user / launchd / auto
+```
+
 ---
 
 ## Linux (`systemd --user`)

--- a/docs/plans/phase-3-cli-thin-client.md
+++ b/docs/plans/phase-3-cli-thin-client.md
@@ -178,3 +178,24 @@ Every task must include a documentation step in the same PR (or explicitly justi
 - Added doc discoverability links from:
   - `docs/cli-daemon-usage.md`
   - `docs/CONTRIBUTING.md`
+
+### 2026-02-23 — Task #1989
+
+- Added daemon lifecycle wrappers to CLI command surface in `packages/cli/src/commands/daemon.ts`:
+  - `daemon start`
+  - `daemon stop`
+  - `daemon restart`
+- Implemented deterministic lifecycle mode selection:
+  - explicit override via `TODUAI_DAEMON_LIFECYCLE_MODE`
+  - auto preference for configured service-manager delegation (systemd user unit / launchd agent)
+  - safe direct managed fallback when no service registration exists
+- Added direct fallback process management behavior:
+  - managed daemon PID file at `<data_dir>/daemon.pid`
+  - refusal to stop unmanaged daemon processes in direct mode
+- Expanded CLI integration coverage in `packages/cli/src/commands/daemon.test.ts`:
+  - direct-mode start/stop/restart success flow
+  - unmanaged-stop failure path with nonzero exit
+  - JSON failure output for invalid lifecycle mode override
+- Updated operator docs for wrapper behavior and delegation/fallback rules:
+  - `docs/daemon-service-operations.md`
+  - `docs/cli-daemon-usage.md`

--- a/packages/cli/src/commands/daemon.test.ts
+++ b/packages/cli/src/commands/daemon.test.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execSync, spawn } from "node:child_process";
+import { type ChildProcess, execSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -10,6 +10,7 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
   const cliPath = path.resolve(rootDir, "packages/cli/dist/index.js");
 
   let tmpDir: string;
+  let homeDir: string;
   let daemon: DaemonHandle | null = null;
   let daemonRunProcess: ChildProcess | null = null;
 
@@ -30,47 +31,72 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     daemonRunProcess = null;
 
     if (tmpDir) {
+      stopManagedDaemon(tmpDir);
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    if (homeDir) {
+      fs.rmSync(homeDir, { recursive: true, force: true });
     }
   });
 
-  function run(args: string, expectFail = false): string {
-    try {
-      return execSync(`node ${cliPath} ${args}`, {
-        cwd: rootDir,
-        env: { ...process.env, TODUAI_DATA_DIR: tmpDir, TODUAI_NO_SYNC: "1" },
-        encoding: "utf-8",
-        timeout: 15000,
-      }).trim();
-    } catch (e: unknown) {
-      if (expectFail) {
-        const err = e as { stderr?: string; stdout?: string };
-        return (err.stderr || err.stdout || "").trim();
-      }
-      throw e;
-    }
+  function runCli(
+    args: string[],
+    options: { env?: Record<string, string>; timeoutMs?: number } = {},
+  ): {
+    status: number;
+    stdout: string;
+    stderr: string;
+  } {
+    const completed = spawnSync(process.execPath, [cliPath, ...args], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        TODUAI_DATA_DIR: tmpDir,
+        TODUAI_NO_SYNC: "1",
+        TODUAI_DAEMON_LIFECYCLE_MODE: "direct",
+        HOME: homeDir,
+        ...(options.env ?? {}),
+      },
+      encoding: "utf8",
+      timeout: options.timeoutMs ?? 15000,
+    });
+
+    return {
+      status: completed.status ?? -1,
+      stdout: completed.stdout.trim(),
+      stderr: completed.stderr.trim(),
+    };
   }
 
   it("daemon status reports not running when daemon is unavailable", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
 
-    const textOutput = run("daemon status");
-    expect(textOutput).toContain("Daemon: not running");
+    const textResult = runCli(["daemon", "status"]);
+    expect(textResult.status).toBe(0);
+    expect(textResult.stdout).toContain("Daemon: not running");
 
-    const jsonOutput = JSON.parse(run("--format json daemon status"));
+    const jsonResult = runCli(["--format", "json", "daemon", "status"]);
+    expect(jsonResult.status).toBe(0);
+    const jsonOutput = JSON.parse(jsonResult.stdout);
     expect(jsonOutput.running).toBe(false);
     expect(jsonOutput.reason).toContain("Daemon unavailable at socket");
   });
 
   it("daemon status reports running daemon details", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
     daemon = await startDaemonForTests(rootDir, tmpDir);
 
-    const textOutput = run("daemon status");
-    expect(textOutput).toContain("Daemon: running");
-    expect(textOutput).toContain("State:  running");
+    const textResult = runCli(["daemon", "status"]);
+    expect(textResult.status).toBe(0);
+    expect(textResult.stdout).toContain("Daemon: running");
+    expect(textResult.stdout).toContain("State:  running");
 
-    const jsonOutput = JSON.parse(run("--format json daemon status"));
+    const jsonResult = runCli(["--format", "json", "daemon", "status"]);
+    expect(jsonResult.status).toBe(0);
+    const jsonOutput = JSON.parse(jsonResult.stdout);
     expect(jsonOutput.running).toBe(true);
     expect(jsonOutput.status.state).toBe("running");
     expect(jsonOutput.status.transport.path).toContain("daemon.sock");
@@ -78,17 +104,25 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
 
   it("daemon run starts foreground daemon process", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-run-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
     const socketPath = path.join(tmpDir, "daemon.sock");
 
-    daemonRunProcess = spawn("node", [cliPath, "daemon", "run"], {
+    daemonRunProcess = spawn(process.execPath, [cliPath, "daemon", "run"], {
       cwd: rootDir,
-      env: { ...process.env, TODUAI_DATA_DIR: tmpDir, TODUAI_NO_SYNC: "1" },
+      env: {
+        ...process.env,
+        TODUAI_DATA_DIR: tmpDir,
+        TODUAI_NO_SYNC: "1",
+        HOME: homeDir,
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
 
     await waitForSocket(socketPath, daemonRunProcess, 7000);
 
-    const jsonOutput = JSON.parse(run("--format json daemon status"));
+    const jsonResult = runCli(["--format", "json", "daemon", "status"]);
+    expect(jsonResult.status).toBe(0);
+    const jsonOutput = JSON.parse(jsonResult.stdout);
     expect(jsonOutput.running).toBe(true);
     expect(jsonOutput.status.state).toBe("running");
 
@@ -96,17 +130,121 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     await waitForProcessExit(daemonRunProcess, 5000);
     daemonRunProcess = null;
 
-    const afterStop = JSON.parse(run("--format json daemon status"));
+    const afterStopResult = runCli(["--format", "json", "daemon", "status"]);
+    expect(afterStopResult.status).toBe(0);
+    const afterStop = JSON.parse(afterStopResult.stdout);
     expect(afterStop.running).toBe(false);
+  });
+
+  it("daemon start/stop/restart commands manage daemon in direct mode", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-lifecycle-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+
+    const start = runCli(["daemon", "start"]);
+    expect(start.status).toBe(0);
+    expect(start.stdout).toContain("Daemon start: started managed daemon process");
+
+    const statusAfterStart = runCli(["--format", "json", "daemon", "status"]);
+    expect(statusAfterStart.status).toBe(0);
+    expect(JSON.parse(statusAfterStart.stdout).running).toBe(true);
+
+    const restart = runCli(["daemon", "restart"]);
+    expect(restart.status).toBe(0);
+    expect(restart.stdout).toContain("Daemon restart: started managed daemon process");
+
+    const statusAfterRestart = runCli(["--format", "json", "daemon", "status"]);
+    expect(statusAfterRestart.status).toBe(0);
+    expect(JSON.parse(statusAfterRestart.stdout).running).toBe(true);
+
+    const stop = runCli(["daemon", "stop"]);
+    expect(stop.status).toBe(0);
+    expect(stop.stdout).toContain("Daemon stop: stopped managed daemon process");
+
+    const statusAfterStop = runCli(["--format", "json", "daemon", "status"]);
+    expect(statusAfterStop.status).toBe(0);
+    expect(JSON.parse(statusAfterStop.stdout).running).toBe(false);
+  });
+
+  it("daemon stop fails when daemon is unmanaged in direct mode", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-unmanaged-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+    daemon = await startDaemonForTests(rootDir, tmpDir);
+
+    const stop = runCli(["daemon", "stop"], {
+      env: {
+        TODUAI_DAEMON_LIFECYCLE_MODE: "direct",
+      },
+    });
+
+    expect(stop.status).toBe(1);
+    expect(stop.stderr).toContain("not managed by direct lifecycle wrapper");
+  });
+
+  it("daemon start returns json error output for invalid lifecycle mode", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-invalid-mode-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+
+    const result = runCli(["--format", "json", "daemon", "start"], {
+      env: {
+        TODUAI_DAEMON_LIFECYCLE_MODE: "invalid-mode",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    const json = JSON.parse(result.stdout);
+    expect(json.ok).toBe(false);
+    expect(json.message).toContain("Invalid TODUAI_DAEMON_LIFECYCLE_MODE value");
   });
 
   it("serve command is removed", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
 
-    const output = run("serve", true);
-    expect(output).toContain("unknown command 'serve'");
+    const output = runCli(["serve"]);
+    expect(output.status).toBe(1);
+    expect(output.stderr).toContain("unknown command 'serve'");
   });
 });
+
+function stopManagedDaemon(storagePath: string): void {
+  const pidPath = path.join(storagePath, "daemon.pid");
+
+  if (!fs.existsSync(pidPath)) {
+    return;
+  }
+
+  const rawPid = fs.readFileSync(pidPath, "utf8").trim();
+  const pid = Number.parseInt(rawPid, 10);
+  if (!Number.isInteger(pid) || pid < 1) {
+    fs.rmSync(pidPath, { force: true });
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    fs.rmSync(pidPath, { force: true });
+    return;
+  }
+
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      fs.rmSync(pidPath, { force: true });
+      return;
+    }
+  }
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // best effort cleanup
+  }
+
+  fs.rmSync(pidPath, { force: true });
+}
 
 async function waitForSocket(socketPath: string, processHandle: ChildProcess, timeoutMs: number) {
   const deadline = Date.now() + timeoutMs;

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,10 +1,15 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { resolveRemoteSyncConfig } from "@todu/core";
 import type { Command } from "commander";
 import { getConfigPath, loadConfig, resolveDataDir } from "../config.js";
-import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
+import {
+  type CliDaemonInvoker,
+  formatDaemonCommandError,
+  resolveDaemonSocketPath,
+} from "../daemon-command-client.js";
 import { formatJSON } from "../format.js";
 
 interface DaemonStatusResult {
@@ -28,6 +33,37 @@ interface DaemonStatusOutput {
   reason?: string;
 }
 
+type DaemonLifecycleAction = "start" | "stop" | "restart";
+type DaemonLifecycleMode = "direct" | "systemd-user" | "launchd";
+
+interface DaemonLifecycleResult {
+  action: DaemonLifecycleAction;
+  ok: boolean;
+  mode: DaemonLifecycleMode;
+  delegated: boolean;
+  message: string;
+  running?: boolean;
+  pid?: number;
+  details?: string;
+}
+
+interface DaemonCommandContext {
+  storagePath: string;
+  socketPath: string;
+  daemonPidPath: string;
+  daemonEntrypoint: string;
+  remoteSyncServer: string | null;
+}
+
+const DIRECT_PID_FILENAME = "daemon.pid";
+const SYSTEMD_SERVICE_NAME = "toduai-daemon";
+const SYSTEMD_SERVICE_PATH = ".config/systemd/user/toduai-daemon.service";
+const LAUNCHD_LABEL = "com.todu.daemon";
+const LAUNCHD_PLIST_PATH = "Library/LaunchAgents/com.todu.daemon.plist";
+const LIFECYCLE_MODE_ENV = "TODUAI_DAEMON_LIFECYCLE_MODE";
+const STARTUP_TIMEOUT_MS = 5_000;
+const STOP_TIMEOUT_MS = 5_000;
+
 export function registerDaemonCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const daemon = program.command("daemon").description("Manage local daemon lifecycle");
 
@@ -35,33 +71,18 @@ export function registerDaemonCommands(program: Command, invokeDaemon: CliDaemon
     .command("run")
     .description("Run local daemon in foreground mode")
     .action(async () => {
-      const configOpt = program.opts().config as string | undefined;
-      const configPath = getConfigPath(configOpt);
-      const fileConfig = loadConfig(configPath);
-      const storagePath = resolveDataDir(configPath, fileConfig);
-      const remoteSync = resolveRemoteSyncConfig(fileConfig);
+      const context = resolveDaemonCommandContext(program);
 
-      const daemonEntrypoint = resolveDaemonEntrypoint();
-      if (!fs.existsSync(daemonEntrypoint)) {
-        console.error(`Error: daemon entrypoint not found at ${daemonEntrypoint}`);
+      if (!fs.existsSync(context.daemonEntrypoint)) {
+        console.error(`Error: daemon entrypoint not found at ${context.daemonEntrypoint}`);
         process.exitCode = 1;
         return;
       }
 
-      const childEnv: NodeJS.ProcessEnv = {
-        ...process.env,
-        TODUAI_DATA_DIR: storagePath,
-      };
-
-      if (remoteSync) {
-        childEnv.TODUAI_SYNC_SERVER = remoteSync.server;
-        childEnv.TODUAI_SYNC_ENABLED = "1";
-      }
-
-      const child = spawn(process.execPath, [daemonEntrypoint], {
+      const child = spawn(process.execPath, [context.daemonEntrypoint], {
         cwd: process.cwd(),
         stdio: "inherit",
-        env: childEnv,
+        env: createDaemonChildEnv(context),
       });
 
       const forwardSigInt = () => {
@@ -147,6 +168,661 @@ export function registerDaemonCommands(program: Command, invokeDaemon: CliDaemon
         console.log(`Catalog: ${result.value.catalog.id}`);
       }
     });
+
+  daemon
+    .command("start")
+    .description("Start daemon via configured service manager or direct fallback")
+    .action(async () => {
+      await handleLifecycleAction("start", program, invokeDaemon);
+    });
+
+  daemon
+    .command("stop")
+    .description("Stop daemon via configured service manager or direct fallback")
+    .action(async () => {
+      await handleLifecycleAction("stop", program, invokeDaemon);
+    });
+
+  daemon
+    .command("restart")
+    .description("Restart daemon via configured service manager or direct fallback")
+    .action(async () => {
+      await handleLifecycleAction("restart", program, invokeDaemon);
+    });
+}
+
+async function handleLifecycleAction(
+  action: DaemonLifecycleAction,
+  program: Command,
+  invokeDaemon: CliDaemonInvoker,
+): Promise<void> {
+  const context = resolveDaemonCommandContext(program);
+  const format = program.opts().format;
+
+  let mode: DaemonLifecycleMode;
+  try {
+    mode = resolveLifecycleMode();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const invalidModeResult: DaemonLifecycleResult = {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message,
+    };
+
+    renderLifecycleResult(invalidModeResult, format);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await executeLifecycleAction(action, mode, context, invokeDaemon);
+  renderLifecycleResult(result, format);
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+function renderLifecycleResult(result: DaemonLifecycleResult, format: string): void {
+  if (format === "json") {
+    console.log(formatJSON(result));
+    return;
+  }
+
+  if (!result.ok) {
+    console.error(`Error: ${result.message}`);
+    console.error(`Mode: ${result.mode}`);
+    if (result.details) {
+      console.error(`Details: ${result.details}`);
+    }
+    return;
+  }
+
+  console.log(`Daemon ${result.action}: ${result.message}`);
+  console.log(`Mode: ${result.mode}${result.delegated ? " (delegated)" : ""}`);
+  if (typeof result.running === "boolean") {
+    console.log(`Running: ${result.running ? "yes" : "no"}`);
+  }
+  if (typeof result.pid === "number") {
+    console.log(`PID: ${result.pid}`);
+  }
+  if (result.details) {
+    console.log(`Details: ${result.details}`);
+  }
+}
+
+async function executeLifecycleAction(
+  action: DaemonLifecycleAction,
+  mode: DaemonLifecycleMode,
+  context: DaemonCommandContext,
+  invokeDaemon: CliDaemonInvoker,
+): Promise<DaemonLifecycleResult> {
+  if (mode === "systemd-user") {
+    return executeSystemdLifecycleAction(action);
+  }
+
+  if (mode === "launchd") {
+    return executeLaunchdLifecycleAction(action);
+  }
+
+  if (action === "start") {
+    return executeDirectStart(action, context, invokeDaemon);
+  }
+
+  if (action === "stop") {
+    return executeDirectStop(action, context, invokeDaemon, {
+      allowUnmanagedRunning: false,
+    });
+  }
+
+  const stop = await executeDirectStop("restart", context, invokeDaemon, {
+    allowUnmanagedRunning: false,
+  });
+  if (!stop.ok) {
+    return stop;
+  }
+
+  return executeDirectStart("restart", context, invokeDaemon);
+}
+
+function executeSystemdLifecycleAction(action: DaemonLifecycleAction): DaemonLifecycleResult {
+  const servicePath = path.join(os.homedir(), SYSTEMD_SERVICE_PATH);
+
+  if (!fs.existsSync(servicePath)) {
+    return {
+      action,
+      ok: false,
+      mode: "systemd-user",
+      delegated: true,
+      message: `systemd user service is not configured at ${servicePath}`,
+      details: "Create the service using docs/daemon-service-operations.md or use direct mode.",
+    };
+  }
+
+  const command = runCommand("systemctl", ["--user", action, SYSTEMD_SERVICE_NAME]);
+  if (!command.ok) {
+    return {
+      action,
+      ok: false,
+      mode: "systemd-user",
+      delegated: true,
+      message: `systemctl --user ${action} ${SYSTEMD_SERVICE_NAME} failed`,
+      details: command.message,
+    };
+  }
+
+  return {
+    action,
+    ok: true,
+    mode: "systemd-user",
+    delegated: true,
+    message: `${action} delegated to systemd user service`,
+    details: servicePath,
+  };
+}
+
+function executeLaunchdLifecycleAction(action: DaemonLifecycleAction): DaemonLifecycleResult {
+  const plistPath = path.join(os.homedir(), LAUNCHD_PLIST_PATH);
+  const uid = process.getuid?.();
+
+  if (!Number.isInteger(uid)) {
+    return {
+      action,
+      ok: false,
+      mode: "launchd",
+      delegated: true,
+      message: "launchd delegation requires a macOS user session with a numeric uid",
+    };
+  }
+
+  if (!fs.existsSync(plistPath)) {
+    return {
+      action,
+      ok: false,
+      mode: "launchd",
+      delegated: true,
+      message: `launchd plist is not configured at ${plistPath}`,
+      details: "Create the LaunchAgent using docs/daemon-service-operations.md or use direct mode.",
+    };
+  }
+
+  const domainTarget = `gui/${uid}`;
+  const serviceTarget = `${domainTarget}/${LAUNCHD_LABEL}`;
+
+  if (action === "stop") {
+    const stop = runCommand("launchctl", ["bootout", domainTarget, plistPath]);
+    if (!stop.ok && !isLaunchdAlreadyStopped(stop.message)) {
+      return {
+        action,
+        ok: false,
+        mode: "launchd",
+        delegated: true,
+        message: `launchctl bootout failed for ${serviceTarget}`,
+        details: stop.message,
+      };
+    }
+
+    return {
+      action,
+      ok: true,
+      mode: "launchd",
+      delegated: true,
+      message: "stop delegated to launchd",
+      details: plistPath,
+    };
+  }
+
+  if (action === "restart") {
+    const start = runLaunchdStart(serviceTarget, domainTarget, plistPath);
+    if (!start.ok) {
+      return {
+        action,
+        ok: false,
+        mode: "launchd",
+        delegated: true,
+        message: `launchctl restart failed for ${serviceTarget}`,
+        details: start.message,
+      };
+    }
+
+    return {
+      action,
+      ok: true,
+      mode: "launchd",
+      delegated: true,
+      message: "restart delegated to launchd",
+      details: plistPath,
+    };
+  }
+
+  const start = runLaunchdStart(serviceTarget, domainTarget, plistPath);
+  if (!start.ok) {
+    return {
+      action,
+      ok: false,
+      mode: "launchd",
+      delegated: true,
+      message: `launchctl start failed for ${serviceTarget}`,
+      details: start.message,
+    };
+  }
+
+  return {
+    action,
+    ok: true,
+    mode: "launchd",
+    delegated: true,
+    message: "start delegated to launchd",
+    details: plistPath,
+  };
+}
+
+function runLaunchdStart(
+  serviceTarget: string,
+  domainTarget: string,
+  plistPath: string,
+): CommandRunResult {
+  const print = runCommand("launchctl", ["print", serviceTarget]);
+  if (!print.ok) {
+    const bootstrap = runCommand("launchctl", ["bootstrap", domainTarget, plistPath]);
+    if (!bootstrap.ok && !isLaunchdAlreadyLoaded(bootstrap.message)) {
+      return bootstrap;
+    }
+  }
+
+  return runCommand("launchctl", ["kickstart", "-k", serviceTarget]);
+}
+
+function isLaunchdAlreadyLoaded(message: string): boolean {
+  return message.includes("already loaded") || message.includes("service already bootstrapped");
+}
+
+function isLaunchdAlreadyStopped(message: string): boolean {
+  return message.includes("No such process") || message.includes("Could not find service");
+}
+
+async function executeDirectStart(
+  action: DaemonLifecycleAction,
+  context: DaemonCommandContext,
+  invokeDaemon: CliDaemonInvoker,
+): Promise<DaemonLifecycleResult> {
+  const pidInfo = readDaemonPid(context.daemonPidPath);
+  if (pidInfo.pid && isProcessAlive(pidInfo.pid)) {
+    const running = await waitForDaemonRunning(invokeDaemon, STARTUP_TIMEOUT_MS);
+    if (!running.running) {
+      return {
+        action,
+        ok: false,
+        mode: "direct",
+        delegated: false,
+        message: "managed daemon process exists but daemon socket is not responding",
+        pid: pidInfo.pid,
+      };
+    }
+
+    return {
+      action,
+      ok: true,
+      mode: "direct",
+      delegated: false,
+      message: "daemon already running",
+      running: true,
+      pid: pidInfo.pid,
+    };
+  }
+
+  if (pidInfo.pid && !isProcessAlive(pidInfo.pid)) {
+    safeUnlink(context.daemonPidPath);
+  }
+
+  const unmanagedRunning = await waitForDaemonRunning(invokeDaemon, 400);
+  if (unmanagedRunning.running) {
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "daemon is running but not managed by direct lifecycle wrapper",
+      details: "Use daemon stop via the service manager that started it.",
+    };
+  }
+
+  if (!fs.existsSync(context.daemonEntrypoint)) {
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: `daemon entrypoint not found at ${context.daemonEntrypoint}`,
+    };
+  }
+
+  fs.mkdirSync(context.storagePath, { recursive: true });
+
+  const daemonProcess = spawn(process.execPath, [context.daemonEntrypoint], {
+    cwd: process.cwd(),
+    detached: true,
+    stdio: "ignore",
+    env: createDaemonChildEnv(context),
+  });
+
+  const daemonPid = daemonProcess.pid;
+  if (!daemonPid) {
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "failed to spawn daemon process",
+    };
+  }
+
+  daemonProcess.unref();
+
+  try {
+    fs.writeFileSync(context.daemonPidPath, `${daemonPid}\n`, "utf8");
+  } catch (error) {
+    terminateProcess(daemonPid, "SIGTERM");
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "failed to write daemon pid file",
+      details: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const running = await waitForDaemonRunning(invokeDaemon, STARTUP_TIMEOUT_MS);
+  if (!running.running) {
+    terminateProcess(daemonPid, "SIGTERM");
+    safeUnlink(context.daemonPidPath);
+
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "daemon failed to become healthy after start",
+      pid: daemonPid,
+      details: running.reason,
+    };
+  }
+
+  return {
+    action,
+    ok: true,
+    mode: "direct",
+    delegated: false,
+    message: "started managed daemon process",
+    running: true,
+    pid: daemonPid,
+  };
+}
+
+async function executeDirectStop(
+  action: DaemonLifecycleAction,
+  context: DaemonCommandContext,
+  invokeDaemon: CliDaemonInvoker,
+  options: { allowUnmanagedRunning: boolean } = { allowUnmanagedRunning: true },
+): Promise<DaemonLifecycleResult> {
+  const pidInfo = readDaemonPid(context.daemonPidPath);
+
+  if (!pidInfo.pid) {
+    const running = await waitForDaemonRunning(invokeDaemon, 400);
+    if (running.running && !options.allowUnmanagedRunning) {
+      return {
+        action,
+        ok: false,
+        mode: "direct",
+        delegated: false,
+        message: "daemon is running but not managed by direct lifecycle wrapper",
+        details: "Stop it through the service manager that started it.",
+      };
+    }
+
+    return {
+      action,
+      ok: true,
+      mode: "direct",
+      delegated: false,
+      message: "daemon already stopped",
+      running: false,
+    };
+  }
+
+  if (!isProcessAlive(pidInfo.pid)) {
+    safeUnlink(context.daemonPidPath);
+    return {
+      action,
+      ok: true,
+      mode: "direct",
+      delegated: false,
+      message: "removed stale daemon pid file",
+      running: false,
+    };
+  }
+
+  terminateProcess(pidInfo.pid, "SIGTERM");
+  const stopped = await waitForProcessExit(pidInfo.pid, STOP_TIMEOUT_MS);
+  if (!stopped) {
+    terminateProcess(pidInfo.pid, "SIGKILL");
+    const killed = await waitForProcessExit(pidInfo.pid, 1_000);
+    if (!killed) {
+      return {
+        action,
+        ok: false,
+        mode: "direct",
+        delegated: false,
+        message: `failed to stop managed daemon process ${pidInfo.pid}`,
+      };
+    }
+  }
+
+  safeUnlink(context.daemonPidPath);
+
+  const running = await waitForDaemonRunning(invokeDaemon, 1_000);
+  if (running.running) {
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "daemon socket still responds after managed process stop",
+    };
+  }
+
+  return {
+    action,
+    ok: true,
+    mode: "direct",
+    delegated: false,
+    message: "stopped managed daemon process",
+    running: false,
+  };
+}
+
+async function waitForDaemonRunning(
+  invokeDaemon: CliDaemonInvoker,
+  timeoutMs: number,
+): Promise<{ running: boolean; reason?: string }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastReason: string | undefined;
+
+  while (Date.now() < deadline) {
+    const status = await invokeDaemon<DaemonStatusResult>("daemon.status", {});
+    if (status.ok) {
+      if (status.value.state === "running" && status.value.healthy) {
+        return { running: true };
+      }
+
+      lastReason = `state=${status.value.state}, healthy=${status.value.healthy ? "yes" : "no"}`;
+      await sleep(100);
+      continue;
+    }
+
+    lastReason = status.error.message;
+    await sleep(100);
+  }
+
+  return {
+    running: false,
+    reason: lastReason,
+  };
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+
+    await sleep(50);
+  }
+
+  return !isProcessAlive(pid);
+}
+
+function terminateProcess(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Process may have already exited.
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readDaemonPid(pidPath: string): { pid: number | null } {
+  try {
+    const raw = fs.readFileSync(pidPath, "utf8").trim();
+    if (!raw) {
+      return { pid: null };
+    }
+
+    const pid = Number.parseInt(raw, 10);
+    if (!Number.isInteger(pid) || pid < 1) {
+      return { pid: null };
+    }
+
+    return { pid };
+  } catch {
+    return { pid: null };
+  }
+}
+
+function safeUnlink(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // File may already be removed.
+  }
+}
+
+function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
+  const configOpt = program.opts().config as string | undefined;
+  const configPath = getConfigPath(configOpt);
+  const fileConfig = loadConfig(configPath);
+  const storagePath = resolveDataDir(configPath, fileConfig);
+  const remoteSync = resolveRemoteSyncConfig(fileConfig);
+
+  return {
+    storagePath,
+    socketPath: resolveDaemonSocketPath(storagePath),
+    daemonPidPath: path.join(storagePath, DIRECT_PID_FILENAME),
+    daemonEntrypoint: resolveDaemonEntrypoint(),
+    remoteSyncServer: remoteSync?.server ?? null,
+  };
+}
+
+function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    TODUAI_DATA_DIR: context.storagePath,
+  };
+
+  if (context.remoteSyncServer) {
+    childEnv.TODUAI_SYNC_SERVER = context.remoteSyncServer;
+    childEnv.TODUAI_SYNC_ENABLED = "1";
+  }
+
+  if (context.socketPath) {
+    childEnv.TODUAI_DAEMON_SOCKET = context.socketPath;
+  }
+
+  return childEnv;
+}
+
+function resolveLifecycleMode(): DaemonLifecycleMode {
+  const override = process.env[LIFECYCLE_MODE_ENV]?.trim();
+
+  if (override && override !== "auto") {
+    if (override === "direct" || override === "systemd-user" || override === "launchd") {
+      return override;
+    }
+
+    throw new Error(
+      `Invalid ${LIFECYCLE_MODE_ENV} value: ${override}. Expected auto, direct, systemd-user, or launchd.`,
+    );
+  }
+
+  if (
+    process.platform === "linux" &&
+    fs.existsSync(path.join(os.homedir(), SYSTEMD_SERVICE_PATH))
+  ) {
+    return "systemd-user";
+  }
+
+  if (process.platform === "darwin" && fs.existsSync(path.join(os.homedir(), LAUNCHD_PLIST_PATH))) {
+    return "launchd";
+  }
+
+  return "direct";
+}
+
+interface CommandRunResult {
+  ok: boolean;
+  message: string;
+}
+
+function runCommand(command: string, args: string[]): CommandRunResult {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.error) {
+    return {
+      ok: false,
+      message: result.error.message,
+    };
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+
+    return {
+      ok: false,
+      message: stderr || stdout || `exit code ${result.status}`,
+    };
+  }
+
+  return {
+    ok: true,
+    message: result.stdout?.trim() ?? "",
+  };
 }
 
 function resolveDaemonEntrypoint(): string {
@@ -156,4 +832,10 @@ function resolveDaemonEntrypoint(): string {
   }
 
   return path.resolve(import.meta.dirname, "../../../daemon/dist/entrypoint.js");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/packages/cli/src/daemon-command-client.ts
+++ b/packages/cli/src/daemon-command-client.ts
@@ -33,7 +33,7 @@ export function formatDaemonCommandError(error: { code: string; message: string 
   return `Error: ${error.message}`;
 }
 
-function resolveDaemonSocketPath(storagePath: string): string {
+export function resolveDaemonSocketPath(storagePath: string): string {
   const socketOverride = process.env.TODUAI_DAEMON_SOCKET;
   if (socketOverride && socketOverride.trim().length > 0) {
     return path.resolve(socketOverride);


### PR DESCRIPTION
## Summary
- add `toduai daemon start|stop|restart` wrappers to CLI daemon command group
- implement deterministic lifecycle mode selection:
  - `TODUAI_DAEMON_LIFECYCLE_MODE` override (`auto|direct|systemd-user|launchd`)
  - auto mode prefers configured service-manager registration (systemd user unit / launchd agent)
  - safe direct managed fallback when no service registration exists
- implement direct-mode managed process lifecycle:
  - detached daemon startup
  - PID tracking at `<data_dir>/daemon.pid`
  - refusal to stop unmanaged daemon processes in direct mode
- expand integration tests for success and key failure cases
- document wrapper behavior, delegation rules, and fallback semantics

## Testing
- npm test -- packages/cli/src/commands/daemon.test.ts
- make pre-pr

Task: #1989
