### PR TITLE
feat(1948): wire CLI and Electron join flows to daemon sync.join

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -82,6 +82,26 @@ toduai --format json daemon status
 
 If the daemon is healthy, status reports `running: true` and includes daemon health details.
 
+## Join operations (per host daemon)
+
+Use daemon-owned join flows from CLI:
+
+```bash
+toduai sync join <catalogId> --check
+toduai sync join <catalogId>
+toduai sync join <catalogId> --yes
+```
+
+Behavior:
+- `--check` validates format + reachability only (no catalog switch)
+- default join prompts for confirmation before transactional switch
+- `--yes` skips confirmation for non-interactive automation
+- result output includes previous/target catalog context and switch/rollback outcome
+
+Operational note:
+- Join is scoped to the local daemon instance.
+- For multi-host setups, run join separately in each host/context that should switch datasets.
+
 ## Expected fail-fast errors
 
 ### Daemon unavailable

--- a/docs/plans/phase-5-join-safety.md
+++ b/docs/plans/phase-5-join-safety.md
@@ -61,6 +61,10 @@ On failure:
 - show explicit error
 - dataset remains unchanged
 
+Implementation note:
+- Electron Settings uses daemon `sync.join` for both validate and join actions.
+- Electron no longer writes catalog marker files directly.
+
 ### CLI UX
 
 - `toduai sync status` — show daemon/catalog state
@@ -72,6 +76,11 @@ CLI output should clearly indicate:
 - previous catalog ID
 - target catalog ID
 - success or rollback outcome
+
+Implementation note:
+- `toduai sync join <catalogId> --check` calls daemon `sync.join` with `check=true`
+- `toduai sync join <catalogId>` performs validation first, prompts for confirmation, then calls daemon `sync.join`
+- `--yes` skips confirmation for non-interactive flows
 
 ### Daemon join API behavior (Phase 5 implementation)
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -2,11 +2,15 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { type CatalogDocument, createEmptyCatalog } from "@todu/core";
+import * as engine from "@todu/engine";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { invokeDaemonMethod } from "../daemon-transport.js";
 import { type DaemonHandle, startDaemonForTests } from "../test-helpers/daemon-process.js";
 
 describe("sync CLI commands", () => {
   let tmpDir: string;
+  let alternateCatalogId: string;
   let daemon: DaemonHandle | null = null;
   const rootDir = path.resolve(__dirname, "../../../..");
   const cliPath = path.resolve(rootDir, "packages/cli/dist/index.js");
@@ -17,6 +21,7 @@ describe("sync CLI commands", () => {
 
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-sync-test-"));
+    alternateCatalogId = await createAlternateCatalogDocument(tmpDir);
     daemon = await startDaemonForTests(rootDir, tmpDir);
   });
 
@@ -60,6 +65,44 @@ describe("sync CLI commands", () => {
     expect(status.remote.state).toBe("disconnected");
   });
 
+  it("sync join --check validates target via daemon without switching catalog", async () => {
+    const initialCatalogId = await readCatalogId(tmpDir);
+    const targetCatalogId = alternateCatalogId;
+
+    const output = run(`sync join ${targetCatalogId} --check --format json`);
+    const result = JSON.parse(output);
+
+    expect(result).toEqual({
+      mode: "check",
+      previousCatalogId: initialCatalogId,
+      targetCatalogId,
+      switched: false,
+      rolledBack: false,
+    });
+
+    const afterCatalogId = await readCatalogId(tmpDir);
+    expect(afterCatalogId).toBe(initialCatalogId);
+  });
+
+  it("sync join --yes switches catalog via daemon", async () => {
+    const initialCatalogId = await readCatalogId(tmpDir);
+    const targetCatalogId = alternateCatalogId;
+
+    const output = run(`sync join ${targetCatalogId} --yes --format json`);
+    const result = JSON.parse(output);
+
+    expect(result).toEqual({
+      mode: "join",
+      previousCatalogId: initialCatalogId,
+      targetCatalogId,
+      switched: true,
+      rolledBack: false,
+    });
+
+    const afterCatalogId = await readCatalogId(tmpDir);
+    expect(afterCatalogId).toBe(targetCatalogId);
+  });
+
   it("fails fast when daemon is unavailable", async () => {
     if (daemon) {
       await daemon.stop("unavailable-test");
@@ -70,3 +113,58 @@ describe("sync CLI commands", () => {
     expect(output).toContain("local daemon is required but unavailable");
   });
 });
+
+async function readCatalogId(storagePath: string): Promise<string> {
+  const socketPath = path.join(storagePath, "daemon.sock");
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const response = await invokeDaemonMethod<string>({
+      socketPath,
+      method: "sync.catalogId",
+    });
+
+    if (response.ok) {
+      return response.value;
+    }
+
+    if (response.error.message.includes("Daemon runtime is not ready")) {
+      await sleep(100);
+      continue;
+    }
+
+    throw new Error(`sync.catalogId failed: ${response.error.code} ${response.error.message}`);
+  }
+
+  throw new Error("sync.catalogId failed: daemon runtime did not become ready in time");
+}
+
+async function createAlternateCatalogDocument(storagePath: string): Promise<string> {
+  const storage = await engine.initBootstrapStorage(storagePath);
+
+  try {
+    const alternateCatalog = storage.repo.create<CatalogDocument>();
+    alternateCatalog.change((doc: CatalogDocument) => {
+      const empty = createEmptyCatalog();
+      doc.version = empty.version;
+      doc.projects = empty.projects;
+      doc.labels = empty.labels;
+      doc.recurringTemplates = empty.recurringTemplates;
+      doc.habits = empty.habits;
+      doc.habitLogDocIds = empty.habitLogDocIds;
+      doc.taskListDocIds = empty.taskListDocIds;
+      doc.settings = empty.settings;
+    });
+
+    await storage.repo.flush();
+
+    return alternateCatalog.documentId;
+  } finally {
+    await storage.close();
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,3 +1,5 @@
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
 import type { Command } from "commander";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { formatJSON } from "../format.js";
@@ -11,6 +13,20 @@ interface SyncStatus {
     server?: string;
     lastSync?: string;
   };
+}
+
+interface SyncJoinResult {
+  mode: "check" | "join";
+  previousCatalogId: string;
+  targetCatalogId: string;
+  switched: boolean;
+  rolledBack: boolean;
+}
+
+interface DaemonError {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
 }
 
 export function registerSyncCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
@@ -37,7 +53,7 @@ export function registerSyncCommands(program: Command, invokeDaemon: CliDaemonIn
 
       console.log(`Local Mode:   ${status.local.mode}`);
       if (status.local.mode === "ephemeral-client") {
-        console.log(`Remote Sync:  managed by server`);
+        console.log("Remote Sync:  managed by server");
       } else {
         console.log(`Remote Sync:  ${status.remote.state}`);
         if (status.remote.server) {
@@ -48,4 +64,134 @@ export function registerSyncCommands(program: Command, invokeDaemon: CliDaemonIn
         }
       }
     });
+
+  sync
+    .command("join <catalogId>")
+    .description("Validate or join a catalog ID through the local daemon")
+    .option("--check", "validate only; do not switch catalog pointer")
+    .option("--yes", "skip confirmation for join switch")
+    .action(async (catalogId: string, options: { check?: boolean; yes?: boolean }) => {
+      const targetCatalogId = catalogId.trim();
+      if (targetCatalogId.length === 0) {
+        console.error("Error: catalog ID is required");
+        process.exitCode = 1;
+        return;
+      }
+
+      const validation = await invokeDaemon<SyncJoinResult>("sync.join", {
+        catalogId: targetCatalogId,
+        check: true,
+      });
+
+      if (!validation.ok) {
+        console.error(formatJoinError(validation.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      if (options.check) {
+        renderJoinResult(program, validation.value);
+        return;
+      }
+
+      if (!options.yes) {
+        if (!stdin.isTTY || !stdout.isTTY) {
+          console.error("Error: join confirmation requires a TTY. Re-run with --yes.");
+          process.exitCode = 1;
+          return;
+        }
+
+        const confirmed = await confirmJoin(validation.value);
+        if (!confirmed) {
+          console.log("Join canceled.");
+          return;
+        }
+      }
+
+      const joined = await invokeDaemon<SyncJoinResult>("sync.join", {
+        catalogId: targetCatalogId,
+      });
+
+      if (!joined.ok) {
+        console.error(formatJoinError(joined.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      renderJoinResult(program, joined.value);
+    });
+}
+
+function renderJoinResult(program: Command, result: SyncJoinResult): void {
+  const opts = program.opts();
+
+  if (opts.format === "json") {
+    console.log(formatJSON(result));
+    return;
+  }
+
+  if (result.mode === "check") {
+    console.log("Validation:   OK");
+    console.log(`Previous:     ${result.previousCatalogId}`);
+    console.log(`Target:       ${result.targetCatalogId}`);
+    console.log(
+      `Would switch: ${result.previousCatalogId !== result.targetCatalogId ? "yes" : "no"}`,
+    );
+    return;
+  }
+
+  console.log("Join:         completed");
+  console.log(`Previous:     ${result.previousCatalogId}`);
+  console.log(`Target:       ${result.targetCatalogId}`);
+  console.log(`Switched:     ${result.switched ? "yes" : "no"}`);
+  console.log(`Rolled back:  ${result.rolledBack ? "yes" : "no"}`);
+}
+
+function formatJoinError(error: DaemonError): string {
+  if (error.code !== "JOIN_FAILED") {
+    return formatDaemonCommandError(error);
+  }
+
+  const stage = getStringDetail(error.details, "stage");
+  const previousCatalogId = getStringDetail(error.details, "previousCatalogId");
+  const targetCatalogId = getStringDetail(error.details, "targetCatalogId");
+  const cause =
+    getStringDetail(error.details, "cause") ??
+    getStringDetail(error.details, "switchError") ??
+    getStringDetail(error.details, "restoreError");
+
+  const contextParts = [
+    stage ? `stage=${stage}` : null,
+    previousCatalogId ? `previous=${previousCatalogId}` : null,
+    targetCatalogId ? `target=${targetCatalogId}` : null,
+  ].filter((value): value is string => value !== null);
+
+  const context = contextParts.length > 0 ? ` (${contextParts.join(", ")})` : "";
+  const causeText = cause ? ` Cause: ${cause}` : "";
+
+  return `Error: ${error.message}${context}${causeText}`;
+}
+
+function getStringDetail(details: Record<string, unknown> | undefined, key: string): string | null {
+  const value = details?.[key];
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return value;
+}
+
+async function confirmJoin(validation: SyncJoinResult): Promise<boolean> {
+  const rl = createInterface({ input: stdin, output: stdout });
+
+  try {
+    const answer = await rl.question(
+      `Join will switch this daemon from ${validation.previousCatalogId} to ${validation.targetCatalogId}. Continue? [y/N] `,
+    );
+
+    const normalized = answer.trim().toLowerCase();
+    return normalized === "y" || normalized === "yes";
+  } finally {
+    rl.close();
+  }
 }

--- a/packages/cli/src/daemon-command-client.ts
+++ b/packages/cli/src/daemon-command-client.ts
@@ -25,12 +25,54 @@ export function createCliDaemonInvoker(program: Command): CliDaemonInvoker {
   };
 }
 
-export function formatDaemonCommandError(error: { code: string; message: string }): string {
+export function formatDaemonCommandError(error: {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}): string {
   if (error.code === "DAEMON_UNAVAILABLE") {
     return `Error: local daemon is required but unavailable (${error.message}). Start the daemon and retry.`;
   }
 
+  if (error.code === "JOIN_FAILED") {
+    return formatJoinFailedError(error);
+  }
+
   return `Error: ${error.message}`;
+}
+
+function formatJoinFailedError(error: {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}): string {
+  const stage = stringDetail(error.details, "stage");
+  const previousCatalogId = stringDetail(error.details, "previousCatalogId");
+  const targetCatalogId = stringDetail(error.details, "targetCatalogId");
+  const cause =
+    stringDetail(error.details, "cause") ??
+    stringDetail(error.details, "switchError") ??
+    stringDetail(error.details, "restoreError");
+
+  const contextParts = [
+    stage ? `stage=${stage}` : null,
+    previousCatalogId ? `previous=${previousCatalogId}` : null,
+    targetCatalogId ? `target=${targetCatalogId}` : null,
+  ].filter((value): value is string => value !== null);
+
+  const context = contextParts.length > 0 ? ` (${contextParts.join(", ")})` : "";
+  const causeText = cause ? ` Cause: ${cause}` : "";
+
+  return `Error: ${error.message}${context}${causeText}`;
+}
+
+function stringDetail(details: Record<string, unknown> | undefined, key: string): string | null {
+  const value = details?.[key];
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return value;
 }
 
 export function resolveDaemonSocketPath(storagePath: string): string {

--- a/packages/electron/src/main/daemon-error-mapping.ts
+++ b/packages/electron/src/main/daemon-error-mapping.ts
@@ -25,7 +25,28 @@ export function mapDaemonErrorToToduError(method: string, error: DaemonConnectio
 }
 
 export function formatDaemonInvocationError(method: string, error: DaemonConnectionError): string {
-  return `${method} failed (${error.code}): ${error.message}`;
+  if (error.code !== "JOIN_FAILED") {
+    return `${method} failed (${error.code}): ${error.message}`;
+  }
+
+  const stage = stringDetail(error, "stage");
+  const previousCatalogId = stringDetail(error, "previousCatalogId");
+  const targetCatalogId = stringDetail(error, "targetCatalogId");
+  const cause =
+    stringDetail(error, "cause") ??
+    stringDetail(error, "switchError") ??
+    stringDetail(error, "restoreError");
+
+  const contextParts = [
+    stage ? `stage=${stage}` : null,
+    previousCatalogId ? `previous=${previousCatalogId}` : null,
+    targetCatalogId ? `target=${targetCatalogId}` : null,
+  ].filter((value): value is string => value !== null);
+
+  const context = contextParts.length > 0 ? ` (${contextParts.join(", ")})` : "";
+  const causeText = cause ? ` Cause: ${cause}` : "";
+
+  return `${method} failed (${error.code}): ${error.message}${context}${causeText}`;
 }
 
 function inferEntityFromMethod(method: string): string {

--- a/packages/electron/src/main/ipc.test.ts
+++ b/packages/electron/src/main/ipc.test.ts
@@ -1,7 +1,3 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { CATALOG_DOC_KEY } from "@todu/core";
 import { describe, expect, it, vi } from "vitest";
 import { createDaemonIpcHandlers, mapDaemonErrorToToduError } from "./ipc.js";
 
@@ -17,10 +13,6 @@ describe("createDaemonIpcHandlers", () => {
     const handlers = createDaemonIpcHandlers({
       daemon,
       storagePath: "/tmp/todu-ipc-test",
-      appLifecycle: {
-        relaunch: vi.fn(),
-        exit: vi.fn(),
-      },
     });
 
     const result = await handlers["todu:task:get"](undefined, "task-1");
@@ -50,10 +42,6 @@ describe("createDaemonIpcHandlers", () => {
     const handlers = createDaemonIpcHandlers({
       daemon,
       storagePath: "/tmp/todu-ipc-test",
-      appLifecycle: {
-        relaunch: vi.fn(),
-        exit: vi.fn(),
-      },
     });
 
     const result = await handlers["todu:task:get"](undefined, "task-999");
@@ -84,10 +72,6 @@ describe("createDaemonIpcHandlers", () => {
     const handlers = createDaemonIpcHandlers({
       daemon,
       storagePath: "/tmp/todu-ipc-test",
-      appLifecycle: {
-        relaunch: vi.fn(),
-        exit: vi.fn(),
-      },
     });
 
     const result = await handlers["todu:sync:status"](undefined);
@@ -96,30 +80,71 @@ describe("createDaemonIpcHandlers", () => {
     expect(result).toEqual(syncStatus);
   });
 
-  it("writes join marker and requests relaunch for valid join code", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-ipc-join-test-"));
-    const relaunch = vi.fn();
-    const exit = vi.fn();
+  it("invokes daemon sync.join for join-check", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          mode: "check",
+          previousCatalogId: "catalog-a",
+          targetCatalogId: "catalog-b",
+          switched: false,
+          rolledBack: false,
+        },
+      }),
+    };
 
     const handlers = createDaemonIpcHandlers({
-      daemon: {
-        request: vi.fn(),
-      },
-      storagePath: tmpDir,
-      appLifecycle: {
-        relaunch,
-        exit,
-      },
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
     });
 
-    const catalogId = "2sFuwGcFcU9fkQDnYCdveNPoF6nK";
+    const result = await handlers["todu:sync:join-check"](undefined, "catalog-b");
 
-    await handlers["todu:sync:join"](undefined, catalogId);
+    expect(daemon.request).toHaveBeenCalledWith("sync.join", {
+      catalogId: "catalog-b",
+      check: true,
+    });
+    expect(result).toEqual({
+      mode: "check",
+      previousCatalogId: "catalog-a",
+      targetCatalogId: "catalog-b",
+      switched: false,
+      rolledBack: false,
+    });
+  });
 
-    const markerPath = path.join(tmpDir, `${CATALOG_DOC_KEY}.id`);
-    expect(fs.readFileSync(markerPath, "utf-8")).toBe(catalogId);
-    expect(relaunch).toHaveBeenCalledTimes(1);
-    expect(exit).toHaveBeenCalledWith(0);
+  it("invokes daemon sync.join for transactional join", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          mode: "join",
+          previousCatalogId: "catalog-a",
+          targetCatalogId: "catalog-b",
+          switched: true,
+          rolledBack: false,
+        },
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+    });
+
+    const result = await handlers["todu:sync:join"](undefined, "catalog-b");
+
+    expect(daemon.request).toHaveBeenCalledWith("sync.join", {
+      catalogId: "catalog-b",
+    });
+    expect(result).toEqual({
+      mode: "join",
+      previousCatalogId: "catalog-a",
+      targetCatalogId: "catalog-b",
+      switched: true,
+      rolledBack: false,
+    });
   });
 });
 

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -1,22 +1,11 @@
-import fs from "node:fs";
-import path from "node:path";
-import { CATALOG_DOC_KEY, err, ok, type Result, type ToduError } from "@todu/core";
-import { app, ipcMain } from "electron";
+import { err, ok, type Result, type ToduError } from "@todu/core";
+import { ipcMain } from "electron";
 import type { DaemonConnectionManager } from "./daemon-connection-manager.js";
 import { formatDaemonInvocationError, mapDaemonErrorToToduError } from "./daemon-error-mapping.js";
-
-interface IpcAppLifecycle {
-  relaunch(): void;
-  exit(code?: number): void;
-}
 
 interface RegisterIpcHandlersOptions {
   daemon: Pick<DaemonConnectionManager, "request">;
   storagePath: string;
-}
-
-interface CreateDaemonIpcHandlersOptions extends RegisterIpcHandlersOptions {
-  appLifecycle: IpcAppLifecycle;
 }
 
 type IpcHandler = (_event: unknown, ...args: unknown[]) => Promise<unknown> | unknown;
@@ -29,10 +18,7 @@ export { mapDaemonErrorToToduError };
  * Channel naming convention: todu:<namespace>:<method>
  */
 export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
-  const handlers = createDaemonIpcHandlers({
-    ...options,
-    appLifecycle: app,
-  });
+  const handlers = createDaemonIpcHandlers(options);
 
   for (const [channel, handler] of Object.entries(handlers)) {
     ipcMain.handle(channel, handler);
@@ -40,7 +26,7 @@ export function registerIpcHandlers(options: RegisterIpcHandlersOptions): void {
 }
 
 export function createDaemonIpcHandlers(
-  options: CreateDaemonIpcHandlersOptions,
+  options: RegisterIpcHandlersOptions,
 ): Record<string, IpcHandler> {
   const invokeResult = <T>(method: string, params: Record<string, unknown> = {}) =>
     invokeDaemonResult<T>(options.daemon, method, params);
@@ -110,32 +96,29 @@ export function createDaemonIpcHandlers(
     "todu:sync:stop": () => invokeRaw("sync.stop"),
     "todu:sync:catalog-id": () => invokeRaw("sync.catalogId"),
 
-    // Join flow: Device B writes Device A's catalog document ID to the
-    // marker file and restarts so the engine picks it up on next launch.
-    //
-    // Basic format guard: Automerge document IDs are URL-safe base58/base64
-    // strings of ~22+ characters. Reject obviously malformed input to avoid
-    // restarting into a broken state that requires manual file recovery.
-    "todu:sync:join": (_event, catalogId: unknown) => {
-      if (typeof catalogId !== "string") {
-        throw new Error("Invalid join code: must be a string");
-      }
-
-      const trimmed = catalogId.trim();
-      if (trimmed.length < 10) {
-        throw new Error("Invalid join code: too short");
-      }
-
-      if (!/^[a-zA-Z0-9+/=_-]+$/.test(trimmed)) {
-        throw new Error("Invalid join code: contains unexpected characters");
-      }
-
-      const markerPath = path.join(options.storagePath, `${CATALOG_DOC_KEY}.id`);
-      fs.writeFileSync(markerPath, trimmed, "utf-8");
-      options.appLifecycle.relaunch();
-      options.appLifecycle.exit(0);
-    },
+    "todu:sync:join-check": (_event, catalogId: unknown) =>
+      invokeRaw("sync.join", {
+        catalogId: parseJoinCatalogId(catalogId),
+        check: true,
+      }),
+    "todu:sync:join": (_event, catalogId: unknown) =>
+      invokeRaw("sync.join", {
+        catalogId: parseJoinCatalogId(catalogId),
+      }),
   };
+}
+
+function parseJoinCatalogId(catalogId: unknown): string {
+  if (typeof catalogId !== "string") {
+    throw new Error("Invalid join code: must be a string");
+  }
+
+  const trimmed = catalogId.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Invalid join code: cannot be empty");
+  }
+
+  return trimmed;
 }
 
 async function invokeDaemonResult<T>(

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -113,6 +113,7 @@ const api = {
     start: () => ipcRenderer.invoke("todu:sync:start"),
     stop: () => ipcRenderer.invoke("todu:sync:stop"),
     getCatalogId: () => ipcRenderer.invoke("todu:sync:catalog-id"),
+    joinCheck: (catalogId: string) => ipcRenderer.invoke("todu:sync:join-check", catalogId),
     join: (catalogId: string) => ipcRenderer.invoke("todu:sync:join", catalogId),
   },
 

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -156,6 +156,14 @@ export interface SyncStatus {
   remote: { state: RemoteSyncState; server?: string; lastSync?: string };
 }
 
+export interface SyncJoinResult {
+  mode: "check" | "join";
+  previousCatalogId: string;
+  targetCatalogId: string;
+  switched: boolean;
+  rolledBack: boolean;
+}
+
 export interface ToduSyncApi {
   /** Get current sync status. */
   status(): Promise<SyncStatus>;
@@ -168,11 +176,10 @@ export interface ToduSyncApi {
    * Share this as a join code so other devices can sync with this one.
    */
   getCatalogId(): Promise<string>;
-  /**
-   * Join another device's data by entering its catalog document ID.
-   * Writes the ID to the marker file and restarts the app.
-   */
-  join(catalogId: string): Promise<void>;
+  /** Validate join reachability/format without switching the local catalog pointer. */
+  joinCheck(catalogId: string): Promise<SyncJoinResult>;
+  /** Perform transactional join switch through the daemon-owned join API. */
+  join(catalogId: string): Promise<SyncJoinResult>;
 }
 
 export interface ToduApi {

--- a/packages/electron/src/renderer/views/SettingsView.tsx
+++ b/packages/electron/src/renderer/views/SettingsView.tsx
@@ -5,6 +5,7 @@ import type {
   OAuthEvent,
   OAuthStatus,
   ProviderInfo,
+  SyncJoinResult,
   SyncStatus,
 } from "../types/window.js";
 
@@ -34,7 +35,9 @@ export function SettingsView({
   const [copied, setCopied] = useState(false);
   const [joinCode, setJoinCode] = useState("");
   const [joining, setJoining] = useState(false);
+  const [validatingJoin, setValidatingJoin] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinResult, setJoinResult] = useState<SyncJoinResult | null>(null);
 
   // OAuth state
   const [oauthStatuses, setOauthStatuses] = useState<OAuthStatus[]>([]);
@@ -223,6 +226,14 @@ export function SettingsView({
 
   // ── Sync handlers ────────────────────────────────────────────────
 
+  const formatJoinErrorMessage = useCallback((error: unknown): string => {
+    if (!(error instanceof Error)) {
+      return String(error);
+    }
+
+    return error.message;
+  }, []);
+
   const handleCopyCatalogId = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(catalogId);
@@ -234,19 +245,42 @@ export function SettingsView({
     }
   }, [catalogId]);
 
+  const handleValidateJoin = useCallback(async () => {
+    const code = joinCode.trim();
+    if (!code) return;
+
+    setValidatingJoin(true);
+    setJoinError(null);
+
+    try {
+      const result = await window.todu.sync.joinCheck(code);
+      setJoinResult(result);
+    } catch (err) {
+      setJoinError(formatJoinErrorMessage(err));
+    } finally {
+      setValidatingJoin(false);
+    }
+  }, [formatJoinErrorMessage, joinCode]);
+
   const handleJoin = useCallback(async () => {
     const code = joinCode.trim();
     if (!code) return;
+
     setJoining(true);
     setJoinError(null);
+
     try {
-      await window.todu.sync.join(code);
-      // App will restart — no further state update needed
+      const result = await window.todu.sync.join(code);
+      setJoinResult(result);
+      setCatalogId(result.targetCatalogId);
+      const refreshedStatus = await window.todu.sync.status();
+      setSyncStatus(refreshedStatus);
     } catch (err) {
-      setJoinError(err instanceof Error ? err.message : String(err));
+      setJoinError(formatJoinErrorMessage(err));
+    } finally {
       setJoining(false);
     }
-  }, [joinCode]);
+  }, [formatJoinErrorMessage, joinCode]);
 
   if (!settings || providers.length === 0) {
     return <div className="loading-state">Loading settings...</div>;
@@ -492,8 +526,8 @@ export function SettingsView({
                   <span className="settings-key-label">Join another device</span>
                 </div>
                 <p className="settings-hint">
-                  Enter a join code from another device. The app will restart and replace your local
-                  data with that device&apos;s data.
+                  Enter a join code from another device. Validate first to confirm reachability,
+                  then run transactional join to switch this daemon safely.
                 </p>
                 <div className="settings-key-input-row">
                   <input
@@ -501,11 +535,23 @@ export function SettingsView({
                     className="input settings-key-input"
                     placeholder="Paste join code here"
                     value={joinCode}
-                    onChange={(e) => setJoinCode(e.target.value)}
+                    onChange={(e) => {
+                      setJoinCode(e.target.value);
+                      setJoinResult(null);
+                      setJoinError(null);
+                    }}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter") void handleJoin();
+                      if (e.key === "Enter") void handleValidateJoin();
                     }}
                   />
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    disabled={!joinCode.trim() || validatingJoin || joining}
+                    onClick={() => void handleValidateJoin()}
+                  >
+                    {validatingJoin ? "Validating..." : "Validate"}
+                  </button>
                   <button
                     type="button"
                     className="btn btn-primary btn-sm"
@@ -515,6 +561,15 @@ export function SettingsView({
                     {joining ? "Joining..." : "Join"}
                   </button>
                 </div>
+                {joinResult && (
+                  <div className="settings-hint">
+                    <div>Mode: {joinResult.mode}</div>
+                    <div>Previous: {joinResult.previousCatalogId}</div>
+                    <div>Target: {joinResult.targetCatalogId}</div>
+                    <div>Switched: {joinResult.switched ? "yes" : "no"}</div>
+                    <div>Rolled back: {joinResult.rolledBack ? "yes" : "no"}</div>
+                  </div>
+                )}
                 {joinError && <div className="settings-oauth-error">{joinError}</div>}
               </div>
             </>


### PR DESCRIPTION
## Summary
- add `sync join <catalogId>` to CLI with `--check` validation mode, interactive confirmation (or `--yes`), JSON/plain output, and staged daemon join error context
- route Electron join flows through daemon APIs (`sync.join` / `sync.join` check mode) instead of marker-file mutation, including IPC/preload/renderer wiring and updated error mapping
- update docs for daemon/CLI join usage and phase-5 join-safety behavior

## Testing
- npm run test -- packages/cli/src/commands/sync.test.ts packages/electron/src/main/ipc.test.ts
- npm run --workspace=packages/cli typecheck
- make pre-pr

Task: #1948
