### PR TITLE
feat: remove electron local ownership startup path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,7 @@ Project context:
 2. **CLI/Electron are thin clients**
    - Clients talk to local daemon only.
    - Clients do not own persistent Automerge storage directly.
+   - Electron main runtime must not initialize local engine ownership paths (for example, no `createTodu()` startup ownership in Electron main process).
 
 3. **Fail-fast client behavior**
    - If local daemon is unavailable, clients fail with clear instructions.

--- a/docs/plans/phase-4-electron-thin-client.md
+++ b/docs/plans/phase-4-electron-thin-client.md
@@ -34,6 +34,10 @@ Migrate Electron to daemon-first architecture by replacing direct engine/storage
    - Remove direct persistent storage ownership assumptions from Electron startup
    - Electron should no longer be local state owner
 
+   Status update:
+   - Electron startup no longer initializes a local engine instance (`createTodu`) and now relies on daemon readiness before opening the runtime UI path.
+   - Startup emits actionable daemon-unavailable guidance (`todu daemon start`) instead of falling back to local ownership.
+
 4. **Reactivity parity**
    - Preserve renderer invalidation/update behavior from daemon events
    - Maintain sync status indicators from `sync.statusChanged`
@@ -68,6 +72,17 @@ Migrate Electron to daemon-first architecture by replacing direct engine/storage
 
 - Temporary daemon unavailability should degrade gracefully
 - UI should recover automatically once connection returns
+
+### Troubleshooting: daemon unavailable at startup
+
+- Electron startup now requires local daemon availability and no longer falls back to local storage ownership.
+- If startup fails with a daemon-unavailable error, start the local daemon first:
+
+```bash
+todu daemon start
+```
+
+- Relaunch Electron after the daemon is running.
 
 ## Acceptance Criteria
 

--- a/packages/electron/src/main/daemon-error-mapping.ts
+++ b/packages/electron/src/main/daemon-error-mapping.ts
@@ -1,0 +1,39 @@
+import type { ToduError } from "@todu/core";
+import type { DaemonConnectionError } from "./daemon-connection-manager.js";
+
+export function mapDaemonErrorToToduError(method: string, error: DaemonConnectionError): ToduError {
+  if (error.code === "NOT_FOUND") {
+    return {
+      type: "not-found",
+      entity: stringDetail(error, "entity") ?? inferEntityFromMethod(method),
+      id: stringDetail(error, "id") ?? "unknown",
+    };
+  }
+
+  if (error.code === "VALIDATION_ERROR" || error.code === "BAD_REQUEST") {
+    return {
+      type: "validation",
+      field: stringDetail(error, "field") ?? "request",
+      message: error.message,
+    };
+  }
+
+  return {
+    type: "storage",
+    message: formatDaemonInvocationError(method, error),
+  };
+}
+
+export function formatDaemonInvocationError(method: string, error: DaemonConnectionError): string {
+  return `${method} failed (${error.code}): ${error.message}`;
+}
+
+function inferEntityFromMethod(method: string): string {
+  const namespace = method.split(".")[0];
+  return namespace.length > 0 ? namespace : "entity";
+}
+
+function stringDetail(error: DaemonConnectionError, key: string): string | undefined {
+  const value = error.details?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/electron/src/main/daemon-startup.test.ts
+++ b/packages/electron/src/main/daemon-startup.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureDaemonReady } from "./daemon-startup.js";
+
+describe("ensureDaemonReady", () => {
+  it("succeeds when daemon.hello succeeds", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { protocolVersion: "1" },
+    });
+
+    await expect(
+      ensureDaemonReady(
+        { request },
+        {
+          protocolVersion: "1",
+          maxAttempts: 1,
+          retryDelayMs: 0,
+        },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(request).toHaveBeenCalledWith("daemon.hello", {
+      protocolVersion: "1",
+    });
+  });
+
+  it("retries and then succeeds", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: "socket missing",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { protocolVersion: "1" },
+      });
+
+    await expect(
+      ensureDaemonReady(
+        { request },
+        {
+          protocolVersion: "1",
+          maxAttempts: 2,
+          retryDelayMs: 0,
+        },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws actionable error when daemon stays unavailable", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "DAEMON_UNAVAILABLE",
+        message: "socket missing",
+      },
+    });
+
+    await expect(
+      ensureDaemonReady(
+        { request },
+        {
+          protocolVersion: "1",
+          maxAttempts: 2,
+          retryDelayMs: 0,
+        },
+      ),
+    ).rejects.toThrow(
+      "Local daemon is required but unavailable (DAEMON_UNAVAILABLE: socket missing). Start it with 'todu daemon start' and relaunch Electron.",
+    );
+  });
+});

--- a/packages/electron/src/main/daemon-startup.ts
+++ b/packages/electron/src/main/daemon-startup.ts
@@ -1,0 +1,43 @@
+import type { DaemonConnectionManager } from "./daemon-connection-manager.js";
+
+export interface EnsureDaemonReadyOptions {
+  protocolVersion: string;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
+
+export async function ensureDaemonReady(
+  daemon: Pick<DaemonConnectionManager, "request">,
+  options: EnsureDaemonReadyOptions,
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? 10;
+  const retryDelayMs = options.retryDelayMs ?? 200;
+
+  let lastError = "unknown daemon error";
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const hello = await daemon.request<{ protocolVersion: string }>("daemon.hello", {
+      protocolVersion: options.protocolVersion,
+    });
+
+    if (hello.ok) {
+      return;
+    }
+
+    lastError = `${hello.error.code}: ${hello.error.message}`;
+
+    if (attempt < maxAttempts) {
+      await wait(retryDelayMs);
+    }
+  }
+
+  throw new Error(
+    `Local daemon is required but unavailable (${lastError}). Start it with 'todu daemon start' and relaunch Electron.`,
+  );
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDaemonToduClient } from "./daemon-todu-client.js";
+
+describe("createDaemonToduClient", () => {
+  it("routes task.list to daemon RPC and preserves Result shape", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [{ id: "task-1", title: "Demo", status: "active" }],
+    });
+
+    const client = createDaemonToduClient({ request });
+
+    const result = await client.task.list({ status: ["active"] }, { field: "title" });
+
+    expect(request).toHaveBeenCalledWith("task.list", {
+      filter: { status: ["active"] },
+      sort: { field: "title" },
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: [{ id: "task-1", title: "Demo", status: "active" }],
+    });
+  });
+
+  it("maps daemon NOT_FOUND errors to not-found ToduError", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "task not found: task-9",
+        details: {
+          entity: "task",
+          id: "task-9",
+        },
+      },
+    });
+
+    const client = createDaemonToduClient({ request });
+
+    const result = await client.task.get("task-9");
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: "not-found",
+        entity: "task",
+        id: "task-9",
+      },
+    });
+  });
+
+  it("maps daemon transport errors to storage ToduError", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "DAEMON_UNAVAILABLE",
+        message: "socket missing",
+      },
+    });
+
+    const client = createDaemonToduClient({ request });
+
+    const result = await client.project.list();
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        type: "storage",
+        message: "project.list failed (DAEMON_UNAVAILABLE): socket missing",
+      },
+    });
+  });
+});

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -1,0 +1,98 @@
+import { err, ok, type Result, type ToduError } from "@todu/core";
+import type { Todu } from "@todu/engine";
+import type { DaemonConnectionManager } from "./daemon-connection-manager.js";
+import { mapDaemonErrorToToduError } from "./daemon-error-mapping.js";
+
+interface DaemonBackedToduMethods {
+  project: {
+    list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    get(id: string): Promise<Result<unknown, ToduError>>;
+    create(input: unknown): Promise<Result<unknown, ToduError>>;
+    update(id: string, input: unknown): Promise<Result<unknown, ToduError>>;
+  };
+  task: {
+    list(filter?: unknown, sort?: unknown): Promise<Result<unknown, ToduError>>;
+    get(id: string): Promise<Result<unknown, ToduError>>;
+    create(input: unknown): Promise<Result<unknown, ToduError>>;
+    update(id: string, input: unknown): Promise<Result<unknown, ToduError>>;
+    move(id: string, projectId: string): Promise<Result<unknown, ToduError>>;
+    search(query: string): Promise<Result<unknown, ToduError>>;
+  };
+  label: {
+    list(): Promise<Result<unknown, ToduError>>;
+    create(input: unknown): Promise<Result<unknown, ToduError>>;
+  };
+  note: {
+    list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    create(input: unknown): Promise<Result<unknown, ToduError>>;
+  };
+  recurring: {
+    list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    get(id: string): Promise<Result<unknown, ToduError>>;
+    upcoming(options?: unknown): Promise<Result<unknown, ToduError>>;
+  };
+  habit: {
+    list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    get(id: string): Promise<Result<unknown, ToduError>>;
+    check(id: string): Promise<Result<unknown, ToduError>>;
+    streak(id: string): Promise<Result<unknown, ToduError>>;
+    history(id: string, days?: number): Promise<Result<unknown, ToduError>>;
+  };
+}
+
+export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "request">): Todu {
+  const invoke = <T>(method: string, params: Record<string, unknown> = {}) =>
+    invokeDaemonResult<T>(daemon, method, params);
+
+  const client: DaemonBackedToduMethods = {
+    project: {
+      list: (filter) => invoke("project.list", { filter }),
+      get: (id) => invoke("project.get", { id }),
+      create: (input) => invoke("project.create", { input }),
+      update: (id, input) => invoke("project.update", { id, input }),
+    },
+    task: {
+      list: (filter, sort) => invoke("task.list", { filter, sort }),
+      get: (id) => invoke("task.get", { id }),
+      create: (input) => invoke("task.create", { input }),
+      update: (id, input) => invoke("task.update", { id, input }),
+      move: (id, projectId) => invoke("task.move", { id, projectId }),
+      search: (query) => invoke("task.search", { query }),
+    },
+    label: {
+      list: () => invoke("label.list", {}),
+      create: (input) => invoke("label.create", { input }),
+    },
+    note: {
+      list: (filter) => invoke("note.list", { filter }),
+      create: (input) => invoke("note.create", { input }),
+    },
+    recurring: {
+      list: (filter) => invoke("recurring.list", { filter }),
+      get: (id) => invoke("recurring.get", { id }),
+      upcoming: (options) => invoke("recurring.upcoming", { options }),
+    },
+    habit: {
+      list: (filter) => invoke("habit.list", { filter }),
+      get: (id) => invoke("habit.get", { id }),
+      check: (id) => invoke("habit.check", { id }),
+      streak: (id) => invoke("habit.streak", { id }),
+      history: (id, days) => invoke("habit.history", { id, days }),
+    },
+  };
+
+  return client as unknown as Todu;
+}
+
+async function invokeDaemonResult<T>(
+  daemon: Pick<DaemonConnectionManager, "request">,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<Result<T, ToduError>> {
+  const response = await daemon.request<T>(method, params);
+  if (response.ok) {
+    return ok(response.value);
+  }
+
+  return err(mapDaemonErrorToToduError(method, response.error));
+}

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1,5 +1,3 @@
-import type { Todu } from "@todu/engine";
-import { createTodu } from "@todu/engine";
 import { app, BrowserWindow } from "electron";
 import { setupAgent, teardownAgent } from "./agent.js";
 import {
@@ -16,6 +14,8 @@ import {
   type DaemonConnectionResult,
   resolveDaemonSocketPath,
 } from "./daemon-connection-manager.js";
+import { ensureDaemonReady } from "./daemon-startup.js";
+import { createDaemonToduClient } from "./daemon-todu-client.js";
 import { registerIpcHandlers } from "./ipc.js";
 import { registerOAuthIpc, unregisterOAuthIpc } from "./oauth.js";
 
@@ -25,7 +25,6 @@ import { destroyTray, setupTray } from "./tray.js";
 import { createWindow, restoreWindowState, saveWindowState } from "./window.js";
 
 let mainWindow: BrowserWindow | null = null;
-let todu: Todu | null = null;
 let daemonConnectionManager: DaemonConnectionManager | null = null;
 let isQuitting = false;
 
@@ -54,8 +53,7 @@ function assertRequestOk<T>(
 }
 
 async function init(): Promise<void> {
-  // Load full config (data dir + remote sync) using the same config chain as CLI
-  const { storagePath, remoteSync } = loadElectronConfig();
+  const { storagePath } = loadElectronConfig();
 
   daemonConnectionManager = createDaemonConnectionManager({
     socketPath: resolveDaemonSocketPath(storagePath),
@@ -86,13 +84,11 @@ async function init(): Promise<void> {
   });
   daemonConnectionManager.start();
 
-  // Initialize engine with sync server so CLI can connect,
-  // and connect to remote sync server if configured
-  todu = await createTodu({
-    storagePath,
-    syncServer: true,
-    remoteSync: remoteSync ?? undefined,
+  await ensureDaemonReady(daemonConnectionManager, {
+    protocolVersion: DAEMON_PROTOCOL_VERSION,
   });
+
+  const daemonTodu = createDaemonToduClient(daemonConnectionManager);
 
   // Register all IPC handlers
   registerIpcHandlers({
@@ -107,10 +103,10 @@ async function init(): Promise<void> {
   // Initialize settings, OAuth, and agent
   registerSettingsIpc();
   registerOAuthIpc(mainWindow);
-  setupAgent(todu, mainWindow);
+  setupAgent(daemonTodu, mainWindow);
 
   // Set up system tray
-  setupTray(todu, getMainWindow, () => showWindowWithAction("new-task"));
+  setupTray(daemonTodu, getMainWindow, () => showWindowWithAction("new-task"));
 
   // Register global shortcuts
   registerGlobalShortcuts(getMainWindow);
@@ -136,7 +132,13 @@ async function init(): Promise<void> {
   });
 }
 
-app.whenReady().then(init);
+app
+  .whenReady()
+  .then(init)
+  .catch((error) => {
+    console.error(error);
+    app.quit();
+  });
 
 // Mark as quitting so the close handler allows it through
 app.on("before-quit", () => {
@@ -155,10 +157,6 @@ app.on("window-all-closed", async () => {
   daemonConnectionManager?.stop();
   daemonConnectionManager = null;
 
-  if (todu) {
-    await todu.close();
-    todu = null;
-  }
   app.quit();
 });
 
@@ -169,7 +167,7 @@ app.on("will-quit", () => {
 
 app.on("activate", () => {
   // macOS: re-create window when dock icon clicked
-  if (BrowserWindow.getAllWindows().length === 0 && todu) {
+  if (BrowserWindow.getAllWindows().length === 0) {
     const windowState = restoreWindowState();
     mainWindow = createWindow(windowState);
   } else if (mainWindow && !mainWindow.isVisible()) {

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -2,10 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { CATALOG_DOC_KEY, err, ok, type Result, type ToduError } from "@todu/core";
 import { app, ipcMain } from "electron";
-import type {
-  DaemonConnectionError,
-  DaemonConnectionManager,
-} from "./daemon-connection-manager.js";
+import type { DaemonConnectionManager } from "./daemon-connection-manager.js";
+import { formatDaemonInvocationError, mapDaemonErrorToToduError } from "./daemon-error-mapping.js";
 
 interface IpcAppLifecycle {
   relaunch(): void;
@@ -22,6 +20,8 @@ interface CreateDaemonIpcHandlersOptions extends RegisterIpcHandlersOptions {
 }
 
 type IpcHandler = (_event: unknown, ...args: unknown[]) => Promise<unknown> | unknown;
+
+export { mapDaemonErrorToToduError };
 
 /**
  * Register all IPC handlers for renderer API channels.
@@ -162,41 +162,4 @@ async function invokeDaemonRaw<T>(
   }
 
   throw new Error(formatDaemonInvocationError(method, response.error));
-}
-
-export function mapDaemonErrorToToduError(method: string, error: DaemonConnectionError): ToduError {
-  if (error.code === "NOT_FOUND") {
-    return {
-      type: "not-found",
-      entity: stringDetail(error, "entity") ?? inferEntityFromMethod(method),
-      id: stringDetail(error, "id") ?? "unknown",
-    };
-  }
-
-  if (error.code === "VALIDATION_ERROR" || error.code === "BAD_REQUEST") {
-    return {
-      type: "validation",
-      field: stringDetail(error, "field") ?? "request",
-      message: error.message,
-    };
-  }
-
-  return {
-    type: "storage",
-    message: formatDaemonInvocationError(method, error),
-  };
-}
-
-function formatDaemonInvocationError(method: string, error: DaemonConnectionError): string {
-  return `${method} failed (${error.code}): ${error.message}`;
-}
-
-function inferEntityFromMethod(method: string): string {
-  const namespace = method.split(".")[0];
-  return namespace.length > 0 ? namespace : "entity";
-}
-
-function stringDetail(error: DaemonConnectionError, key: string): string | undefined {
-  const value = error.details?.[key];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Summary
- remove Electron local ownership startup path (`createTodu`) from main runtime
- require daemon readiness during startup via `daemon.hello` gate before initializing UI runtime path
- add daemon-backed client adapter for agent/tray integrations so they use daemon RPC instead of local engine ownership
- share daemon error-to-`ToduError` mapping between IPC handlers and daemon-backed runtime helpers
- add daemon-mode startup and daemon-backed client tests
- update architecture + phase docs, including daemon-unavailable startup troubleshooting guidance

## Testing
- npm run test -- packages/electron/src/main/daemon-todu-client.test.ts packages/electron/src/main/daemon-startup.test.ts packages/electron/src/main/change-notifications.test.ts packages/electron/src/main/daemon-connection-manager.test.ts packages/electron/src/main/ipc.test.ts packages/electron/src/main/tools.test.ts
- make pre-pr

Task: #1945
