### PR TITLE
feat: migrate electron ipc handlers to daemon rpc

### DIFF
--- a/docs/plans/phase-4-electron-thin-client.md
+++ b/docs/plans/phase-4-electron-thin-client.md
@@ -27,6 +27,9 @@ Migrate Electron to daemon-first architecture by replacing direct engine/storage
    - Main process IPC handlers forward to daemon methods
    - Remove direct engine namespace calls in Electron runtime path
 
+   Status update:
+   - Electron main IPC handlers now invoke daemon RPC methods and map protocol errors to renderer Result shapes while preserving existing channel contracts.
+
 3. **Runtime ownership removal**
    - Remove direct persistent storage ownership assumptions from Electron startup
    - Electron should no longer be local state owner

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -81,7 +81,10 @@ async function init(): Promise<void> {
   });
 
   // Register all IPC handlers
-  registerIpcHandlers(todu, storagePath);
+  registerIpcHandlers({
+    daemon: daemonConnectionManager,
+    storagePath,
+  });
 
   // Create the main window
   const windowState = restoreWindowState();

--- a/packages/electron/src/main/ipc.test.ts
+++ b/packages/electron/src/main/ipc.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CATALOG_DOC_KEY } from "@todu/core";
+import { describe, expect, it, vi } from "vitest";
+import { createDaemonIpcHandlers, mapDaemonErrorToToduError } from "./ipc.js";
+
+describe("createDaemonIpcHandlers", () => {
+  it("routes task IPC handlers to daemon RPC and preserves Result contract", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { id: "task-1", title: "Demo" },
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+      appLifecycle: {
+        relaunch: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+
+    const result = await handlers["todu:task:get"](undefined, "task-1");
+
+    expect(daemon.request).toHaveBeenCalledWith("task.get", { id: "task-1" });
+    expect(result).toEqual({
+      ok: true,
+      value: { id: "task-1", title: "Demo" },
+    });
+  });
+
+  it("maps daemon NOT_FOUND errors to renderer-consumable not-found Result errors", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "task not found: task-999",
+          details: {
+            entity: "task",
+            id: "task-999",
+          },
+        },
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+      appLifecycle: {
+        relaunch: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+
+    const result = await handlers["todu:task:get"](undefined, "task-999");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: "not-found",
+        entity: "task",
+        id: "task-999",
+      },
+    });
+  });
+
+  it("returns raw sync status payload for sync IPC contracts", async () => {
+    const syncStatus = {
+      local: { mode: "authority" },
+      remote: { state: "connected" as const, server: "ws://localhost:3030" },
+    };
+
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: syncStatus,
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+      appLifecycle: {
+        relaunch: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+
+    const result = await handlers["todu:sync:status"](undefined);
+
+    expect(daemon.request).toHaveBeenCalledWith("sync.status", {});
+    expect(result).toEqual(syncStatus);
+  });
+
+  it("writes join marker and requests relaunch for valid join code", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-ipc-join-test-"));
+    const relaunch = vi.fn();
+    const exit = vi.fn();
+
+    const handlers = createDaemonIpcHandlers({
+      daemon: {
+        request: vi.fn(),
+      },
+      storagePath: tmpDir,
+      appLifecycle: {
+        relaunch,
+        exit,
+      },
+    });
+
+    const catalogId = "2sFuwGcFcU9fkQDnYCdveNPoF6nK";
+
+    await handlers["todu:sync:join"](undefined, catalogId);
+
+    const markerPath = path.join(tmpDir, `${CATALOG_DOC_KEY}.id`);
+    expect(fs.readFileSync(markerPath, "utf-8")).toBe(catalogId);
+    expect(relaunch).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});
+
+describe("mapDaemonErrorToToduError", () => {
+  it("maps BAD_REQUEST to validation error shape", () => {
+    const mapped = mapDaemonErrorToToduError("task.update", {
+      code: "BAD_REQUEST",
+      message: "task.update requires params.input",
+      details: {
+        field: "input",
+      },
+    });
+
+    expect(mapped).toEqual({
+      type: "validation",
+      field: "input",
+      message: "task.update requires params.input",
+    });
+  });
+
+  it("maps infrastructure errors to storage error shape", () => {
+    const mapped = mapDaemonErrorToToduError("task.list", {
+      code: "DAEMON_UNAVAILABLE",
+      message: "Daemon unavailable at socket: /tmp/todu.sock",
+    });
+
+    expect(mapped).toEqual({
+      type: "storage",
+      message:
+        "task.list failed (DAEMON_UNAVAILABLE): Daemon unavailable at socket: /tmp/todu.sock",
+    });
+  });
+});

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -1,98 +1,202 @@
 import fs from "node:fs";
 import path from "node:path";
-import { CATALOG_DOC_KEY } from "@todu/core";
-import type { Todu } from "@todu/engine";
+import { CATALOG_DOC_KEY, err, ok, type Result, type ToduError } from "@todu/core";
 import { app, ipcMain } from "electron";
+import type {
+  DaemonConnectionError,
+  DaemonConnectionManager,
+} from "./daemon-connection-manager.js";
+
+interface IpcAppLifecycle {
+  relaunch(): void;
+  exit(code?: number): void;
+}
+
+interface RegisterIpcHandlersOptions {
+  daemon: Pick<DaemonConnectionManager, "request">;
+  storagePath: string;
+}
+
+interface CreateDaemonIpcHandlersOptions extends RegisterIpcHandlersOptions {
+  appLifecycle: IpcAppLifecycle;
+}
+
+type IpcHandler = (_event: unknown, ...args: unknown[]) => Promise<unknown> | unknown;
 
 /**
- * Register all IPC handlers for the engine SDK.
+ * Register all IPC handlers for renderer API channels.
  *
  * Channel naming convention: todu:<namespace>:<method>
- * Each handler wraps the corresponding engine SDK method and returns
- * the Result<T> directly — the renderer handles ok/error.
  */
-export function registerIpcHandlers(todu: Todu, storagePath: string): void {
-  // ── Project ──────────────────────────────────────────────────────────
-  ipcMain.handle("todu:project:list", (_, filter) => todu.project.list(filter));
-  ipcMain.handle("todu:project:get", (_, id) => todu.project.get(id));
-  ipcMain.handle("todu:project:create", (_, input) => todu.project.create(input));
-  ipcMain.handle("todu:project:update", (_, id, input) => todu.project.update(id, input));
-  ipcMain.handle("todu:project:delete", (_, id) => todu.project.delete(id));
-
-  // ── Task ─────────────────────────────────────────────────────────────
-  ipcMain.handle("todu:task:list", (_, filter, sort) => todu.task.list(filter, sort));
-  ipcMain.handle("todu:task:get", (_, id) => todu.task.get(id));
-  ipcMain.handle("todu:task:create", (_, input) => todu.task.create(input));
-  ipcMain.handle("todu:task:update", (_, id, input) => todu.task.update(id, input));
-  ipcMain.handle("todu:task:delete", (_, id) => todu.task.delete(id));
-  ipcMain.handle("todu:task:move", (_, id, projectId) => todu.task.move(id, projectId));
-  ipcMain.handle("todu:task:search", (_, query) => todu.task.search(query));
-
-  // ── Label ────────────────────────────────────────────────────────────
-  ipcMain.handle("todu:label:list", () => todu.label.list());
-  ipcMain.handle("todu:label:create", (_, input) => todu.label.create(input));
-  ipcMain.handle("todu:label:update", (_, id, input) => todu.label.update(id, input));
-  ipcMain.handle("todu:label:delete", (_, id) => todu.label.delete(id));
-
-  // ── Note ─────────────────────────────────────────────────────────────
-  ipcMain.handle("todu:note:list", (_, filter) => todu.note.list(filter));
-  ipcMain.handle("todu:note:create", (_, input) => todu.note.create(input));
-  ipcMain.handle("todu:note:update", (_, id, input) => todu.note.update(id, input));
-  ipcMain.handle("todu:note:delete", (_, id) => todu.note.delete(id));
-
-  // ── Recurring ────────────────────────────────────────────────────────
-  ipcMain.handle("todu:recurring:list", (_, filter) => todu.recurring.list(filter));
-  ipcMain.handle("todu:recurring:get", (_, id) => todu.recurring.get(id));
-  ipcMain.handle("todu:recurring:create", (_, input) => todu.recurring.create(input));
-  ipcMain.handle("todu:recurring:update", (_, id, input) => todu.recurring.update(id, input));
-  ipcMain.handle("todu:recurring:delete", (_, id) => todu.recurring.delete(id));
-  ipcMain.handle("todu:recurring:pause", (_, id) => todu.recurring.pause(id));
-  ipcMain.handle("todu:recurring:resume", (_, id) => todu.recurring.resume(id));
-  ipcMain.handle("todu:recurring:upcoming", (_, options) => todu.recurring.upcoming(options));
-  ipcMain.handle("todu:recurring:generate", (_, templateId, date) =>
-    todu.recurring.generate(templateId, date),
-  );
-  ipcMain.handle("todu:recurring:process", () => todu.recurring.process());
-
-  // ── Habit ────────────────────────────────────────────────────────────
-  ipcMain.handle("todu:habit:list", (_, filter) => todu.habit.list(filter));
-  ipcMain.handle("todu:habit:get", (_, id) => todu.habit.get(id));
-  ipcMain.handle("todu:habit:create", (_, input) => todu.habit.create(input));
-  ipcMain.handle("todu:habit:update", (_, id, input) => todu.habit.update(id, input));
-  ipcMain.handle("todu:habit:delete", (_, id) => todu.habit.delete(id));
-  ipcMain.handle("todu:habit:pause", (_, id) => todu.habit.pause(id));
-  ipcMain.handle("todu:habit:resume", (_, id) => todu.habit.resume(id));
-  ipcMain.handle("todu:habit:check", (_, id) => todu.habit.check(id));
-  ipcMain.handle("todu:habit:uncheck", (_, id) => todu.habit.uncheck(id));
-  ipcMain.handle("todu:habit:streak", (_, id) => todu.habit.streak(id));
-  ipcMain.handle("todu:habit:history", (_, id, days) => todu.habit.history(id, days));
-
-  // ── Sync ─────────────────────────────────────────────────────────────
-  ipcMain.handle("todu:sync:status", () => todu.sync.status());
-  ipcMain.handle("todu:sync:start", () => todu.sync.start());
-  ipcMain.handle("todu:sync:stop", () => todu.sync.stop());
-  ipcMain.handle("todu:sync:catalog-id", () => todu.sync.getCatalogId());
-
-  // Join flow: Device B writes Device A's catalog document ID to the
-  // marker file and restarts so the engine picks it up on next launch.
-  //
-  // Basic format guard: Automerge document IDs are URL-safe base58/base64
-  // strings of ~22+ characters. Reject obviously malformed input to avoid
-  // restarting into a broken state that requires manual file recovery.
-  ipcMain.handle("todu:sync:join", (_event, catalogId: unknown) => {
-    if (typeof catalogId !== "string") {
-      throw new Error("Invalid join code: must be a string");
-    }
-    const trimmed = catalogId.trim();
-    if (trimmed.length < 10) {
-      throw new Error("Invalid join code: too short");
-    }
-    if (!/^[a-zA-Z0-9+/=_-]+$/.test(trimmed)) {
-      throw new Error("Invalid join code: contains unexpected characters");
-    }
-    const markerPath = path.join(storagePath, `${CATALOG_DOC_KEY}.id`);
-    fs.writeFileSync(markerPath, trimmed, "utf-8");
-    app.relaunch();
-    app.exit(0);
+export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
+  const handlers = createDaemonIpcHandlers({
+    ...options,
+    appLifecycle: app,
   });
+
+  for (const [channel, handler] of Object.entries(handlers)) {
+    ipcMain.handle(channel, handler);
+  }
+}
+
+export function createDaemonIpcHandlers(
+  options: CreateDaemonIpcHandlersOptions,
+): Record<string, IpcHandler> {
+  const invokeResult = <T>(method: string, params: Record<string, unknown> = {}) =>
+    invokeDaemonResult<T>(options.daemon, method, params);
+
+  const invokeRaw = <T>(method: string, params: Record<string, unknown> = {}) =>
+    invokeDaemonRaw<T>(options.daemon, method, params);
+
+  return {
+    // ── Project ───────────────────────────────────────────────────────────
+    "todu:project:list": (_event, filter) => invokeResult("project.list", { filter }),
+    "todu:project:get": (_event, id) => invokeResult("project.get", { id }),
+    "todu:project:create": (_event, input) => invokeResult("project.create", { input }),
+    "todu:project:update": (_event, id, input) => invokeResult("project.update", { id, input }),
+    "todu:project:delete": (_event, id) => invokeResult("project.delete", { id }),
+
+    // ── Task ──────────────────────────────────────────────────────────────
+    "todu:task:list": (_event, filter, sort) => invokeResult("task.list", { filter, sort }),
+    "todu:task:get": (_event, id) => invokeResult("task.get", { id }),
+    "todu:task:create": (_event, input) => invokeResult("task.create", { input }),
+    "todu:task:update": (_event, id, input) => invokeResult("task.update", { id, input }),
+    "todu:task:delete": (_event, id) => invokeResult("task.delete", { id }),
+    "todu:task:move": (_event, id, projectId) => invokeResult("task.move", { id, projectId }),
+    "todu:task:search": (_event, query) => invokeResult("task.search", { query }),
+
+    // ── Label ─────────────────────────────────────────────────────────────
+    "todu:label:list": () => invokeResult("label.list"),
+    "todu:label:create": (_event, input) => invokeResult("label.create", { input }),
+    "todu:label:update": (_event, id, input) => invokeResult("label.update", { id, input }),
+    "todu:label:delete": (_event, id) => invokeResult("label.delete", { id }),
+
+    // ── Note ──────────────────────────────────────────────────────────────
+    "todu:note:list": (_event, filter) => invokeResult("note.list", { filter }),
+    "todu:note:create": (_event, input) => invokeResult("note.create", { input }),
+    "todu:note:update": (_event, id, input) => invokeResult("note.update", { id, input }),
+    "todu:note:delete": (_event, id) => invokeResult("note.delete", { id }),
+
+    // ── Recurring ─────────────────────────────────────────────────────────
+    "todu:recurring:list": (_event, filter) => invokeResult("recurring.list", { filter }),
+    "todu:recurring:get": (_event, id) => invokeResult("recurring.get", { id }),
+    "todu:recurring:create": (_event, input) => invokeResult("recurring.create", { input }),
+    "todu:recurring:update": (_event, id, input) => invokeResult("recurring.update", { id, input }),
+    "todu:recurring:delete": (_event, id) => invokeResult("recurring.delete", { id }),
+    "todu:recurring:pause": (_event, id) => invokeResult("recurring.pause", { id }),
+    "todu:recurring:resume": (_event, id) => invokeResult("recurring.resume", { id }),
+    "todu:recurring:upcoming": (_event, optionsArg) =>
+      invokeResult("recurring.upcoming", { options: optionsArg }),
+    "todu:recurring:generate": (_event, templateId, date) =>
+      invokeResult("recurring.generate", { templateId, date }),
+    "todu:recurring:process": () => invokeResult("recurring.process"),
+
+    // ── Habit ─────────────────────────────────────────────────────────────
+    "todu:habit:list": (_event, filter) => invokeResult("habit.list", { filter }),
+    "todu:habit:get": (_event, id) => invokeResult("habit.get", { id }),
+    "todu:habit:create": (_event, input) => invokeResult("habit.create", { input }),
+    "todu:habit:update": (_event, id, input) => invokeResult("habit.update", { id, input }),
+    "todu:habit:delete": (_event, id) => invokeResult("habit.delete", { id }),
+    "todu:habit:pause": (_event, id) => invokeResult("habit.pause", { id }),
+    "todu:habit:resume": (_event, id) => invokeResult("habit.resume", { id }),
+    "todu:habit:check": (_event, id) => invokeResult("habit.check", { id }),
+    "todu:habit:uncheck": (_event, id) => invokeResult("habit.uncheck", { id }),
+    "todu:habit:streak": (_event, id) => invokeResult("habit.streak", { id }),
+    "todu:habit:history": (_event, id, days) => invokeResult("habit.history", { id, days }),
+
+    // ── Sync ──────────────────────────────────────────────────────────────
+    "todu:sync:status": () => invokeRaw("sync.status"),
+    "todu:sync:start": () => invokeRaw("sync.start"),
+    "todu:sync:stop": () => invokeRaw("sync.stop"),
+    "todu:sync:catalog-id": () => invokeRaw("sync.catalogId"),
+
+    // Join flow: Device B writes Device A's catalog document ID to the
+    // marker file and restarts so the engine picks it up on next launch.
+    //
+    // Basic format guard: Automerge document IDs are URL-safe base58/base64
+    // strings of ~22+ characters. Reject obviously malformed input to avoid
+    // restarting into a broken state that requires manual file recovery.
+    "todu:sync:join": (_event, catalogId: unknown) => {
+      if (typeof catalogId !== "string") {
+        throw new Error("Invalid join code: must be a string");
+      }
+
+      const trimmed = catalogId.trim();
+      if (trimmed.length < 10) {
+        throw new Error("Invalid join code: too short");
+      }
+
+      if (!/^[a-zA-Z0-9+/=_-]+$/.test(trimmed)) {
+        throw new Error("Invalid join code: contains unexpected characters");
+      }
+
+      const markerPath = path.join(options.storagePath, `${CATALOG_DOC_KEY}.id`);
+      fs.writeFileSync(markerPath, trimmed, "utf-8");
+      options.appLifecycle.relaunch();
+      options.appLifecycle.exit(0);
+    },
+  };
+}
+
+async function invokeDaemonResult<T>(
+  daemon: Pick<DaemonConnectionManager, "request">,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<Result<T, ToduError>> {
+  const response = await daemon.request<T>(method, params);
+  if (response.ok) {
+    return ok(response.value);
+  }
+
+  return err(mapDaemonErrorToToduError(method, response.error));
+}
+
+async function invokeDaemonRaw<T>(
+  daemon: Pick<DaemonConnectionManager, "request">,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const response = await daemon.request<T>(method, params);
+  if (response.ok) {
+    return response.value;
+  }
+
+  throw new Error(formatDaemonInvocationError(method, response.error));
+}
+
+export function mapDaemonErrorToToduError(method: string, error: DaemonConnectionError): ToduError {
+  if (error.code === "NOT_FOUND") {
+    return {
+      type: "not-found",
+      entity: stringDetail(error, "entity") ?? inferEntityFromMethod(method),
+      id: stringDetail(error, "id") ?? "unknown",
+    };
+  }
+
+  if (error.code === "VALIDATION_ERROR" || error.code === "BAD_REQUEST") {
+    return {
+      type: "validation",
+      field: stringDetail(error, "field") ?? "request",
+      message: error.message,
+    };
+  }
+
+  return {
+    type: "storage",
+    message: formatDaemonInvocationError(method, error),
+  };
+}
+
+function formatDaemonInvocationError(method: string, error: DaemonConnectionError): string {
+  return `${method} failed (${error.code}): ${error.message}`;
+}
+
+function inferEntityFromMethod(method: string): string {
+  const namespace = method.split(".")[0];
+  return namespace.length > 0 ? namespace : "entity";
+}
+
+function stringDetail(error: DaemonConnectionError, key: string): string | undefined {
+  const value = error.details?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Summary
- migrate Electron main IPC handlers from direct engine namespace calls to daemon RPC invocations
- preserve renderer-facing IPC channel contracts by returning `Result` shapes for project/task/label/note/recurring/habit handlers
- map daemon protocol/transport errors into renderer-consumable `ToduError` variants (`not-found`, `validation`, `storage`)
- keep sync IPC contracts intact (`status`, `start`, `stop`, `catalog-id`) while routing through daemon methods
- add IPC regression tests for routing, error mapping, contract preservation, and join lifecycle behavior
- update Phase 4 plan doc with IPC migration status note

## Testing
- make pre-pr
- npm run test -- packages/electron/src/main/ipc.test.ts packages/electron/src/main/daemon-connection-manager.test.ts packages/electron/src/main/settings.test.ts packages/electron/src/main/oauth.test.ts packages/electron/src/main/agent.test.ts
- npm run --workspace=packages/electron build

Task: #1943
Closes #192
