### PR TITLE
feat: add electron daemon connection manager lifecycle

### DIFF
--- a/docs/plans/phase-4-electron-thin-client.md
+++ b/docs/plans/phase-4-electron-thin-client.md
@@ -47,6 +47,16 @@ Migrate Electron to daemon-first architecture by replacing direct engine/storage
 - On disconnect, reconnect with bounded backoff
 - On reconnect: re-hello, re-subscribe, refresh relevant state
 
+#### Connection lifecycle notes
+
+- Reconnect backoff schedule is fixed to `250ms → 500ms → 1s → 2s` (2s cap).
+- Electron main-process daemon client exposes lifecycle hooks for:
+  - connection established
+  - reconnect established
+  - disconnected
+  - reconnect scheduled (with attempt + delay)
+- Lifecycle hooks are intended to run reconnect recovery logic (re-hello, re-subscribe) in one place.
+
 ### UI Behavior
 
 - Temporary daemon unavailability should degrade gracefully

--- a/packages/electron/src/main/daemon-connection-manager.test.ts
+++ b/packages/electron/src/main/daemon-connection-manager.test.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs";
+import net, { type Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDaemonConnectionManager,
+  DAEMON_PROTOCOL_VERSION,
+  type DaemonConnectionResult,
+} from "./daemon-connection-manager.js";
+
+describe("createDaemonConnectionManager", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses bounded reconnect backoff (250ms → 500ms → 1s → 2s cap)", async () => {
+    const scheduledDelays: number[] = [];
+    const manager = createDaemonConnectionManager({
+      socketPath: "/tmp/never-used.sock",
+      connect: () => createFailingSocket("ENOENT"),
+      hooks: {
+        onReconnectScheduled: (info) => {
+          scheduledDelays.push(info.delayMs);
+        },
+      },
+    });
+
+    manager.start();
+
+    await waitForCondition(() => scheduledDelays.length >= 5, "backoff attempts", 6_000);
+
+    expect(scheduledDelays.slice(0, 5)).toEqual([250, 500, 1_000, 2_000, 2_000]);
+
+    manager.stop();
+  });
+
+  it("reconnects and re-runs lifecycle hooks after daemon restart", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-electron-daemon-conn-"));
+    const socketPath = path.join(tmpDir, "daemon.sock");
+
+    const daemon = createMockDaemonServer(socketPath);
+    await daemon.start();
+
+    let connectedCount = 0;
+    let reconnectedCount = 0;
+
+    const manager = createDaemonConnectionManager({
+      socketPath,
+      hooks: {
+        onConnected: async ({ isReconnect, request }) => {
+          connectedCount += 1;
+
+          const hello = await request<{ protocolVersion: string }>("daemon.hello", {
+            protocolVersion: DAEMON_PROTOCOL_VERSION,
+          });
+          assertOk(hello, "daemon.hello");
+
+          if (isReconnect) {
+            const subscribe = await request<{ subscribed: string[] }>("events.subscribe", {
+              events: ["data.changed", "sync.statusChanged"],
+            });
+            assertOk(subscribe, "events.subscribe");
+            reconnectedCount += 1;
+          }
+        },
+      },
+    });
+
+    manager.start();
+
+    await waitForCondition(() => connectedCount >= 1, "initial daemon connection");
+
+    const ping = await manager.request<{ pong: boolean }>("daemon.ping");
+    expect(ping).toEqual({ ok: true, value: { pong: true } });
+
+    await daemon.stop();
+    await waitForCondition(() => !manager.isConnected(), "disconnect after daemon stop");
+
+    await daemon.start();
+
+    await waitForCondition(() => connectedCount >= 2, "daemon reconnect");
+    await waitForCondition(() => reconnectedCount >= 1, "reconnect lifecycle hook");
+
+    expect(
+      daemon.methodCalls.filter((method) => method === "daemon.hello").length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      daemon.methodCalls.filter((method) => method === "events.subscribe").length,
+    ).toBeGreaterThanOrEqual(1);
+
+    manager.stop();
+    await daemon.stop();
+  });
+});
+
+function createFailingSocket(code: string): Socket {
+  const socket = new net.Socket();
+
+  setTimeout(() => {
+    const error = new Error("connect failed") as NodeJS.ErrnoException;
+    error.code = code;
+    socket.emit("error", error);
+  }, 0);
+
+  return socket;
+}
+
+interface MockDaemonServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  methodCalls: string[];
+}
+
+function createMockDaemonServer(socketPath: string): MockDaemonServer {
+  let server: net.Server | null = null;
+  const sockets = new Set<Socket>();
+  const methodCalls: string[] = [];
+
+  return {
+    methodCalls,
+
+    async start(): Promise<void> {
+      await fs.promises.mkdir(path.dirname(socketPath), { recursive: true });
+      try {
+        await fs.promises.unlink(socketPath);
+      } catch {
+        // Socket did not exist.
+      }
+
+      server = net.createServer((socket) => {
+        sockets.add(socket);
+        socket.setEncoding("utf8");
+
+        let buffer = "";
+
+        socket.on("data", (chunk: string) => {
+          buffer += chunk;
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (trimmed.length === 0) {
+              continue;
+            }
+
+            const frame = JSON.parse(trimmed) as {
+              id?: string;
+              method?: string;
+              params?: Record<string, unknown>;
+            };
+
+            if (typeof frame.method !== "string" || typeof frame.id !== "string") {
+              continue;
+            }
+
+            methodCalls.push(frame.method);
+
+            if (frame.method === "daemon.hello") {
+              socket.write(
+                `${JSON.stringify({ id: frame.id, result: { protocolVersion: DAEMON_PROTOCOL_VERSION } })}\n`,
+              );
+              continue;
+            }
+
+            if (frame.method === "events.subscribe") {
+              const events = Array.isArray(frame.params?.events)
+                ? (frame.params?.events as string[])
+                : [];
+              socket.write(`${JSON.stringify({ id: frame.id, result: { subscribed: events } })}\n`);
+              continue;
+            }
+
+            if (frame.method === "daemon.ping") {
+              socket.write(`${JSON.stringify({ id: frame.id, result: { pong: true } })}\n`);
+              continue;
+            }
+
+            socket.write(
+              `${JSON.stringify({
+                id: frame.id,
+                error: { code: "METHOD_NOT_FOUND", message: `Unknown method: ${frame.method}` },
+              })}\n`,
+            );
+          }
+        });
+
+        const removeSocket = () => {
+          sockets.delete(socket);
+        };
+
+        socket.on("close", removeSocket);
+        socket.on("error", removeSocket);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server?.once("error", reject);
+        server?.listen(socketPath, () => {
+          server?.off("error", reject);
+          resolve();
+        });
+      });
+    },
+
+    async stop(): Promise<void> {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      sockets.clear();
+
+      if (server) {
+        const activeServer = server;
+        server = null;
+
+        await new Promise<void>((resolve) => {
+          activeServer.close(() => {
+            resolve();
+          });
+        });
+      }
+
+      try {
+        await fs.promises.unlink(socketPath);
+      } catch {
+        // Already removed.
+      }
+    },
+  };
+}
+
+function assertOk<T>(
+  result: DaemonConnectionResult<T>,
+  method: string,
+): asserts result is { ok: true; value: T } {
+  if (!result.ok) {
+    throw new Error(`${method} failed: ${result.error.code} ${result.error.message}`);
+  }
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 6_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+
+  throw new Error(`Timed out waiting for condition: ${label}`);
+}

--- a/packages/electron/src/main/daemon-connection-manager.ts
+++ b/packages/electron/src/main/daemon-connection-manager.ts
@@ -1,0 +1,725 @@
+import net, { type Socket } from "node:net";
+import path from "node:path";
+
+export const DAEMON_PROTOCOL_VERSION = "1";
+export const DEFAULT_ELECTRON_DAEMON_CONNECT_TIMEOUT_MS = 2_000;
+export const DEFAULT_ELECTRON_DAEMON_REQUEST_TIMEOUT_MS = 10_000;
+
+const DEFAULT_RECONNECT_BACKOFF_MS = [250, 500, 1_000, 2_000] as const;
+
+export interface DaemonConnectionError {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export type DaemonConnectionResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: DaemonConnectionError };
+
+export interface DaemonConnectionContext {
+  isReconnect: boolean;
+  request<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ): Promise<DaemonConnectionResult<T>>;
+}
+
+export interface DaemonReconnectInfo {
+  attempt: number;
+  delayMs: number;
+  reason: unknown;
+}
+
+export interface DaemonDisconnectInfo {
+  reason: unknown;
+}
+
+export interface DaemonEventFrame {
+  event: string;
+  payload: unknown;
+  ts?: unknown;
+}
+
+export interface DaemonConnectionLifecycleHooks {
+  onConnected?: (context: DaemonConnectionContext) => Promise<void> | void;
+  onReconnected?: (context: DaemonConnectionContext) => Promise<void> | void;
+  onDisconnected?: (info: DaemonDisconnectInfo) => void;
+  onReconnectScheduled?: (info: DaemonReconnectInfo) => void;
+  onEvent?: (event: DaemonEventFrame) => void;
+}
+
+export interface DaemonConnectionManagerOptions {
+  socketPath: string;
+  connectTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  reconnectBackoffMs?: readonly number[];
+  connect?: (socketPath: string) => Socket;
+  requestIdFactory?: () => string;
+  hooks?: DaemonConnectionLifecycleHooks;
+}
+
+export interface DaemonConnectionManager {
+  start(): void;
+  stop(): void;
+  isConnected(): boolean;
+  setHooks(hooks: DaemonConnectionLifecycleHooks): void;
+  request<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ): Promise<DaemonConnectionResult<T>>;
+}
+
+interface PendingRequest {
+  id: string;
+  resolve: (result: DaemonConnectionResult<unknown>) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface ActiveConnection {
+  socket: Socket;
+  pending: Map<string, PendingRequest>;
+  buffer: string;
+  closed: boolean;
+  dispose: () => void;
+}
+
+interface ProtocolRequestFrame {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+interface ProtocolSuccessFrame {
+  id: string;
+  result: unknown;
+}
+
+interface ProtocolErrorFrame {
+  id: string | null;
+  error: DaemonConnectionError;
+}
+
+class ElectronDaemonConnectionManager implements DaemonConnectionManager {
+  private readonly socketPath: string;
+  private readonly connectTimeoutMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly reconnectBackoffMs: readonly number[];
+  private readonly connect: (socketPath: string) => Socket;
+  private readonly requestIdFactory: () => string;
+
+  private hooks: DaemonConnectionLifecycleHooks;
+  private running = false;
+  private connecting = false;
+  private hasConnectedOnce = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private activeConnection: ActiveConnection | null = null;
+  private requestChain: Promise<void> = Promise.resolve();
+
+  constructor(options: DaemonConnectionManagerOptions) {
+    this.socketPath = options.socketPath;
+    this.connectTimeoutMs = normalizeTimeout(
+      options.connectTimeoutMs,
+      DEFAULT_ELECTRON_DAEMON_CONNECT_TIMEOUT_MS,
+    );
+    this.requestTimeoutMs = normalizeTimeout(
+      options.requestTimeoutMs,
+      DEFAULT_ELECTRON_DAEMON_REQUEST_TIMEOUT_MS,
+    );
+
+    const backoff =
+      options.reconnectBackoffMs && options.reconnectBackoffMs.length > 0
+        ? options.reconnectBackoffMs
+        : DEFAULT_RECONNECT_BACKOFF_MS;
+    this.reconnectBackoffMs = backoff.map((value) => normalizeTimeout(value, 250));
+
+    this.connect = options.connect ?? ((socketPath: string) => net.createConnection(socketPath));
+    this.requestIdFactory = options.requestIdFactory ?? createRequestId;
+    this.hooks = options.hooks ?? {};
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    void this.attemptConnect();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.connecting = false;
+    this.hasConnectedOnce = false;
+    this.reconnectAttempt = 0;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.activeConnection) {
+      this.closeConnection(this.activeConnection, {
+        reason: new Error("Daemon connection manager stopped"),
+        shouldReconnect: false,
+      });
+    }
+  }
+
+  isConnected(): boolean {
+    return this.activeConnection !== null;
+  }
+
+  setHooks(hooks: DaemonConnectionLifecycleHooks): void {
+    this.hooks = hooks;
+  }
+
+  async request<T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    options?: { timeoutMs?: number },
+  ): Promise<DaemonConnectionResult<T>> {
+    const timeoutMs = normalizeTimeout(options?.timeoutMs, this.requestTimeoutMs);
+
+    const resultPromise = this.requestChain.then(() =>
+      this.sendRequest<T>(method, params, timeoutMs),
+    );
+
+    this.requestChain = resultPromise.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return resultPromise;
+  }
+
+  private async attemptConnect(): Promise<void> {
+    if (!this.running || this.connecting || this.activeConnection) {
+      return;
+    }
+
+    this.connecting = true;
+
+    const socketResult = await connectSocket(this.socketPath, this.connectTimeoutMs, this.connect);
+
+    this.connecting = false;
+
+    if (!this.running) {
+      if (socketResult.ok) {
+        socketResult.value.destroy();
+      }
+      return;
+    }
+
+    if (!socketResult.ok) {
+      this.scheduleReconnect(socketResult.error);
+      return;
+    }
+
+    const isReconnect = this.hasConnectedOnce;
+    const active = this.createActiveConnection(socketResult.value);
+    this.activeConnection = active;
+
+    const lifecycleResult = await this.runLifecycleHooks(isReconnect);
+    if (!lifecycleResult.ok) {
+      this.closeConnection(active, {
+        reason: lifecycleResult.error,
+        shouldReconnect: true,
+      });
+      return;
+    }
+
+    this.hasConnectedOnce = true;
+    this.reconnectAttempt = 0;
+  }
+
+  private createActiveConnection(socket: Socket): ActiveConnection {
+    const connection: ActiveConnection = {
+      socket,
+      pending: new Map<string, PendingRequest>(),
+      buffer: "",
+      closed: false,
+      dispose: () => {
+        socket.off("data", onData);
+        socket.off("error", onError);
+        socket.off("close", onClose);
+      },
+    };
+
+    const onData = (chunk: string) => {
+      if (connection.closed) {
+        return;
+      }
+
+      connection.buffer += chunk;
+      const lines = connection.buffer.split("\n");
+      connection.buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          continue;
+        }
+
+        let frame: unknown;
+        try {
+          frame = JSON.parse(trimmed) as unknown;
+        } catch (error) {
+          this.closeConnection(connection, {
+            reason: {
+              code: "BAD_RESPONSE",
+              message: "Daemon returned invalid JSON frame",
+              details: {
+                parseError: getErrorMessage(error),
+              },
+            },
+            shouldReconnect: true,
+          });
+          return;
+        }
+
+        this.handleFrame(connection, frame);
+      }
+    };
+
+    const onError = (error: unknown) => {
+      this.closeConnection(connection, {
+        reason: error,
+        shouldReconnect: true,
+      });
+    };
+
+    const onClose = () => {
+      this.closeConnection(connection, {
+        reason: new Error("Daemon connection closed"),
+        shouldReconnect: true,
+      });
+    };
+
+    socket.setEncoding("utf8");
+    socket.on("data", onData);
+    socket.on("error", onError);
+    socket.on("close", onClose);
+
+    return connection;
+  }
+
+  private handleFrame(connection: ActiveConnection, frame: unknown): void {
+    const parsed = parseIncomingFrame(frame);
+
+    if (!parsed.ok) {
+      this.closeConnection(connection, {
+        reason: parsed.error,
+        shouldReconnect: true,
+      });
+      return;
+    }
+
+    if (parsed.kind === "event") {
+      this.hooks.onEvent?.(parsed.value);
+      return;
+    }
+
+    const pending = connection.pending.get(parsed.value.id);
+    if (!pending) {
+      return;
+    }
+
+    connection.pending.delete(parsed.value.id);
+    clearTimeout(pending.timeout);
+
+    if (parsed.kind === "error") {
+      pending.resolve({
+        ok: false,
+        error: parsed.value.error,
+      });
+      return;
+    }
+
+    pending.resolve({
+      ok: true,
+      value: parsed.value.result,
+    });
+  }
+
+  private async runLifecycleHooks(isReconnect: boolean): Promise<DaemonConnectionResult<void>> {
+    const context: DaemonConnectionContext = {
+      isReconnect,
+      request: <T>(
+        method: string,
+        params: Record<string, unknown> = {},
+        options?: { timeoutMs?: number },
+      ) => this.request<T>(method, params, options),
+    };
+
+    try {
+      await this.hooks.onConnected?.(context);
+      if (isReconnect) {
+        await this.hooks.onReconnected?.(context);
+      }
+      return { ok: true, value: undefined };
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Daemon connection lifecycle hook failed",
+          details: {
+            reason: getErrorMessage(error),
+          },
+        },
+      };
+    }
+  }
+
+  private closeConnection(
+    connection: ActiveConnection,
+    options: { reason: unknown; shouldReconnect: boolean },
+  ): void {
+    if (connection.closed) {
+      return;
+    }
+
+    connection.closed = true;
+    connection.dispose();
+
+    if (this.activeConnection === connection) {
+      this.activeConnection = null;
+    }
+
+    for (const pending of connection.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.resolve({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: "Daemon connection closed before response was received",
+        },
+      });
+    }
+    connection.pending.clear();
+
+    try {
+      connection.socket.end();
+      connection.socket.destroy();
+    } catch {
+      // Ignore socket teardown failures.
+    }
+
+    this.hooks.onDisconnected?.({ reason: options.reason });
+
+    if (options.shouldReconnect) {
+      this.scheduleReconnect(options.reason);
+    }
+  }
+
+  private scheduleReconnect(reason: unknown): void {
+    if (!this.running) {
+      return;
+    }
+
+    if (this.reconnectTimer) {
+      return;
+    }
+
+    const delayMs =
+      this.reconnectBackoffMs[Math.min(this.reconnectAttempt, this.reconnectBackoffMs.length - 1)];
+    this.reconnectAttempt += 1;
+
+    this.hooks.onReconnectScheduled?.({
+      attempt: this.reconnectAttempt,
+      delayMs,
+      reason,
+    });
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.attemptConnect();
+    }, delayMs);
+  }
+
+  private async sendRequest<T>(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+  ): Promise<DaemonConnectionResult<T>> {
+    const connection = this.activeConnection;
+    if (!this.running || !connection || connection.closed) {
+      return {
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: "Daemon connection is not available",
+          details: {
+            method,
+          },
+        },
+      };
+    }
+
+    const id = this.requestIdFactory();
+    const request: ProtocolRequestFrame = {
+      id,
+      method,
+      params,
+    };
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        connection.pending.delete(id);
+        resolve({
+          ok: false,
+          error: {
+            code: "TIMEOUT",
+            message: `Daemon request timed out after ${timeoutMs}ms`,
+            details: {
+              method,
+              timeoutMs,
+            },
+          },
+        });
+      }, timeoutMs);
+
+      connection.pending.set(id, {
+        id,
+        resolve: resolve as (result: DaemonConnectionResult<unknown>) => void,
+        timeout,
+      });
+
+      try {
+        connection.socket.write(`${JSON.stringify(request)}\n`);
+      } catch (error) {
+        clearTimeout(timeout);
+        connection.pending.delete(id);
+        resolve({
+          ok: false,
+          error: {
+            code: "DAEMON_UNAVAILABLE",
+            message: getErrorMessage(error),
+            details: {
+              method,
+            },
+          },
+        });
+      }
+    });
+  }
+}
+
+export function createDaemonConnectionManager(
+  options: DaemonConnectionManagerOptions,
+): DaemonConnectionManager {
+  return new ElectronDaemonConnectionManager(options);
+}
+
+export function resolveDaemonSocketPath(storagePath: string): string {
+  const socketOverride = process.env.TODUAI_DAEMON_SOCKET;
+  if (socketOverride && socketOverride.trim().length > 0) {
+    return path.resolve(socketOverride);
+  }
+
+  return path.join(storagePath, "daemon.sock");
+}
+
+interface ParsedEvent {
+  event: string;
+  payload: unknown;
+  ts?: unknown;
+}
+
+function parseIncomingFrame(
+  frame: unknown,
+):
+  | { ok: true; kind: "success"; value: ProtocolSuccessFrame }
+  | { ok: true; kind: "error"; value: ProtocolErrorFrame }
+  | { ok: true; kind: "event"; value: ParsedEvent }
+  | { ok: false; error: DaemonConnectionError } {
+  if (!isRecord(frame)) {
+    return {
+      ok: false,
+      error: {
+        code: "BAD_RESPONSE",
+        message: "Daemon response frame must be an object",
+      },
+    };
+  }
+
+  if (typeof frame.event === "string") {
+    return {
+      ok: true,
+      kind: "event",
+      value: {
+        event: frame.event,
+        payload: frame.payload,
+        ts: frame.ts,
+      },
+    };
+  }
+
+  if (isRecord(frame.error)) {
+    const id = frame.id;
+    if (typeof id === "string" || id === null) {
+      const error = frame.error;
+      if (typeof error.code === "string" && typeof error.message === "string") {
+        return {
+          ok: true,
+          kind: "error",
+          value: {
+            id,
+            error: {
+              code: error.code,
+              message: error.message,
+              details: isRecord(error.details) ? error.details : undefined,
+            },
+          },
+        };
+      }
+    }
+  }
+
+  if (typeof frame.id === "string" && "result" in frame) {
+    return {
+      ok: true,
+      kind: "success",
+      value: {
+        id: frame.id,
+        result: frame.result,
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: "BAD_RESPONSE",
+      message: "Daemon response frame shape is invalid",
+    },
+  };
+}
+
+async function connectSocket(
+  socketPath: string,
+  timeoutMs: number,
+  connect: (socketPath: string) => Socket,
+): Promise<DaemonConnectionResult<Socket>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = connect(socketPath);
+
+    const cleanup = () => {
+      socket.off("error", onError);
+      socket.off("connect", onConnect);
+    };
+
+    const finish = (result: DaemonConnectionResult<Socket>) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      cleanup();
+      resolve(result);
+    };
+
+    const onConnect = () => {
+      finish({ ok: true, value: socket });
+    };
+
+    const onError = (error: unknown) => {
+      socket.destroy();
+      finish({
+        ok: false,
+        error: mapConnectError(socketPath, error),
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      finish({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: `Timed out connecting to daemon socket after ${Math.floor(timeoutMs)}ms`,
+          details: {
+            socketPath,
+            timeoutMs: Math.floor(timeoutMs),
+          },
+        },
+      });
+    }, timeoutMs);
+
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+  });
+}
+
+function mapConnectError(socketPath: string, source: unknown): DaemonConnectionError {
+  const code = errorCode(source);
+
+  if (code === "ENOENT" || code === "ECONNREFUSED" || code === "EACCES" || code === "EPERM") {
+    return {
+      code: "DAEMON_UNAVAILABLE",
+      message: `Daemon unavailable at socket: ${socketPath}`,
+      details: {
+        socketPath,
+        reason: code,
+      },
+    };
+  }
+
+  return {
+    code: "INTERNAL_ERROR",
+    message: getErrorMessage(source),
+    details: {
+      socketPath,
+      reason: code,
+    },
+  };
+}
+
+function normalizeTimeout(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  if (value < 1) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unexpected daemon connection error";
+}
+
+let requestCounter = 0;
+
+function createRequestId(): string {
+  requestCounter += 1;
+  return `electron-${Date.now()}-${requestCounter}`;
+}

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -4,6 +4,13 @@ import { app, BrowserWindow } from "electron";
 import { setupAgent, teardownAgent } from "./agent.js";
 import { setupChangeNotifications } from "./change-notifications.js";
 import { loadElectronConfig } from "./config.js";
+import {
+  createDaemonConnectionManager,
+  DAEMON_PROTOCOL_VERSION,
+  type DaemonConnectionManager,
+  type DaemonConnectionResult,
+  resolveDaemonSocketPath,
+} from "./daemon-connection-manager.js";
 import { registerIpcHandlers } from "./ipc.js";
 import { registerOAuthIpc, unregisterOAuthIpc } from "./oauth.js";
 
@@ -14,6 +21,7 @@ import { createWindow, restoreWindowState, saveWindowState } from "./window.js";
 
 let mainWindow: BrowserWindow | null = null;
 let todu: Todu | null = null;
+let daemonConnectionManager: DaemonConnectionManager | null = null;
 let isQuitting = false;
 
 function getMainWindow(): BrowserWindow | null {
@@ -31,9 +39,38 @@ function showWindowWithAction(action: string): void {
   }
 }
 
+function assertRequestOk<T>(
+  result: DaemonConnectionResult<T>,
+  method: string,
+): asserts result is { ok: true; value: T } {
+  if (!result.ok) {
+    throw new Error(`Daemon ${method} failed: ${result.error.code} ${result.error.message}`);
+  }
+}
+
 async function init(): Promise<void> {
   // Load full config (data dir + remote sync) using the same config chain as CLI
   const { storagePath, remoteSync } = loadElectronConfig();
+
+  daemonConnectionManager = createDaemonConnectionManager({
+    socketPath: resolveDaemonSocketPath(storagePath),
+    hooks: {
+      onConnected: async ({ isReconnect, request }) => {
+        const hello = await request("daemon.hello", {
+          protocolVersion: DAEMON_PROTOCOL_VERSION,
+        });
+        assertRequestOk(hello, "daemon.hello");
+
+        if (isReconnect) {
+          const subscribe = await request("events.subscribe", {
+            events: ["data.changed", "sync.statusChanged"],
+          });
+          assertRequestOk(subscribe, "events.subscribe");
+        }
+      },
+    },
+  });
+  daemonConnectionManager.start();
 
   // Initialize engine with sync server so CLI can connect,
   // and connect to remote sync server if configured
@@ -90,6 +127,8 @@ app.whenReady().then(init);
 // Mark as quitting so the close handler allows it through
 app.on("before-quit", () => {
   isQuitting = true;
+  daemonConnectionManager?.stop();
+  daemonConnectionManager = null;
 });
 
 app.on("window-all-closed", async () => {
@@ -99,6 +138,9 @@ app.on("window-all-closed", async () => {
 
   unregisterOAuthIpc();
   unregisterSettingsIpc();
+  daemonConnectionManager?.stop();
+  daemonConnectionManager = null;
+
   if (todu) {
     await todu.close();
     todu = null;


### PR DESCRIPTION
## Summary
- add an Electron main-process daemon connection manager with persistent UDS connectivity
- implement bounded reconnect backoff (250ms → 500ms → 1s → 2s cap) and lifecycle hooks for reconnect recovery
- wire manager startup/shutdown into Electron main and run daemon.hello + events.subscribe on reconnect
- add daemon connection manager tests for backoff behavior and daemon restart recovery
- document connection lifecycle notes in the phase 4 plan doc

## Testing
- make pre-pr
- npm run --workspace=packages/electron build

Task: #1942
Closes #191