### PR TITLE
feat: daemon transactional join check/switch rollback (task #1947)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This project uses an AI-first development process. Agents do the work, automatio
 2. Read relevant files before editing.
 3. Make the smallest change that satisfies the task.
 4. Follow [CODE_STANDARDS.md](CODE_STANDARDS.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
-5. Set task status to `inprogress` when implementation starts.
+5. Use the `task-update` skill to set task status to `inprogress` when implementation starts.
 6. If blocked, ambiguous, or conflicting requirements are found, stop and report `BLOCKED` with reason.
 7. Add task comments only via the `task-comment-create` skill.
 8. Do not add manual line breaks in markdown paragraphs.

--- a/docs/plans/phase-5-join-safety.md
+++ b/docs/plans/phase-5-join-safety.md
@@ -73,6 +73,33 @@ CLI output should clearly indicate:
 - target catalog ID
 - success or rollback outcome
 
+### Daemon join API behavior (Phase 5 implementation)
+
+Daemon exposes `sync.join` with params:
+- `catalogId` (required string)
+- `check` (optional boolean, default `false`)
+
+Behavior:
+- `check=true`: validation-only path (format + reachability), no catalog pointer switch
+- `check=false`: transactional switch path using marker snapshot + rollback on failure
+
+Result shape:
+- `mode`: `check` | `join`
+- `previousCatalogId`
+- `targetCatalogId`
+- `switched`
+- `rolledBack`
+
+### Join error semantics
+
+Join failures return `JOIN_FAILED` with structured details:
+- `stage=validate-format` for malformed join codes
+- `stage=validate-reachability` when target catalog cannot be loaded
+- `stage=switch` when transactional switch fails and rollback restores previous catalog
+- `stage=rollback-restore` when switch fails and runtime recovery also fails
+
+Details include relevant catalog IDs (`previousCatalogId`, `targetCatalogId`) and failure context (`cause`/`restoreError`) for operator troubleshooting.
+
 ### Host/context rule
 
 Join is per daemon instance, not per app.

--- a/packages/daemon/src/protocol-conformance.test.ts
+++ b/packages/daemon/src/protocol-conformance.test.ts
@@ -240,6 +240,26 @@ describe("daemon protocol conformance suite", () => {
 
       expect(typeof syncCatalog.result).toBe("string");
       expect((syncCatalog.result as string).length).toBeGreaterThan(0);
+
+      const joinCheck = await sendRequest(runtime.config().socketPath, {
+        id: "sync-join-check-conformance",
+        method: "sync.join",
+        params: {
+          catalogId: syncCatalog.result,
+          check: true,
+        },
+      });
+
+      expect(joinCheck).toEqual({
+        id: "sync-join-check-conformance",
+        result: {
+          mode: "check",
+          previousCatalogId: syncCatalog.result,
+          targetCatalogId: syncCatalog.result,
+          switched: false,
+          rolledBack: false,
+        },
+      });
     });
   });
 

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -59,7 +59,7 @@ export const CORE_DAEMON_NAMESPACE_METHODS = {
     "streak",
     "history",
   ],
-  sync: ["start", "stop", "status", "catalogId"],
+  sync: ["start", "stop", "status", "catalogId", "join"],
 } as const;
 
 export const RESERVED_DAEMON_NAMESPACES = ["worker"] as const;

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -2,7 +2,9 @@ import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type CatalogDocument, createEmptyCatalog } from "@todu/core";
+import * as engine from "@todu/engine";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProtocolSuccessFrame } from "./protocol.js";
 import {
   DAEMON_CAPABILITY_EVENTS,
@@ -80,7 +82,7 @@ describe("createDaemonRuntime", () => {
     });
 
     expect(DAEMON_CAPABILITY_METHODS).toEqual(
-      expect.arrayContaining(["recurring.process", "habit.history", "sync.catalogId"]),
+      expect.arrayContaining(["recurring.process", "habit.history", "sync.catalogId", "sync.join"]),
     );
 
     await runtime.stop();
@@ -845,6 +847,132 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
+  it("supports sync.join check mode without switching catalog pointer", async () => {
+    const alternateCatalogId = await createAlternateCatalogDocument(tmpDir);
+    const markerPath = path.join(tmpDir, "todu-catalog.id");
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const previousCatalogId = runtime.status().catalogId;
+    if (!previousCatalogId) {
+      throw new Error("Expected runtime catalog id");
+    }
+
+    const checkResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-join-check-1",
+      method: "sync.join",
+      params: {
+        catalogId: alternateCatalogId,
+        check: true,
+      },
+    });
+
+    expect(checkResponse).toEqual({
+      id: "sync-join-check-1",
+      result: {
+        mode: "check",
+        previousCatalogId,
+        targetCatalogId: alternateCatalogId,
+        switched: false,
+        rolledBack: false,
+      },
+    });
+
+    expect(runtime.status().catalogId).toBe(previousCatalogId);
+    expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(previousCatalogId);
+
+    await runtime.stop();
+  });
+
+  it("switches catalog pointer transactionally on sync.join success", async () => {
+    const alternateCatalogId = await createAlternateCatalogDocument(tmpDir);
+    const markerPath = path.join(tmpDir, "todu-catalog.id");
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const previousCatalogId = runtime.status().catalogId;
+    if (!previousCatalogId) {
+      throw new Error("Expected runtime catalog id");
+    }
+
+    const joinResponse = await sendRequest(runtime.config().socketPath, {
+      id: "sync-join-1",
+      method: "sync.join",
+      params: {
+        catalogId: alternateCatalogId,
+      },
+    });
+
+    expect(joinResponse).toEqual({
+      id: "sync-join-1",
+      result: {
+        mode: "join",
+        previousCatalogId,
+        targetCatalogId: alternateCatalogId,
+        switched: true,
+        rolledBack: false,
+      },
+    });
+
+    expect(runtime.status().catalogId).toBe(alternateCatalogId);
+    expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(alternateCatalogId);
+
+    await runtime.stop();
+  });
+
+  it("rolls back marker and preserves prior dataset when sync.join switch fails", async () => {
+    const alternateCatalogId = await createAlternateCatalogDocument(tmpDir);
+    const markerPath = path.join(tmpDir, "todu-catalog.id");
+    const originalCreateTodu = engine.createTodu;
+    const createToduSpy = vi.spyOn(engine, "createTodu");
+
+    let createInvocation = 0;
+    createToduSpy.mockImplementation(async (config) => {
+      createInvocation += 1;
+      if (createInvocation === 2) {
+        throw new Error("simulated join switch failure");
+      }
+      return originalCreateTodu(config);
+    });
+
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    try {
+      await runtime.start();
+
+      const previousCatalogId = runtime.status().catalogId;
+      if (!previousCatalogId) {
+        throw new Error("Expected runtime catalog id");
+      }
+
+      const joinResponse = await sendRequest(runtime.config().socketPath, {
+        id: "sync-join-fail-1",
+        method: "sync.join",
+        params: {
+          catalogId: alternateCatalogId,
+        },
+      });
+
+      expect(joinResponse.id).toBe("sync-join-fail-1");
+      expect(joinResponse.error).toMatchObject({
+        code: "JOIN_FAILED",
+        details: {
+          stage: "switch",
+          previousCatalogId,
+          targetCatalogId: alternateCatalogId,
+        },
+      });
+
+      expect(runtime.status().catalogId).toBe(previousCatalogId);
+      expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(previousCatalogId);
+    } finally {
+      await runtime.stop();
+      createToduSpy.mockRestore();
+    }
+  });
+
   it("maps domain and request validation errors for project/task/label/note/recurring/habit/sync methods", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
@@ -1141,6 +1269,31 @@ describe("createDaemonRuntime", () => {
     await expect(runtime.stop()).resolves.toBeUndefined();
   });
 });
+
+async function createAlternateCatalogDocument(storagePath: string): Promise<string> {
+  const storage = await engine.initBootstrapStorage(storagePath);
+
+  try {
+    const alternateCatalog = storage.repo.create<CatalogDocument>();
+    alternateCatalog.change((doc: CatalogDocument) => {
+      const empty = createEmptyCatalog();
+      doc.version = empty.version;
+      doc.projects = empty.projects;
+      doc.labels = empty.labels;
+      doc.recurringTemplates = empty.recurringTemplates;
+      doc.habits = empty.habits;
+      doc.habitLogDocIds = empty.habitLogDocIds;
+      doc.taskListDocIds = empty.taskListDocIds;
+      doc.settings = empty.settings;
+    });
+
+    await storage.repo.flush();
+
+    return alternateCatalog.documentId;
+  } finally {
+    await storage.close();
+  }
+}
 
 function sendRequest(
   socketPath: string,

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,5 +1,6 @@
+import type { DocumentId } from "@automerge/automerge-repo";
 import { type RemoteSyncConfig, resolveStoragePath } from "@todu/core";
-import { createTodu, type Todu } from "@todu/engine";
+import { beginCatalogJoinSwitch, createTodu, initJoinStorage, type Todu } from "@todu/engine";
 import { createCoreNamespaceHandlers, mergeNamespaceHandlerSets } from "./core-rpc-adapters.js";
 import {
   createDaemonLogger,
@@ -7,6 +8,12 @@ import {
   type DaemonLogLevel,
   resolveDaemonLogLevelFromEnv,
 } from "./logger.js";
+import {
+  createProtocolError,
+  createProtocolErrorFrame,
+  createProtocolSuccessFrame,
+  type ProtocolRequestFrame,
+} from "./protocol.js";
 import {
   createDaemonRpcRouter,
   type DaemonRpcMethodHandler,
@@ -71,6 +78,14 @@ export interface DaemonRuntime {
   config(): ResolvedDaemonRuntimeConfig;
 }
 
+interface JoinOperationResult {
+  mode: "check" | "join";
+  previousCatalogId: string;
+  targetCatalogId: string;
+  switched: boolean;
+  rolledBack: boolean;
+}
+
 export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRuntime {
   const resolvedStoragePath = config.storagePath ?? resolveStoragePath();
   const resolvedSocketPath = resolveUdsSocketPath(resolvedStoragePath, config.socketPath);
@@ -94,6 +109,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   let todu: Todu | null = null;
   let startPromise: Promise<DaemonRuntimeStatus> | null = null;
   let stopPromise: Promise<void> | null = null;
+  let joinPromise: Promise<JoinOperationResult> | null = null;
   let changeSubscriptionCleanup: (() => void) | null = null;
   let syncStatusSubscriptionCleanup: (() => void) | null = null;
 
@@ -102,16 +118,19 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     role: resolvedConfig.role,
   };
 
-  const defaultNamespaceHandlers = createCoreNamespaceHandlers({
-    getTodu: () => todu,
-  });
-
   const runtimeLogger =
     config.logger ??
     createDaemonLogger({
       component: "daemon.runtime",
       level: resolvedConfig.logLevel,
     });
+
+  const defaultNamespaceHandlers = mergeNamespaceHandlerSets(
+    createCoreNamespaceHandlers({
+      getTodu: () => todu,
+    }),
+    createJoinSyncNamespaceHandlers(),
+  );
 
   const rpcLogger = runtimeLogger.child("rpc");
 
@@ -161,6 +180,22 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     }
   }
 
+  function attachEventSubscriptions(activeTodu: Todu): void {
+    clearEventSubscriptions();
+
+    changeSubscriptionCleanup = activeTodu.onChange(() => {
+      rpcRouter.dispatchEvent("data.changed", {
+        catalog: {
+          id: todu?.sync.getCatalogId() ?? runtimeStatus.catalogId ?? null,
+        },
+      });
+    });
+
+    syncStatusSubscriptionCleanup = activeTodu.sync.onStatusChange((status) => {
+      rpcRouter.dispatchEvent("sync.statusChanged", status);
+    });
+  }
+
   function cloneStatus(): DaemonRuntimeStatus {
     return {
       state: runtimeStatus.state,
@@ -181,27 +216,18 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     try {
       const endpoint = await transport.start();
 
-      todu = await createTodu({
+      const startedTodu = await createTodu({
         storagePath: resolvedConfig.storagePath,
         remoteSync: resolvedConfig.remoteSync,
       });
 
+      todu = startedTodu;
       runtimeStatus.state = "running";
       runtimeStatus.startedAt = new Date().toISOString();
-      runtimeStatus.catalogId = todu.sync.getCatalogId();
+      runtimeStatus.catalogId = startedTodu.sync.getCatalogId();
       runtimeStatus.transport = endpoint;
 
-      changeSubscriptionCleanup = todu.onChange(() => {
-        rpcRouter.dispatchEvent("data.changed", {
-          catalog: {
-            id: todu?.sync.getCatalogId() ?? runtimeStatus.catalogId ?? null,
-          },
-        });
-      });
-
-      syncStatusSubscriptionCleanup = todu.sync.onStatusChange((status) => {
-        rpcRouter.dispatchEvent("sync.statusChanged", status);
-      });
+      attachEventSubscriptions(startedTodu);
 
       runtimeLogger.info("daemon runtime started", {
         role: runtimeStatus.role,
@@ -222,6 +248,223 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
+    }
+  }
+
+  function createJoinSyncNamespaceHandlers(): DaemonRpcNamespaceHandlers {
+    return {
+      sync: {
+        join: async (request) => {
+          const parsedRequest = parseJoinRequest(request);
+          if ("error" in parsedRequest) {
+            return parsedRequest.error;
+          }
+
+          if (joinPromise) {
+            return createProtocolErrorFrame(
+              request.id,
+              createProtocolError("CONFLICT", "Join operation already in progress", {
+                method: request.method,
+              }),
+            );
+          }
+
+          joinPromise = executeJoinOperation(
+            parsedRequest.targetCatalogId,
+            parsedRequest.checkOnly,
+          );
+
+          try {
+            const result = await joinPromise;
+            return createProtocolSuccessFrame(request.id, result);
+          } catch (error) {
+            return createProtocolErrorFrame(request.id, error);
+          } finally {
+            joinPromise = null;
+          }
+        },
+      },
+    };
+  }
+
+  function parseJoinRequest(request: ProtocolRequestFrame):
+    | {
+        targetCatalogId: string;
+        checkOnly: boolean;
+      }
+    | {
+        error: ReturnType<typeof createProtocolErrorFrame>;
+      } {
+    const catalogIdParam = request.params.catalogId;
+
+    if (typeof catalogIdParam !== "string" || catalogIdParam.trim().length === 0) {
+      return {
+        error: createProtocolErrorFrame(
+          request.id,
+          createProtocolError("BAD_REQUEST", "sync.join requires params.catalogId string", {
+            field: "catalogId",
+          }),
+        ),
+      };
+    }
+
+    const checkParam = request.params.check;
+    if (checkParam !== undefined && typeof checkParam !== "boolean") {
+      return {
+        error: createProtocolErrorFrame(
+          request.id,
+          createProtocolError("BAD_REQUEST", "sync.join requires params.check boolean", {
+            field: "check",
+          }),
+        ),
+      };
+    }
+
+    const targetCatalogId = catalogIdParam.trim();
+    if (!isValidJoinCodeFormat(targetCatalogId)) {
+      return {
+        error: createProtocolErrorFrame(
+          request.id,
+          createProtocolError("JOIN_FAILED", "Join validation failed", {
+            stage: "validate-format",
+            reason: "invalid_catalog_id_format",
+            targetCatalogId,
+          }),
+        ),
+      };
+    }
+
+    return {
+      targetCatalogId,
+      checkOnly: checkParam === true,
+    };
+  }
+
+  async function executeJoinOperation(
+    targetCatalogId: string,
+    checkOnly: boolean,
+  ): Promise<JoinOperationResult> {
+    if (runtimeStatus.state !== "running" || !todu) {
+      throw createProtocolError("PRECONDITION_FAILED", "Daemon runtime is not ready for join", {
+        state: runtimeStatus.state,
+      });
+    }
+
+    const previousCatalogId = todu.sync.getCatalogId();
+
+    if (targetCatalogId === previousCatalogId) {
+      return {
+        mode: checkOnly ? "check" : "join",
+        previousCatalogId,
+        targetCatalogId,
+        switched: false,
+        rolledBack: false,
+      };
+    }
+
+    await validateJoinTarget(targetCatalogId);
+
+    if (checkOnly) {
+      return {
+        mode: "check",
+        previousCatalogId,
+        targetCatalogId,
+        switched: false,
+        rolledBack: false,
+      };
+    }
+
+    const targetDocumentId = targetCatalogId as DocumentId;
+    const tx = beginCatalogJoinSwitch(resolvedConfig.storagePath, targetDocumentId);
+    const previousTodu = todu;
+
+    try {
+      clearEventSubscriptions();
+      todu = null;
+      await previousTodu.close();
+
+      const joinedTodu = await createTodu({
+        storagePath: resolvedConfig.storagePath,
+        remoteSync: resolvedConfig.remoteSync,
+      });
+
+      todu = joinedTodu;
+      runtimeStatus.catalogId = joinedTodu.sync.getCatalogId();
+      attachEventSubscriptions(joinedTodu);
+      tx.commit();
+
+      return {
+        mode: "join",
+        previousCatalogId,
+        targetCatalogId,
+        switched: runtimeStatus.catalogId === targetCatalogId,
+        rolledBack: false,
+      };
+    } catch (error) {
+      tx.rollback();
+
+      let restoredCatalogId = previousCatalogId;
+      try {
+        const restoredTodu = await createTodu({
+          storagePath: resolvedConfig.storagePath,
+          remoteSync: resolvedConfig.remoteSync,
+        });
+        todu = restoredTodu;
+        runtimeStatus.catalogId = restoredTodu.sync.getCatalogId();
+        restoredCatalogId = runtimeStatus.catalogId;
+        attachEventSubscriptions(restoredTodu);
+      } catch (restoreError) {
+        runtimeLogger.error("daemon join rollback restore failed", {
+          previousCatalogId,
+          targetCatalogId,
+          switchError: getErrorMessage(error),
+          restoreError: getErrorMessage(restoreError),
+        });
+
+        todu = null;
+        clearEventSubscriptions();
+        runtimeStatus.catalogId = undefined;
+
+        throw createProtocolError(
+          "JOIN_FAILED",
+          "Join failed and rollback restore could not recover runtime",
+          {
+            stage: "rollback-restore",
+            previousCatalogId,
+            targetCatalogId,
+            switchError: getErrorMessage(error),
+            restoreError: getErrorMessage(restoreError),
+          },
+        );
+      }
+
+      throw createProtocolError(
+        "JOIN_FAILED",
+        "Join switch failed; rolled back to previous catalog",
+        {
+          stage: "switch",
+          previousCatalogId,
+          targetCatalogId,
+          restoredCatalogId,
+          cause: getErrorMessage(error),
+        },
+      );
+    }
+  }
+
+  async function validateJoinTarget(targetCatalogId: string): Promise<void> {
+    try {
+      const validationStorage = await initJoinStorage(
+        resolvedConfig.storagePath,
+        targetCatalogId as DocumentId,
+      );
+      await validationStorage.close();
+    } catch (error) {
+      throw createProtocolError("JOIN_FAILED", "Join validation failed", {
+        stage: "validate-reachability",
+        targetCatalogId,
+        cause: getErrorMessage(error),
+      });
     }
   }
 
@@ -306,6 +549,22 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       };
     },
   };
+}
+
+function isValidJoinCodeFormat(value: string): boolean {
+  if (value.length < 10) {
+    return false;
+  }
+
+  return /^[a-zA-Z0-9+/=_-]+$/.test(value);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {


### PR DESCRIPTION
## Summary
- add daemon-owned `sync.join` RPC method with validation-only (`check=true`) and transactional switch modes
- implement join pointer switch via storage transaction (`beginCatalogJoinSwitch`) with rollback + runtime restore on failure
- return structured `JOIN_FAILED` details by failure stage (`validate-format`, `validate-reachability`, `switch`, `rollback-restore`)
- advertise `sync.join` in daemon capabilities and add tests for check, success switch, and rollback preservation
- document phase-5 daemon join API behavior and join error semantics

## Verification
- `npm run --workspace=packages/daemon typecheck`
- `npm run test -- packages/daemon/src/runtime.test.ts packages/daemon/src/protocol-conformance.test.ts`
- `npm run test -- packages/daemon/src/rpc.test.ts packages/daemon/src/daemon-engine-parity.test.ts`
- `make pre-pr`

Refs: #1947
