### PR TITLE
feat: required-domain worker gating with blocked reason reporting

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,11 @@ Each worker declares required domain capabilities. Daemon behavior:
 - block worker start if required domains are disabled/missing
 - expose blocked reason in status/logs/errors
 
+Dependency gating semantics:
+- Workers may register even when dependencies are unavailable; they are held in `blocked` state.
+- Transitioning a dependency-blocked worker to `running` returns a dependency error and preserves `blocked` state.
+- Block reasons must include the missing/disabled required domains in deterministic order.
+
 Baseline worker lifecycle states are:
 - `registered`
 - `running`

--- a/docs/plans/phase-6-worker-foundation.md
+++ b/docs/plans/phase-6-worker-foundation.md
@@ -83,6 +83,12 @@ Daemon runtime registration/lifecycle entrypoints:
 - Core domains remain usable without workers
 - Worker lifecycle must not alter baseline core CRUD/query behavior
 
+## Phase 6 Gating Notes
+
+- Required-domain checks run for workers loaded at daemon startup and for runtime registrations (reload-equivalent path).
+- If a required domain is unavailable, the worker transitions to `blocked` with a deterministic blocked reason that lists missing/disabled domains.
+- Attempting to transition a dependency-blocked worker to `running` returns a dependency-blocked error and keeps worker state `blocked`.
+
 ## Acceptance Criteria
 
 - [ ] Worker registration contract implemented

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -83,7 +83,9 @@ export {
 
 export {
   type CreateWorkerRegistryOptions,
+  createWorkerDependencyBlockedReason,
   createWorkerRegistry,
+  findMissingRequiredWorkerDomains,
   isWorkerDomainCapability,
   isWorkerLifecycleState,
   isWorkerRoleHint,

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,5 +1,5 @@
 import type { DocumentId } from "@automerge/automerge-repo";
-import { type RemoteSyncConfig, type Result, resolveStoragePath } from "@todu/core";
+import { err, ok, type RemoteSyncConfig, type Result, resolveStoragePath } from "@todu/core";
 import { beginCatalogJoinSwitch, createTodu, initJoinStorage, type Todu } from "@todu/engine";
 import { createCoreNamespaceHandlers, mergeNamespaceHandlerSets } from "./core-rpc-adapters.js";
 import {
@@ -28,8 +28,12 @@ import {
   type UdsTransport,
 } from "./transport.js";
 import {
+  createWorkerDependencyBlockedReason,
   createWorkerRegistry,
+  findMissingRequiredWorkerDomains,
   type RegisteredWorkerSnapshot,
+  WORKER_DOMAIN_CAPABILITIES,
+  type WorkerDomainCapability,
   type WorkerLifecycleState,
   type WorkerLifecycleTransitionDetails,
   type WorkerRegistration,
@@ -59,6 +63,7 @@ export interface DaemonRuntimeConfig {
   rpcMethodHandlers?: Partial<Record<string, DaemonRpcMethodHandler>>;
   rpcNamespaceHandlers?: DaemonRpcNamespaceHandlers;
   workerRegistrations?: WorkerRegistration[];
+  enabledWorkerDomains?: WorkerDomainCapability[];
 }
 
 export interface ResolvedDaemonRuntimeConfig {
@@ -70,6 +75,7 @@ export interface ResolvedDaemonRuntimeConfig {
   daemonVersion: string;
   requestTimeoutMs: number;
   logLevel: DaemonLogLevel;
+  enabledWorkerDomains: WorkerDomainCapability[];
 }
 
 export interface DaemonRuntimeStatus {
@@ -109,6 +115,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   const resolvedStoragePath = config.storagePath ?? resolveStoragePath();
   const resolvedSocketPath = resolveUdsSocketPath(resolvedStoragePath, config.socketPath);
   const resolvedLogLevel = config.logLevel ?? resolveDaemonLogLevelFromEnv(process.env);
+  const resolvedEnabledWorkerDomains = resolveEnabledWorkerDomains(config.enabledWorkerDomains);
 
   const resolvedConfig: ResolvedDaemonRuntimeConfig = {
     storagePath: resolvedStoragePath,
@@ -123,6 +130,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       parsePositiveInteger(process.env.TODUAI_DAEMON_REQUEST_TIMEOUT_MS) ??
       DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
     logLevel: resolvedLogLevel,
+    enabledWorkerDomains: resolvedEnabledWorkerDomains,
   };
 
   let todu: Todu | null = null;
@@ -139,6 +147,78 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
 
   const workerRegistry = createWorkerRegistry();
 
+  const runtimeLogger =
+    config.logger ??
+    createDaemonLogger({
+      component: "daemon.runtime",
+      level: resolvedConfig.logLevel,
+    });
+
+  function createDependencyBlockedError(
+    workerType: string,
+    missingRequiredDomains: readonly WorkerDomainCapability[],
+    blockedReason: string,
+  ): WorkerRegistryError {
+    return {
+      code: "DEPENDENCY_BLOCKED",
+      message: `Worker cannot transition to running because required domains are unavailable: ${workerType}`,
+      details: {
+        workerType,
+        blockedReason,
+        missingRequiredDomains,
+        enabledWorkerDomains: resolvedConfig.enabledWorkerDomains,
+      },
+    };
+  }
+
+  function applyWorkerDependencyGating(
+    workerType: string,
+  ): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
+    const normalizedWorkerType = workerType.trim();
+    const worker = workerRegistry.get(normalizedWorkerType);
+    if (!worker) {
+      return err({
+        code: "NOT_FOUND",
+        message: `Worker is not registered: ${normalizedWorkerType}`,
+        details: {
+          workerType: normalizedWorkerType,
+        },
+      });
+    }
+
+    const missingRequiredDomains = findMissingRequiredWorkerDomains(
+      worker.manifest.requiredDomains,
+      resolvedConfig.enabledWorkerDomains,
+    );
+
+    if (missingRequiredDomains.length === 0) {
+      return ok(worker);
+    }
+
+    const blockedReason = createWorkerDependencyBlockedReason(missingRequiredDomains);
+
+    if (worker.state === "blocked" && worker.blockedReason === blockedReason) {
+      return ok(worker);
+    }
+
+    const blockedTransition = workerRegistry.transition(normalizedWorkerType, "blocked", {
+      blockedReason,
+    });
+
+    if (!blockedTransition.ok) {
+      return blockedTransition;
+    }
+
+    runtimeLogger.warn("worker blocked by required-domain gating", {
+      workerType: normalizedWorkerType,
+      blockedReason,
+      missingRequiredDomains,
+      enabledWorkerDomains: resolvedConfig.enabledWorkerDomains,
+    });
+
+    return blockedTransition;
+  }
+
   for (const registration of config.workerRegistrations ?? []) {
     const registerResult = workerRegistry.register(registration);
     if (!registerResult.ok) {
@@ -147,14 +227,14 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         `Invalid worker registration for daemon runtime (${workerType}): ${registerResult.error.message}`,
       );
     }
-  }
 
-  const runtimeLogger =
-    config.logger ??
-    createDaemonLogger({
-      component: "daemon.runtime",
-      level: resolvedConfig.logLevel,
-    });
+    const dependencyGateResult = applyWorkerDependencyGating(registerResult.value.manifest.type);
+    if (!dependencyGateResult.ok) {
+      throw new Error(
+        `Failed to apply worker dependency gating for daemon runtime (${registerResult.value.manifest.type}): ${dependencyGateResult.error.message}`,
+      );
+    }
+  }
 
   const defaultNamespaceHandlers = mergeNamespaceHandlerSets(
     createCoreNamespaceHandlers({
@@ -564,7 +644,12 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     },
 
     registerWorker(registration): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
-      return workerRegistry.register(registration);
+      const registerResult = workerRegistry.register(registration);
+      if (!registerResult.ok) {
+        return registerResult;
+      }
+
+      return applyWorkerDependencyGating(registerResult.value.manifest.type);
     },
 
     transitionWorkerState(
@@ -572,6 +657,34 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       state,
       details,
     ): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
+      if (state !== "running") {
+        return workerRegistry.transition(workerType, state, details);
+      }
+
+      const dependencyGateResult = applyWorkerDependencyGating(workerType);
+      if (!dependencyGateResult.ok) {
+        return dependencyGateResult;
+      }
+
+      const missingRequiredDomains = findMissingRequiredWorkerDomains(
+        dependencyGateResult.value.manifest.requiredDomains,
+        resolvedConfig.enabledWorkerDomains,
+      );
+
+      if (missingRequiredDomains.length > 0) {
+        const blockedReason =
+          dependencyGateResult.value.blockedReason ??
+          createWorkerDependencyBlockedReason(missingRequiredDomains);
+
+        return err(
+          createDependencyBlockedError(
+            dependencyGateResult.value.manifest.type,
+            missingRequiredDomains,
+            blockedReason,
+          ),
+        );
+      }
+
       return workerRegistry.transition(workerType, state, details);
     },
 
@@ -597,6 +710,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         daemonVersion: resolvedConfig.daemonVersion,
         requestTimeoutMs: resolvedConfig.requestTimeoutMs,
         logLevel: resolvedConfig.logLevel,
+        enabledWorkerDomains: [...resolvedConfig.enabledWorkerDomains],
       };
     },
   };
@@ -616,6 +730,23 @@ function getErrorMessage(error: unknown): string {
   }
 
   return String(error);
+}
+
+function resolveEnabledWorkerDomains(
+  domains: readonly WorkerDomainCapability[] | undefined,
+): WorkerDomainCapability[] {
+  if (!domains) {
+    return [...WORKER_DOMAIN_CAPABILITIES];
+  }
+
+  const normalized: WorkerDomainCapability[] = [];
+  for (const domain of domains) {
+    if (!normalized.includes(domain)) {
+      normalized.push(domain);
+    }
+  }
+
+  return normalized;
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {

--- a/packages/daemon/src/workers.test.ts
+++ b/packages/daemon/src/workers.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDaemonRuntime } from "./runtime.js";
-import { createWorkerRegistry, validateWorkerManifest } from "./workers.js";
+import {
+  createWorkerDependencyBlockedReason,
+  createWorkerRegistry,
+  findMissingRequiredWorkerDomains,
+  validateWorkerManifest,
+} from "./workers.js";
 
 describe("validateWorkerManifest", () => {
   it("accepts and normalizes valid manifests", () => {
@@ -66,6 +71,18 @@ describe("validateWorkerManifest", () => {
         overlappingDomains: ["sync"],
       },
     });
+  });
+});
+
+describe("worker dependency gating helpers", () => {
+  it("finds missing required domains deterministically", () => {
+    const missing = findMissingRequiredWorkerDomains(["recurring", "sync"], ["sync", "task"]);
+    expect(missing).toEqual(["recurring"]);
+  });
+
+  it("creates blocked reasons with missing domain details", () => {
+    const reason = createWorkerDependencyBlockedReason(["recurring", "sync"]);
+    expect(reason).toBe("required domains are disabled or missing: recurring, sync");
   });
 });
 
@@ -199,5 +216,120 @@ describe("createDaemonRuntime worker registration entrypoints", () => {
     }
 
     expect(duplicateRegistration.error.code).toBe("ALREADY_REGISTERED");
+  });
+
+  it("blocks worker registration when required domains are unavailable", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      enabledWorkerDomains: ["task", "sync"],
+    });
+
+    const registerResult = runtime.registerWorker({
+      manifest: {
+        type: "recurring",
+        requiredDomains: ["recurring"],
+      },
+    });
+
+    expect(registerResult.ok).toBe(true);
+    if (!registerResult.ok) {
+      throw new Error("Expected registration to succeed in blocked state");
+    }
+
+    expect(registerResult.value.state).toBe("blocked");
+    expect(registerResult.value.blockedReason).toBe(
+      "required domains are disabled or missing: recurring",
+    );
+  });
+
+  it("applies dependency gating to startup registrations", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      enabledWorkerDomains: ["task", "sync"],
+      workerRegistrations: [
+        {
+          manifest: {
+            type: "recurring",
+            requiredDomains: ["recurring"],
+          },
+        },
+      ],
+    });
+
+    expect(runtime.getWorker("recurring")).toMatchObject({
+      state: "blocked",
+      blockedReason: "required domains are disabled or missing: recurring",
+    });
+  });
+
+  it("returns dependency-blocked errors when starting a blocked worker", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      enabledWorkerDomains: ["task", "sync"],
+    });
+
+    runtime.registerWorker({
+      manifest: {
+        type: "recurring",
+        requiredDomains: ["recurring"],
+      },
+    });
+
+    const transitionResult = runtime.transitionWorkerState("recurring", "running");
+
+    expect(transitionResult.ok).toBe(false);
+    if (transitionResult.ok) {
+      throw new Error("Expected transition to running to fail due to dependency gating");
+    }
+
+    expect(transitionResult.error).toMatchObject({
+      code: "DEPENDENCY_BLOCKED",
+      details: {
+        workerType: "recurring",
+        blockedReason: "required domains are disabled or missing: recurring",
+        missingRequiredDomains: ["recurring"],
+      },
+    });
+
+    expect(runtime.getWorker("recurring")).toMatchObject({
+      state: "blocked",
+      blockedReason: "required domains are disabled or missing: recurring",
+    });
+  });
+
+  it("allows running transitions when required domains are enabled", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      enabledWorkerDomains: ["recurring", "task", "sync"],
+    });
+
+    const registerResult = runtime.registerWorker({
+      manifest: {
+        type: "recurring",
+        requiredDomains: ["recurring"],
+      },
+    });
+
+    expect(registerResult.ok).toBe(true);
+    if (!registerResult.ok) {
+      throw new Error("Expected registration to succeed");
+    }
+
+    const transitionResult = runtime.transitionWorkerState("recurring", "running");
+    expect(transitionResult.ok).toBe(true);
+    if (!transitionResult.ok) {
+      throw new Error("Expected transition to running to succeed");
+    }
+
+    expect(transitionResult.value.state).toBe("running");
+    expect(transitionResult.value.blockedReason).toBeUndefined();
   });
 });

--- a/packages/daemon/src/workers.ts
+++ b/packages/daemon/src/workers.ts
@@ -54,6 +54,7 @@ export const WORKER_REGISTRY_ERROR_CODES = [
   "NOT_FOUND",
   "INVALID_TRANSITION",
   "MISSING_BLOCKED_REASON",
+  "DEPENDENCY_BLOCKED",
 ] as const;
 
 export type WorkerRegistryErrorCode = (typeof WORKER_REGISTRY_ERROR_CODES)[number];
@@ -318,6 +319,21 @@ export function isWorkerRoleHint(value: string): value is WorkerRoleHint {
 
 export function isWorkerLifecycleState(value: string): value is WorkerLifecycleState {
   return (WORKER_LIFECYCLE_STATES as readonly string[]).includes(value);
+}
+
+export function findMissingRequiredWorkerDomains(
+  requiredDomains: readonly WorkerDomainCapability[],
+  enabledDomains: readonly WorkerDomainCapability[],
+): WorkerDomainCapability[] {
+  const enabledSet = new Set(enabledDomains);
+  return requiredDomains.filter((domain) => !enabledSet.has(domain));
+}
+
+export function createWorkerDependencyBlockedReason(
+  missingRequiredDomains: readonly WorkerDomainCapability[],
+): string {
+  const domains = missingRequiredDomains.join(", ");
+  return `required domains are disabled or missing: ${domains}`;
 }
 
 function cloneRegisteredWorker(worker: RegisteredWorkerSnapshot): RegisteredWorkerSnapshot {


### PR DESCRIPTION
## Summary
- add required-domain gating in daemon runtime for startup registrations and runtime worker registration
- keep dependency-missing workers in blocked state with deterministic blocked reasons listing missing domains
- return explicit DEPENDENCY_BLOCKED errors when transitioning blocked workers to running
- add tests for dependency gating behavior and helper semantics
- update architecture and phase-6 docs with gating semantics

## Verification
- make pre-pr

Task: #1951