### PR TITLE
fix(2077): prevent post-merge storage teardown CI regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Protocol conformance
         run: npm run test:conformance
 
+      - name: Storage stability
+        run: npm run test:storage-stability
+
       - name: Test
         run: make test
 

--- a/.github/workflows/main-ci-auto-revert.yml
+++ b/.github/workflows/main-ci-auto-revert.yml
@@ -1,0 +1,125 @@
+name: Main CI Auto-Revert
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Commit SHA on main to revert"
+        required: true
+        type: string
+      dry_run:
+        description: "Print planned revert actions without pushing"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  auto-revert:
+    name: Revert failing main commit
+    if: >
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve target
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_SHA: ${{ inputs.head_sha }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "sha=$WORKFLOW_SHA" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            echo "source=workflow_run" >> "$GITHUB_OUTPUT"
+          else
+            if [[ -z "$INPUT_SHA" ]]; then
+              echo "workflow_dispatch requires head_sha" >&2
+              exit 1
+            fi
+            echo "sha=$INPUT_SHA" >> "$GITHUB_OUTPUT"
+            echo "dry_run=$INPUT_DRY_RUN" >> "$GITHUB_OUTPUT"
+            echo "source=workflow_dispatch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate revert target
+        id: validate
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --prune
+
+          if ! git cat-file -e "$TARGET_SHA^{commit}" 2>/dev/null; then
+            echo "Target commit not found: $TARGET_SHA" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TARGET_SHA" origin/main; then
+            echo "Target commit is not reachable from origin/main: $TARGET_SHA" >&2
+            exit 1
+          fi
+
+          subject="$(git log -1 --pretty=%s "$TARGET_SHA")"
+          echo "subject=$subject" >> "$GITHUB_OUTPUT"
+
+          if [[ "$subject" == Revert\ * ]]; then
+            echo "already_revert=true" >> "$GITHUB_OUTPUT"
+            echo "This is already a revert commit; skipping." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if git log origin/main --grep="This reverts commit $TARGET_SHA" --oneline | head -n 1 | grep -q .; then
+            echo "already_revert=true" >> "$GITHUB_OUTPUT"
+            echo "A revert for $TARGET_SHA already exists on main; skipping." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "already_revert=false" >> "$GITHUB_OUTPUT"
+
+      - name: Revert failing commit
+        if: steps.validate.outputs.already_revert == 'false'
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+          DRY_RUN: ${{ steps.target.outputs.dry_run }}
+          SOURCE: ${{ steps.target.outputs.source }}
+        run: |
+          set -euo pipefail
+
+          echo "Source: $SOURCE"
+          echo "Target SHA: $TARGET_SHA"
+          echo "Dry run: $DRY_RUN"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run enabled. Would execute: git revert --no-edit $TARGET_SHA && git push origin HEAD:main"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git revert --no-edit "$TARGET_SHA"
+          git push origin HEAD:main
+
+          echo "Reverted failing main commit $TARGET_SHA" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,9 +48,10 @@ After implementation is complete, follow this sequence in order:
 2. Commit changes.
 3. Push branch and open/update PR.
 4. Wait for CI to finish and pass before requesting review.
-5. Start independent review in a visible tmux sub-agent and run the `pr-review` skill in that session.
-6. Report review result to the human, fix warnings by default unless explicitly waived, and fix all requested changes.
-7. Stop and wait for explicit human merge approval (`merge`, `approved`, `LGTM`, etc.).
+5. Treat any unhandled rejection or race-signature failure in candidate CI runs as a merge blocker (even if a rerun later passes); root-cause and fix before proceeding.
+6. Start independent review in a visible tmux sub-agent and run the `pr-review` skill in that session.
+7. Report review result to the human, fix warnings by default unless explicitly waived, and fix all requested changes.
+8. Stop and wait for explicit human merge approval (`merge`, `approved`, `LGTM`, etc.).
 
 If CI fails, fix the issue, recommit, push again, and wait for CI to pass.
 
@@ -68,8 +69,20 @@ PR Pipeline Status
 ## Review and merge rules
 
 - CI must pass before requesting review.
+- Any unhandled rejection in CI is treated as a failure and must be fixed, even if retries pass.
 - Agent review helps catch issues early and does not grant merge permission.
 - Never merge without explicit human approval.
+- If a commit reaches `main` and push CI fails, `main-ci-auto-revert.yml` may revert that commit automatically to keep `main` healthy.
+
+### Main auto-revert validation
+
+You can validate the revert workflow behavior in dry-run mode without pushing a revert:
+
+```bash
+gh workflow run main-ci-auto-revert.yml -f head_sha=<main-commit-sha> -f dry_run=true
+```
+
+Use `dry_run=false` only with explicit human approval.
 
 ## Tooling
 
@@ -79,6 +92,7 @@ PR Pipeline Status
 | `make test` | Run tests |
 | `make check` | Lint + format + typecheck |
 | `make pre-pr` | Full pre-PR checks (check + test) |
+| `npm run test:storage-stability` | Repeat storage teardown tests to detect race leaks |
 | `make run ARGS="..."` | Run CLI |
 
 For targeted verification during daemon protocol work:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:cli": "npm run --workspace=packages/cli build",
     "test": "vitest run",
     "test:conformance": "vitest run packages/daemon/src/protocol-conformance.test.ts",
+    "test:storage-stability": "node scripts/test-storage-stability.mjs",
     "test:watch": "vitest",
     "check": "biome check --write --error-on-warnings . && npm run typecheck",
     "check:ci": "biome check --error-on-warnings . && npm run typecheck",

--- a/packages/engine/src/storage.test.ts
+++ b/packages/engine/src/storage.test.ts
@@ -5,6 +5,12 @@ import type { DocumentId } from "@automerge/automerge-repo";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { beginCatalogJoinSwitch, initBootstrapStorage, initJoinStorage } from "./storage.js";
 
+const UNREACHABLE_CATALOG_ID = "2sFuwGcFcU9fkQDnYCdveNPoF6nK" as DocumentId;
+
+async function nextTick(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("storage bootstrap/join boundaries", () => {
   let tmpDir: string;
 
@@ -29,27 +35,48 @@ describe("storage bootstrap/join boundaries", () => {
 
   it("bootstrap does not create replacement catalog when marker is unreachable", async () => {
     const markerPath = path.join(tmpDir, "todu-catalog.id");
-    const unreachable = "2sFuwGcFcU9fkQDnYCdveNPoF6nK";
-    fs.writeFileSync(markerPath, unreachable, "utf-8");
+    fs.writeFileSync(markerPath, UNREACHABLE_CATALOG_ID, "utf-8");
 
     await expect(initBootstrapStorage(tmpDir)).rejects.toThrow("bootstrap catalog");
 
-    expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(unreachable);
+    expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(UNREACHABLE_CATALOG_ID);
   });
 
   it("join path never creates a fresh catalog when target is unreachable", async () => {
-    const target = "2sFuwGcFcU9fkQDnYCdveNPoF6nK" as DocumentId;
-
-    await expect(initJoinStorage(tmpDir, target)).rejects.toThrow("join catalog");
+    await expect(initJoinStorage(tmpDir, UNREACHABLE_CATALOG_ID)).rejects.toThrow("join catalog");
 
     const markerPath = path.join(tmpDir, "todu-catalog.id");
     expect(fs.existsSync(markerPath)).toBe(false);
   });
 
+  it("failed bootstrap init cleans up owned repo without async storage leaks", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-storage-bootstrap-fail-"));
+      const markerPath = path.join(runDir, "todu-catalog.id");
+      fs.writeFileSync(markerPath, UNREACHABLE_CATALOG_ID, "utf-8");
+
+      await expect(initBootstrapStorage(runDir)).rejects.toThrow("bootstrap catalog");
+
+      fs.rmSync(runDir, { recursive: true, force: true });
+      await nextTick();
+    }
+  });
+
+  it("failed join init cleans up owned repo without async storage leaks", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-storage-join-fail-"));
+
+      await expect(initJoinStorage(runDir, UNREACHABLE_CATALOG_ID)).rejects.toThrow("join catalog");
+
+      fs.rmSync(runDir, { recursive: true, force: true });
+      await nextTick();
+    }
+  });
+
   it("join switch rollback restores prior marker", () => {
     const markerPath = path.join(tmpDir, "todu-catalog.id");
     const previous = "2Y2aJ8G8MSYn6wVqVEf4GQ9B5m5H" as DocumentId;
-    const target = "2sFuwGcFcU9fkQDnYCdveNPoF6nK" as DocumentId;
+    const target = UNREACHABLE_CATALOG_ID;
 
     fs.writeFileSync(markerPath, previous, "utf-8");
 
@@ -62,7 +89,7 @@ describe("storage bootstrap/join boundaries", () => {
 
   it("join switch rollback removes marker when no prior catalog existed", () => {
     const markerPath = path.join(tmpDir, "todu-catalog.id");
-    const target = "2sFuwGcFcU9fkQDnYCdveNPoF6nK" as DocumentId;
+    const target = UNREACHABLE_CATALOG_ID;
 
     const tx = beginCatalogJoinSwitch(tmpDir, target);
     expect(fs.readFileSync(markerPath, "utf-8").trim()).toBe(target);

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -129,15 +129,22 @@ export function beginCatalogJoinSwitch(
 export async function initBootstrapStorage(storagePath: string, repo?: Repo): Promise<Storage> {
   fs.mkdirSync(storagePath, { recursive: true });
 
+  const ownsRepo = repo === undefined;
   const actualRepo =
     repo ??
     new Repo({
       storage: new NodeFSStorageAdapter(storagePath),
     });
 
-  const catalog = await loadOrBootstrapCatalog(actualRepo, storagePath);
-
-  return createPersistentStorage(actualRepo, catalog);
+  try {
+    const catalog = await loadOrBootstrapCatalog(actualRepo, storagePath);
+    return createPersistentStorage(actualRepo, catalog);
+  } catch (error) {
+    if (ownsRepo) {
+      await shutdownRepoQuietly(actualRepo);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -154,15 +161,22 @@ export async function initJoinStorage(
 ): Promise<Storage> {
   fs.mkdirSync(storagePath, { recursive: true });
 
+  const ownsRepo = repo === undefined;
   const actualRepo =
     repo ??
     new Repo({
       storage: new NodeFSStorageAdapter(storagePath),
     });
 
-  const catalog = await loadCatalogById(actualRepo, targetCatalogId, "join");
-
-  return createPersistentStorage(actualRepo, catalog);
+  try {
+    const catalog = await loadCatalogById(actualRepo, targetCatalogId, "join");
+    return createPersistentStorage(actualRepo, catalog);
+  } catch (error) {
+    if (ownsRepo) {
+      await shutdownRepoQuietly(actualRepo);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -246,6 +260,24 @@ export async function initEphemeralStorage(storagePath: string): Promise<
       };
     },
   };
+}
+
+async function shutdownRepoQuietly(repo: Repo): Promise<void> {
+  try {
+    await repo.flush();
+  } catch {
+    // Safe to ignore — requesting docs have no content to save
+  }
+
+  try {
+    await repo.shutdown();
+  } catch {
+    // Safe to ignore — shutdown may race with pending requesting docs
+  }
+
+  // Allow any queued storage adapter writes to settle before callers clean up
+  // temporary directories in tests.
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function createPersistentStorage(repo: Repo, catalog: DocHandle<CatalogDocument>): Storage {

--- a/scripts/test-storage-stability.mjs
+++ b/scripts/test-storage-stability.mjs
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+
+const runs = Number(process.env.STORAGE_STABILITY_RUNS ?? "20");
+
+if (!Number.isInteger(runs) || runs <= 0) {
+  console.error("STORAGE_STABILITY_RUNS must be a positive integer");
+  process.exit(1);
+}
+
+for (let index = 1; index <= runs; index += 1) {
+  console.log(`\n[storage-stability] run ${index}/${runs}`);
+
+  const result = spawnSync("npm", ["run", "test", "--", "packages/engine/src/storage.test.ts"], {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+console.log(`\n[storage-stability] passed ${runs}/${runs} runs`);


### PR DESCRIPTION
## Summary
- harden engine storage init failure paths by closing internally owned repos (flush + shutdown + settle) before rethrowing bootstrap/join unreachable errors
- expand storage boundary tests with repeated failed bootstrap/join leak checks to guard against unhandled async ENOENT teardown races
- add `npm run test:storage-stability` and wire it into CI as a required gate before full test execution
- add `main-ci-auto-revert.yml` to automatically revert failing push commits on `main` (plus workflow_dispatch dry-run validation mode)
- update CONTRIBUTING merge gates to block on any unhandled rejection signature even if reruns pass, and document auto-revert dry-run usage

## Testing
- npm run test -- packages/engine/src/storage.test.ts
- npm run test:storage-stability
- make pre-pr

Task: #2077
