### PR TITLE
feat: wire daemon events to renderer reactivity

### DIFF
--- a/docs/plans/phase-4-electron-thin-client.md
+++ b/docs/plans/phase-4-electron-thin-client.md
@@ -38,6 +38,10 @@ Migrate Electron to daemon-first architecture by replacing direct engine/storage
    - Preserve renderer invalidation/update behavior from daemon events
    - Maintain sync status indicators from `sync.statusChanged`
 
+   Status update:
+   - Electron main process now subscribes to daemon `data.changed` and `sync.statusChanged` events and forwards them over existing renderer channels (`todu:data:changed`, `todu:sync:status-changed`).
+   - Reconnect path now applies best-effort refresh semantics by forcing renderer data invalidation and requesting fresh `sync.status` snapshot.
+
 5. **Electron daemon-mode tests**
    - Integration tests against daemon harness
    - Reconnect recovery tests

--- a/packages/electron/src/main/change-notifications.test.ts
+++ b/packages/electron/src/main/change-notifications.test.ts
@@ -1,0 +1,120 @@
+import type { BrowserWindow } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildReconnectRefreshEvents,
+  DAEMON_REACTIVE_EVENTS,
+  dispatchRendererEvent,
+  mapDaemonEventToRendererEvent,
+  subscribeRendererToDaemonEvents,
+} from "./change-notifications.js";
+
+describe("change notifications", () => {
+  it("subscribes to daemon data and sync status events", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { subscribed: [...DAEMON_REACTIVE_EVENTS] },
+    });
+
+    await subscribeRendererToDaemonEvents({ request });
+
+    expect(request).toHaveBeenCalledWith("events.subscribe", {
+      events: [...DAEMON_REACTIVE_EVENTS],
+    });
+  });
+
+  it("throws if event subscription fails", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "DAEMON_UNAVAILABLE",
+        message: "socket missing",
+      },
+    });
+
+    await expect(subscribeRendererToDaemonEvents({ request })).rejects.toThrow(
+      "events.subscribe failed (DAEMON_UNAVAILABLE): socket missing",
+    );
+  });
+
+  it("maps daemon event frames to renderer channels", () => {
+    expect(mapDaemonEventToRendererEvent({ event: "data.changed", payload: {} })).toEqual({
+      channel: "todu:data:changed",
+      payload: { type: "catalog" },
+    });
+
+    const statusPayload = {
+      local: { mode: "authority" },
+      remote: { state: "connected" as const, server: "ws://localhost:3030" },
+    };
+    expect(
+      mapDaemonEventToRendererEvent({ event: "sync.statusChanged", payload: statusPayload }),
+    ).toEqual({
+      channel: "todu:sync:status-changed",
+      payload: statusPayload,
+    });
+
+    expect(mapDaemonEventToRendererEvent({ event: "worker.changed", payload: {} })).toBeNull();
+  });
+
+  it("builds reconnect refresh events with best-effort sync status refresh", async () => {
+    const statusPayload = {
+      local: { mode: "authority" },
+      remote: { state: "connected" as const, server: "ws://localhost:3030" },
+    };
+
+    const request = vi.fn().mockResolvedValue({ ok: true, value: statusPayload });
+
+    const refreshEvents = await buildReconnectRefreshEvents({ request });
+
+    expect(request).toHaveBeenCalledWith("sync.status", {});
+    expect(refreshEvents).toEqual([
+      { channel: "todu:data:changed", payload: { type: "catalog" } },
+      { channel: "todu:sync:status-changed", payload: statusPayload },
+    ]);
+  });
+
+  it("keeps reconnect refresh best-effort when sync.status fails", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { code: "TIMEOUT", message: "request timed out" },
+    });
+
+    const refreshEvents = await buildReconnectRefreshEvents({ request });
+
+    expect(refreshEvents).toEqual([{ channel: "todu:data:changed", payload: { type: "catalog" } }]);
+  });
+
+  it("dispatches renderer events only when window is available", () => {
+    const send = vi.fn();
+    const activeWindow = {
+      isDestroyed: () => false,
+      webContents: {
+        send,
+      },
+    } as unknown as BrowserWindow;
+
+    dispatchRendererEvent(activeWindow, {
+      channel: "todu:data:changed",
+      payload: { type: "catalog" },
+    });
+    expect(send).toHaveBeenCalledWith("todu:data:changed", { type: "catalog" });
+
+    const destroyedWindow = {
+      isDestroyed: () => true,
+      webContents: {
+        send,
+      },
+    } as unknown as BrowserWindow;
+
+    dispatchRendererEvent(destroyedWindow, {
+      channel: "todu:sync:status-changed",
+      payload: { remote: { state: "disconnected" } },
+    });
+    dispatchRendererEvent(null, {
+      channel: "todu:sync:status-changed",
+      payload: { remote: { state: "disconnected" } },
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/electron/src/main/change-notifications.ts
+++ b/packages/electron/src/main/change-notifications.ts
@@ -1,31 +1,88 @@
-import type { SyncStatus, Todu } from "@todu/engine";
+import type { SyncStatus } from "@todu/engine";
 import type { BrowserWindow } from "electron";
+import type { DaemonConnectionResult, DaemonEventFrame } from "./daemon-connection-manager.js";
+
+export const DAEMON_REACTIVE_EVENTS = ["data.changed", "sync.statusChanged"] as const;
+
+interface DaemonRequester {
+  request<T>(method: string, params?: Record<string, unknown>): Promise<DaemonConnectionResult<T>>;
+}
+
+export interface RendererEvent {
+  channel: "todu:data:changed" | "todu:sync:status-changed";
+  payload: unknown;
+}
 
 /**
- * Forward engine data changes to the renderer process.
- *
- * Uses coarse-grained invalidation: any change triggers a single
- * "todu:data:changed" event. The renderer invalidates all React Query
- * caches and re-fetches visible data. Simple and correct for single-user.
- *
- * Also forwards remote sync status changes so the renderer can show
- * a connection indicator without polling.
+ * Subscribe Electron renderer reactivity channels to daemon event streams.
  */
-export function setupChangeNotifications(todu: Todu, mainWindow: BrowserWindow): () => void {
-  const unsubscribeData = todu.onChange(() => {
-    if (!mainWindow.isDestroyed()) {
-      mainWindow.webContents.send("todu:data:changed", { type: "catalog" });
-    }
+export async function subscribeRendererToDaemonEvents(requester: DaemonRequester): Promise<void> {
+  const subscribe = await requester.request<{ subscribed: string[] }>("events.subscribe", {
+    events: [...DAEMON_REACTIVE_EVENTS],
   });
 
-  const unsubscribeSync = todu.sync.onStatusChange((status: SyncStatus) => {
-    if (!mainWindow.isDestroyed()) {
-      mainWindow.webContents.send("todu:sync:status-changed", status);
-    }
-  });
+  if (!subscribe.ok) {
+    throw new Error(
+      `events.subscribe failed (${subscribe.error.code}): ${subscribe.error.message}`,
+    );
+  }
+}
 
-  return () => {
-    unsubscribeData();
-    unsubscribeSync();
-  };
+/**
+ * Map daemon event frames into existing renderer IPC channels.
+ */
+export function mapDaemonEventToRendererEvent(event: DaemonEventFrame): RendererEvent | null {
+  if (event.event === "data.changed") {
+    return {
+      channel: "todu:data:changed",
+      payload: { type: "catalog" },
+    };
+  }
+
+  if (event.event === "sync.statusChanged") {
+    return {
+      channel: "todu:sync:status-changed",
+      payload: event.payload,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Reconnect refresh strategy for best-effort daemon event delivery.
+ *
+ * We force a renderer data invalidation event and attempt to refresh sync
+ * status snapshot. If sync.status fails, we keep going with data refresh only.
+ */
+export async function buildReconnectRefreshEvents(
+  requester: DaemonRequester,
+): Promise<RendererEvent[]> {
+  const events: RendererEvent[] = [
+    {
+      channel: "todu:data:changed",
+      payload: { type: "catalog" },
+    },
+  ];
+
+  const status = await requester.request<SyncStatus>("sync.status", {});
+  if (status.ok) {
+    events.push({
+      channel: "todu:sync:status-changed",
+      payload: status.value,
+    });
+  }
+
+  return events;
+}
+
+export function dispatchRendererEvent(
+  mainWindow: BrowserWindow | null,
+  event: RendererEvent,
+): void {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  mainWindow.webContents.send(event.channel, event.payload);
 }

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -2,7 +2,12 @@ import type { Todu } from "@todu/engine";
 import { createTodu } from "@todu/engine";
 import { app, BrowserWindow } from "electron";
 import { setupAgent, teardownAgent } from "./agent.js";
-import { setupChangeNotifications } from "./change-notifications.js";
+import {
+  buildReconnectRefreshEvents,
+  dispatchRendererEvent,
+  mapDaemonEventToRendererEvent,
+  subscribeRendererToDaemonEvents,
+} from "./change-notifications.js";
 import { loadElectronConfig } from "./config.js";
 import {
   createDaemonConnectionManager,
@@ -55,18 +60,27 @@ async function init(): Promise<void> {
   daemonConnectionManager = createDaemonConnectionManager({
     socketPath: resolveDaemonSocketPath(storagePath),
     hooks: {
-      onConnected: async ({ isReconnect, request }) => {
+      onConnected: async ({ request }) => {
         const hello = await request("daemon.hello", {
           protocolVersion: DAEMON_PROTOCOL_VERSION,
         });
         assertRequestOk(hello, "daemon.hello");
 
-        if (isReconnect) {
-          const subscribe = await request("events.subscribe", {
-            events: ["data.changed", "sync.statusChanged"],
-          });
-          assertRequestOk(subscribe, "events.subscribe");
+        await subscribeRendererToDaemonEvents({ request });
+      },
+      onReconnected: async ({ request }) => {
+        const refreshEvents = await buildReconnectRefreshEvents({ request });
+        for (const event of refreshEvents) {
+          dispatchRendererEvent(getMainWindow(), event);
         }
+      },
+      onEvent: (event) => {
+        const rendererEvent = mapDaemonEventToRendererEvent(event);
+        if (!rendererEvent) {
+          return;
+        }
+
+        dispatchRendererEvent(getMainWindow(), rendererEvent);
       },
     },
   });
@@ -89,9 +103,6 @@ async function init(): Promise<void> {
   // Create the main window
   const windowState = restoreWindowState();
   mainWindow = createWindow(windowState);
-
-  // Forward Automerge change events to renderer
-  setupChangeNotifications(todu, mainWindow);
 
   // Initialize settings, OAuth, and agent
   registerSettingsIpc();


### PR DESCRIPTION
## Summary
- wire Electron renderer reactivity to daemon event stream instead of local engine observers
- subscribe to `data.changed` + `sync.statusChanged` on daemon connect and forward to existing renderer channels
- add reconnect refresh behavior (best-effort): force `todu:data:changed` invalidation and refresh `sync.status`
- add unit tests for event subscription, event mapping, reconnect refresh behavior, and guarded renderer dispatch
- update phase 4 plan doc with daemon event wiring status notes

## Testing
- npm run test -- packages/electron/src/main/change-notifications.test.ts packages/electron/src/main/daemon-connection-manager.test.ts
- npm run --workspace=packages/electron build
- make pre-pr

Task: #1944