### PR TITLE
feat: implement static daemon worker assignment model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,9 +209,12 @@ Baseline worker lifecycle states are:
 
 ## Worker Assignment and Failover (Initial)
 
-- Assignment configured via local config file/env vars
-- No lease system initially
-- Duplicate assignment handling starts with logging/observability
+- Assignment configured via local config file/env vars.
+- Config file model uses `daemon.workers.assigned` (list of worker types).
+- Environment override uses `TODUAI_DAEMON_ASSIGNED_WORKERS` (comma-separated worker types) and takes precedence over file assignment.
+- Empty assignment is allowed and means no local workers are assigned.
+- Duplicate assignment entries are tolerated and logged for observability; first occurrence wins.
+- No lease system initially.
 
 ## Operational failover UX
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -73,6 +73,29 @@ Override with:
 
 - `TODUAI_DAEMON_SOCKET=/path/to/daemon.sock`
 
+## Worker assignment configuration
+
+Configure assigned worker types in config file:
+
+```yaml
+daemon:
+  workers:
+    assigned:
+      - recurring
+      - github-sync
+```
+
+Override with env var (comma-separated):
+
+```bash
+export TODUAI_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
+```
+
+Notes:
+- Env var overrides config file assignment.
+- Empty assignment (`TODUAI_DAEMON_ASSIGNED_WORKERS=""`) means no local workers are assigned.
+- Duplicate entries are tolerated and logged; first occurrence wins.
+
 ## Validate connectivity
 
 ```bash

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -161,6 +161,12 @@ tail -f ~/Library/Logs/toduai-daemon.out.log ~/Library/Logs/toduai-daemon.err.lo
 
 - Default data dir is config-resolved; examples use `~/.local/share/todu` for clarity.
 - Default daemon socket path is `<data_dir>/daemon.sock`.
+- Worker assignment env override (comma-separated worker types):
+
+```bash
+export TODUAI_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
+```
+
 - Optional socket override:
 
 ```bash

--- a/docs/plans/phase-6-worker-foundation.md
+++ b/docs/plans/phase-6-worker-foundation.md
@@ -75,8 +75,10 @@ Daemon runtime registration/lifecycle entrypoints:
 
 ### Assignment Behavior
 
-- Assignment config is authoritative in initial model
-- Duplicate assignment is logged clearly (prevention hardening deferred)
+- Assignment config is authoritative in initial model.
+- Config file source: `daemon.workers.assigned`.
+- Env override source: `TODUAI_DAEMON_ASSIGNED_WORKERS` (comma-separated), which takes precedence over file assignment.
+- Duplicate assignment entries are logged clearly (prevention hardening deferred).
 
 ### Compatibility Behavior
 

--- a/docs/plans/phase-8-ops-controls.md
+++ b/docs/plans/phase-8-ops-controls.md
@@ -18,8 +18,8 @@ Implement the operational layer around worker assignment so daemon-based deploym
 ### Deliverables
 
 1. **Assignment configuration surfaces**
-   - Local config file support
-   - Environment variable overrides
+   - Local config file support (`daemon.workers.assigned`)
+   - Environment variable override (`TODUAI_DAEMON_ASSIGNED_WORKERS`)
 
 2. **CLI operational controls (single daemon target)**
    - View worker assignment and status

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -10,6 +10,10 @@ import {
   formatDaemonCommandError,
   resolveDaemonSocketPath,
 } from "../daemon-command-client.js";
+import {
+  resolveDaemonAssignedWorkers,
+  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+} from "../daemon-worker-assignment.js";
 import { formatJSON } from "../format.js";
 
 interface DaemonStatusResult {
@@ -53,6 +57,7 @@ interface DaemonCommandContext {
   daemonPidPath: string;
   daemonEntrypoint: string;
   remoteSyncServer: string | null;
+  assignedWorkersEnvValue: string | undefined;
 }
 
 const DIRECT_PID_FILENAME = "daemon.pid";
@@ -736,6 +741,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
   const fileConfig = loadConfig(configPath);
   const storagePath = resolveDataDir(configPath, fileConfig);
   const remoteSync = resolveRemoteSyncConfig(fileConfig);
+  const assignedWorkers = resolveDaemonAssignedWorkers(fileConfig);
 
   return {
     storagePath,
@@ -743,6 +749,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
     daemonPidPath: path.join(storagePath, DIRECT_PID_FILENAME),
     daemonEntrypoint: resolveDaemonEntrypoint(),
     remoteSyncServer: remoteSync?.server ?? null,
+    assignedWorkersEnvValue: assignedWorkers.value,
   };
 }
 
@@ -759,6 +766,10 @@ function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv 
 
   if (context.socketPath) {
     childEnv.TODUAI_DAEMON_SOCKET = context.socketPath;
+  }
+
+  if (context.assignedWorkersEnvValue !== undefined) {
+    childEnv[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV] = context.assignedWorkersEnvValue;
   }
 
   return childEnv;

--- a/packages/cli/src/daemon-worker-assignment.test.ts
+++ b/packages/cli/src/daemon-worker-assignment.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDaemonAssignedWorkers,
+  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+} from "./daemon-worker-assignment.js";
+
+describe("resolveDaemonAssignedWorkers", () => {
+  it("prefers env override over config file assignments", () => {
+    const resolved = resolveDaemonAssignedWorkers(
+      {
+        daemon: {
+          workers: {
+            assigned: ["recurring", "sync"],
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "habit,task",
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: "habit,task",
+      source: "env",
+    });
+  });
+
+  it("loads assignments from config file when env override is not set", () => {
+    const resolved = resolveDaemonAssignedWorkers(
+      {
+        daemon: {
+          workers: {
+            assigned: [" recurring ", "sync", "sync"],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: "recurring,sync,sync",
+      source: "file",
+    });
+  });
+
+  it("keeps explicit empty assignment list from config", () => {
+    const resolved = resolveDaemonAssignedWorkers(
+      {
+        daemon: {
+          workers: {
+            assigned: [],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: "",
+      source: "file",
+    });
+  });
+
+  it("returns unset when neither env nor config assignments are present", () => {
+    const resolved = resolveDaemonAssignedWorkers({}, {});
+
+    expect(resolved).toEqual({
+      value: undefined,
+      source: "unset",
+    });
+  });
+});

--- a/packages/cli/src/daemon-worker-assignment.ts
+++ b/packages/cli/src/daemon-worker-assignment.ts
@@ -1,0 +1,34 @@
+import type { ToduFileConfig } from "@todu/core";
+
+export const TODUAI_DAEMON_ASSIGNED_WORKERS_ENV = "TODUAI_DAEMON_ASSIGNED_WORKERS";
+
+export interface ResolvedDaemonAssignedWorkers {
+  value: string | undefined;
+  source: "env" | "file" | "unset";
+}
+
+export function resolveDaemonAssignedWorkers(
+  config: ToduFileConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedDaemonAssignedWorkers {
+  const envValue = env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
+  if (envValue !== undefined) {
+    return {
+      value: envValue,
+      source: "env",
+    };
+  }
+
+  const fileAssigned = config.daemon?.workers?.assigned;
+  if (!fileAssigned) {
+    return {
+      value: undefined,
+      source: "unset",
+    };
+  }
+
+  return {
+    value: fileAssigned.map((workerType) => workerType.trim()).join(","),
+    source: "file",
+  };
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,6 +27,13 @@ export interface ToduFileConfig {
       enabled?: boolean;
     };
   };
+  /** Daemon-specific configuration */
+  daemon?: {
+    workers?: {
+      /** Worker types statically assigned to this daemon */
+      assigned?: string[];
+    };
+  };
 }
 
 /** Resolved remote sync config — only present when server is set and enabled. */

--- a/packages/daemon/src/entrypoint.ts
+++ b/packages/daemon/src/entrypoint.ts
@@ -4,6 +4,10 @@ import { resolveRemoteSyncConfig } from "@todu/core";
 import { createDaemonLogger, resolveDaemonLogLevelFromEnv } from "./logger.js";
 import { startDaemonProcess } from "./process.js";
 import { type DaemonRole, isDaemonRole } from "./runtime.js";
+import {
+  parseAssignedWorkerTypesFromEnv,
+  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+} from "./worker-assignment.js";
 
 function parseDaemonRole(value: string | undefined): DaemonRole {
   if (!value) {
@@ -27,6 +31,21 @@ export async function runDaemonEntrypoint(): Promise<void> {
   const daemonRole = parseDaemonRole(process.env.TODUAI_DAEMON_ROLE);
   const daemonSocketPath = process.env.TODUAI_DAEMON_SOCKET;
   const remoteSync = resolveRemoteSyncConfig({});
+  const assignmentConfig = parseAssignedWorkerTypesFromEnv(process.env);
+
+  if (assignmentConfig.duplicateWorkerTypes.length > 0) {
+    logger.warn("duplicate daemon worker assignment entries detected", {
+      envVar: TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+      duplicateWorkerTypes: assignmentConfig.duplicateWorkerTypes,
+    });
+  }
+
+  if (assignmentConfig.ignoredEntries.length > 0) {
+    logger.warn("ignored empty daemon worker assignment entries", {
+      envVar: TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+      ignoredEntryCount: assignmentConfig.ignoredEntries.length,
+    });
+  }
 
   const daemon = await startDaemonProcess(
     {
@@ -34,6 +53,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
       socketPath: daemonSocketPath,
       remoteSync: remoteSync ?? undefined,
       logLevel: daemonLogLevel,
+      assignedWorkerTypes: assignmentConfig.assignedWorkerTypes,
     },
     {
       hooks: {
@@ -42,6 +62,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
             role: status.role,
             socketPath: status.transport?.path ?? "-",
             catalogId: status.catalogId ?? "-",
+            assignedWorkerTypes: assignmentConfig.assignedWorkerTypes ?? "all",
           });
         },
         onStopping: (reason) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -82,8 +82,15 @@ export {
 } from "./transport.js";
 
 export {
+  type ParsedWorkerAssignmentEnv,
+  parseAssignedWorkerTypesFromEnv,
+  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+} from "./worker-assignment.js";
+
+export {
   type CreateWorkerRegistryOptions,
   createWorkerDependencyBlockedReason,
+  createWorkerNotAssignedReason,
   createWorkerRegistry,
   findMissingRequiredWorkerDomains,
   isWorkerDomainCapability,

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -29,6 +29,7 @@ import {
 } from "./transport.js";
 import {
   createWorkerDependencyBlockedReason,
+  createWorkerNotAssignedReason,
   createWorkerRegistry,
   findMissingRequiredWorkerDomains,
   type RegisteredWorkerSnapshot,
@@ -64,6 +65,7 @@ export interface DaemonRuntimeConfig {
   rpcNamespaceHandlers?: DaemonRpcNamespaceHandlers;
   workerRegistrations?: WorkerRegistration[];
   enabledWorkerDomains?: WorkerDomainCapability[];
+  assignedWorkerTypes?: string[];
 }
 
 export interface ResolvedDaemonRuntimeConfig {
@@ -76,6 +78,7 @@ export interface ResolvedDaemonRuntimeConfig {
   requestTimeoutMs: number;
   logLevel: DaemonLogLevel;
   enabledWorkerDomains: WorkerDomainCapability[];
+  assignedWorkerTypes?: string[];
 }
 
 export interface DaemonRuntimeStatus {
@@ -116,6 +119,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   const resolvedSocketPath = resolveUdsSocketPath(resolvedStoragePath, config.socketPath);
   const resolvedLogLevel = config.logLevel ?? resolveDaemonLogLevelFromEnv(process.env);
   const resolvedEnabledWorkerDomains = resolveEnabledWorkerDomains(config.enabledWorkerDomains);
+  const assignmentResolution = resolveAssignedWorkerTypes(config.assignedWorkerTypes);
 
   const resolvedConfig: ResolvedDaemonRuntimeConfig = {
     storagePath: resolvedStoragePath,
@@ -131,6 +135,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
     logLevel: resolvedLogLevel,
     enabledWorkerDomains: resolvedEnabledWorkerDomains,
+    assignedWorkerTypes: assignmentResolution.assignedWorkerTypes,
   };
 
   let todu: Todu | null = null;
@@ -154,6 +159,13 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       level: resolvedConfig.logLevel,
     });
 
+  if (assignmentResolution.duplicateWorkerTypes.length > 0) {
+    runtimeLogger.warn("duplicate worker assignment entries detected", {
+      duplicateWorkerTypes: assignmentResolution.duplicateWorkerTypes,
+      assignedWorkerTypes: resolvedConfig.assignedWorkerTypes ?? null,
+    });
+  }
+
   function createDependencyBlockedError(
     workerType: string,
     missingRequiredDomains: readonly WorkerDomainCapability[],
@@ -169,6 +181,68 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         enabledWorkerDomains: resolvedConfig.enabledWorkerDomains,
       },
     };
+  }
+
+  function createNotAssignedError(workerType: string, blockedReason: string): WorkerRegistryError {
+    return {
+      code: "NOT_ASSIGNED",
+      message: `Worker is not assigned to this daemon: ${workerType}`,
+      details: {
+        workerType,
+        blockedReason,
+        assignedWorkerTypes: resolvedConfig.assignedWorkerTypes ?? null,
+      },
+    };
+  }
+
+  function isWorkerAssigned(workerType: string): boolean {
+    if (!resolvedConfig.assignedWorkerTypes) {
+      return true;
+    }
+
+    return resolvedConfig.assignedWorkerTypes.includes(workerType);
+  }
+
+  function applyWorkerAssignmentGating(
+    workerType: string,
+  ): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
+    const normalizedWorkerType = workerType.trim();
+    const worker = workerRegistry.get(normalizedWorkerType);
+    if (!worker) {
+      return err({
+        code: "NOT_FOUND",
+        message: `Worker is not registered: ${normalizedWorkerType}`,
+        details: {
+          workerType: normalizedWorkerType,
+        },
+      });
+    }
+
+    if (isWorkerAssigned(worker.manifest.type)) {
+      return ok(worker);
+    }
+
+    const blockedReason = createWorkerNotAssignedReason(worker.manifest.type);
+
+    if (worker.state === "blocked" && worker.blockedReason === blockedReason) {
+      return ok(worker);
+    }
+
+    const blockedTransition = workerRegistry.transition(normalizedWorkerType, "blocked", {
+      blockedReason,
+    });
+
+    if (!blockedTransition.ok) {
+      return blockedTransition;
+    }
+
+    runtimeLogger.warn("worker blocked by static assignment", {
+      workerType: normalizedWorkerType,
+      blockedReason,
+      assignedWorkerTypes: resolvedConfig.assignedWorkerTypes ?? null,
+    });
+
+    return blockedTransition;
   }
 
   function applyWorkerDependencyGating(
@@ -226,6 +300,17 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       throw new Error(
         `Invalid worker registration for daemon runtime (${workerType}): ${registerResult.error.message}`,
       );
+    }
+
+    const assignmentGateResult = applyWorkerAssignmentGating(registerResult.value.manifest.type);
+    if (!assignmentGateResult.ok) {
+      throw new Error(
+        `Failed to apply worker assignment gating for daemon runtime (${registerResult.value.manifest.type}): ${assignmentGateResult.error.message}`,
+      );
+    }
+
+    if (!isWorkerAssigned(registerResult.value.manifest.type)) {
+      continue;
     }
 
     const dependencyGateResult = applyWorkerDependencyGating(registerResult.value.manifest.type);
@@ -649,6 +734,15 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         return registerResult;
       }
 
+      const assignmentGateResult = applyWorkerAssignmentGating(registerResult.value.manifest.type);
+      if (!assignmentGateResult.ok) {
+        return assignmentGateResult;
+      }
+
+      if (!isWorkerAssigned(registerResult.value.manifest.type)) {
+        return assignmentGateResult;
+      }
+
       return applyWorkerDependencyGating(registerResult.value.manifest.type);
     },
 
@@ -659,6 +753,18 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     ): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
       if (state !== "running") {
         return workerRegistry.transition(workerType, state, details);
+      }
+
+      const assignmentGateResult = applyWorkerAssignmentGating(workerType);
+      if (!assignmentGateResult.ok) {
+        return assignmentGateResult;
+      }
+
+      if (!isWorkerAssigned(assignmentGateResult.value.manifest.type)) {
+        const blockedReason =
+          assignmentGateResult.value.blockedReason ??
+          createWorkerNotAssignedReason(assignmentGateResult.value.manifest.type);
+        return err(createNotAssignedError(assignmentGateResult.value.manifest.type, blockedReason));
       }
 
       const dependencyGateResult = applyWorkerDependencyGating(workerType);
@@ -711,6 +817,9 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         requestTimeoutMs: resolvedConfig.requestTimeoutMs,
         logLevel: resolvedConfig.logLevel,
         enabledWorkerDomains: [...resolvedConfig.enabledWorkerDomains],
+        assignedWorkerTypes: resolvedConfig.assignedWorkerTypes
+          ? [...resolvedConfig.assignedWorkerTypes]
+          : undefined,
       };
     },
   };
@@ -747,6 +856,42 @@ function resolveEnabledWorkerDomains(
   }
 
   return normalized;
+}
+
+function resolveAssignedWorkerTypes(workerTypes: readonly string[] | undefined): {
+  assignedWorkerTypes: string[] | undefined;
+  duplicateWorkerTypes: string[];
+} {
+  if (!workerTypes) {
+    return {
+      assignedWorkerTypes: undefined,
+      duplicateWorkerTypes: [],
+    };
+  }
+
+  const normalized: string[] = [];
+  const duplicates: string[] = [];
+
+  for (const workerType of workerTypes) {
+    const trimmedWorkerType = workerType.trim();
+    if (!trimmedWorkerType) {
+      continue;
+    }
+
+    if (normalized.includes(trimmedWorkerType)) {
+      if (!duplicates.includes(trimmedWorkerType)) {
+        duplicates.push(trimmedWorkerType);
+      }
+      continue;
+    }
+
+    normalized.push(trimmedWorkerType);
+  }
+
+  return {
+    assignedWorkerTypes: normalized,
+    duplicateWorkerTypes: duplicates,
+  };
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {

--- a/packages/daemon/src/worker-assignment.test.ts
+++ b/packages/daemon/src/worker-assignment.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAssignedWorkerTypesFromEnv,
+  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+} from "./worker-assignment.js";
+
+describe("parseAssignedWorkerTypesFromEnv", () => {
+  it("returns undefined assignment when env var is not set", () => {
+    const parsed = parseAssignedWorkerTypesFromEnv({});
+
+    expect(parsed).toEqual({
+      assignedWorkerTypes: undefined,
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("parses assigned worker types from comma-separated env value", () => {
+    const parsed = parseAssignedWorkerTypesFromEnv({
+      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: " recurring,sync ",
+    });
+
+    expect(parsed).toEqual({
+      assignedWorkerTypes: ["recurring", "sync"],
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("reports duplicates and ignored empty entries", () => {
+    const parsed = parseAssignedWorkerTypesFromEnv({
+      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "recurring,,sync,recurring, ",
+    });
+
+    expect(parsed).toEqual({
+      assignedWorkerTypes: ["recurring", "sync"],
+      duplicateWorkerTypes: ["recurring"],
+      ignoredEntries: ["", " "],
+    });
+  });
+
+  it("supports explicit empty assignment list", () => {
+    const parsed = parseAssignedWorkerTypesFromEnv({
+      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "",
+    });
+
+    expect(parsed).toEqual({
+      assignedWorkerTypes: [],
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    });
+  });
+});

--- a/packages/daemon/src/worker-assignment.ts
+++ b/packages/daemon/src/worker-assignment.ts
@@ -1,0 +1,55 @@
+export const TODUAI_DAEMON_ASSIGNED_WORKERS_ENV = "TODUAI_DAEMON_ASSIGNED_WORKERS";
+
+export interface ParsedWorkerAssignmentEnv {
+  assignedWorkerTypes: string[] | undefined;
+  duplicateWorkerTypes: string[];
+  ignoredEntries: string[];
+}
+
+export function parseAssignedWorkerTypesFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ParsedWorkerAssignmentEnv {
+  const rawAssignments = env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
+  if (rawAssignments === undefined) {
+    return {
+      assignedWorkerTypes: undefined,
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    };
+  }
+
+  if (rawAssignments.trim().length === 0) {
+    return {
+      assignedWorkerTypes: [],
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    };
+  }
+
+  const assignedWorkerTypes: string[] = [];
+  const duplicateWorkerTypes: string[] = [];
+  const ignoredEntries: string[] = [];
+
+  for (const rawEntry of rawAssignments.split(",")) {
+    const workerType = rawEntry.trim();
+    if (!workerType) {
+      ignoredEntries.push(rawEntry);
+      continue;
+    }
+
+    if (assignedWorkerTypes.includes(workerType)) {
+      if (!duplicateWorkerTypes.includes(workerType)) {
+        duplicateWorkerTypes.push(workerType);
+      }
+      continue;
+    }
+
+    assignedWorkerTypes.push(workerType);
+  }
+
+  return {
+    assignedWorkerTypes,
+    duplicateWorkerTypes,
+    ignoredEntries,
+  };
+}

--- a/packages/daemon/src/workers.test.ts
+++ b/packages/daemon/src/workers.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createDaemonRuntime } from "./runtime.js";
 import {
   createWorkerDependencyBlockedReason,
+  createWorkerNotAssignedReason,
   createWorkerRegistry,
   findMissingRequiredWorkerDomains,
   validateWorkerManifest,
@@ -83,6 +84,11 @@ describe("worker dependency gating helpers", () => {
   it("creates blocked reasons with missing domain details", () => {
     const reason = createWorkerDependencyBlockedReason(["recurring", "sync"]);
     expect(reason).toBe("required domains are disabled or missing: recurring, sync");
+  });
+
+  it("creates not-assigned reasons with worker type details", () => {
+    const reason = createWorkerNotAssignedReason("recurring");
+    expect(reason).toBe("worker is not assigned to this daemon: recurring");
   });
 });
 
@@ -216,6 +222,105 @@ describe("createDaemonRuntime worker registration entrypoints", () => {
     }
 
     expect(duplicateRegistration.error.code).toBe("ALREADY_REGISTERED");
+  });
+
+  it("blocks unassigned workers from running", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      assignedWorkerTypes: ["sync"],
+    });
+
+    const registerResult = runtime.registerWorker({
+      manifest: {
+        type: "recurring",
+        requiredDomains: ["recurring"],
+      },
+    });
+
+    expect(registerResult.ok).toBe(true);
+    if (!registerResult.ok) {
+      throw new Error("Expected registration to succeed with blocked state");
+    }
+
+    expect(registerResult.value.state).toBe("blocked");
+    expect(registerResult.value.blockedReason).toBe(
+      "worker is not assigned to this daemon: recurring",
+    );
+
+    const transitionResult = runtime.transitionWorkerState("recurring", "running");
+    expect(transitionResult.ok).toBe(false);
+    if (transitionResult.ok) {
+      throw new Error("Expected transition to running to fail for unassigned worker");
+    }
+
+    expect(transitionResult.error).toMatchObject({
+      code: "NOT_ASSIGNED",
+      details: {
+        workerType: "recurring",
+        blockedReason: "worker is not assigned to this daemon: recurring",
+        assignedWorkerTypes: ["sync"],
+      },
+    });
+  });
+
+  it("applies assignment gating to startup registrations", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      assignedWorkerTypes: ["sync"],
+      workerRegistrations: [
+        {
+          manifest: {
+            type: "recurring",
+            requiredDomains: ["recurring"],
+          },
+        },
+      ],
+    });
+
+    expect(runtime.getWorker("recurring")).toMatchObject({
+      state: "blocked",
+      blockedReason: "worker is not assigned to this daemon: recurring",
+    });
+  });
+
+  it("logs duplicate assignment entries from runtime config", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-daemon-worker-runtime-test-"));
+
+    const warnings: Array<{ message: string; context?: Record<string, unknown> }> = [];
+
+    const runtimeLogger = {
+      level: "info" as const,
+      debug: () => {},
+      info: () => {},
+      warn: (message: string, context?: Record<string, unknown>) => {
+        warnings.push({ message, context });
+      },
+      error: () => {},
+      child: () => runtimeLogger,
+    };
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      assignedWorkerTypes: ["recurring", "sync", "recurring"],
+      logger: runtimeLogger,
+    });
+
+    expect(runtime.config().assignedWorkerTypes).toEqual(["recurring", "sync"]);
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "duplicate worker assignment entries detected",
+          context: expect.objectContaining({
+            duplicateWorkerTypes: ["recurring"],
+            assignedWorkerTypes: ["recurring", "sync"],
+          }),
+        }),
+      ]),
+    );
   });
 
   it("blocks worker registration when required domains are unavailable", () => {

--- a/packages/daemon/src/workers.ts
+++ b/packages/daemon/src/workers.ts
@@ -55,6 +55,7 @@ export const WORKER_REGISTRY_ERROR_CODES = [
   "INVALID_TRANSITION",
   "MISSING_BLOCKED_REASON",
   "DEPENDENCY_BLOCKED",
+  "NOT_ASSIGNED",
 ] as const;
 
 export type WorkerRegistryErrorCode = (typeof WORKER_REGISTRY_ERROR_CODES)[number];
@@ -334,6 +335,10 @@ export function createWorkerDependencyBlockedReason(
 ): string {
   const domains = missingRequiredDomains.join(", ");
   return `required domains are disabled or missing: ${domains}`;
+}
+
+export function createWorkerNotAssignedReason(workerType: string): string {
+  return `worker is not assigned to this daemon: ${workerType}`;
 }
 
 function cloneRegisteredWorker(worker: RegisteredWorkerSnapshot): RegisteredWorkerSnapshot {


### PR DESCRIPTION
## Summary
- add static worker assignment config support via `daemon.workers.assigned` with env override `TODUAI_DAEMON_ASSIGNED_WORKERS`
- enforce assignment gating in daemon runtime so unassigned workers are blocked and cannot transition to `running`
- add duplicate/empty assignment observability in daemon entrypoint/runtime logging
- document assignment behavior in architecture, phase 6/8 docs, and daemon CLI/service ops docs

## Implementation details
- `packages/core/src/config.ts`
  - extend `ToduFileConfig` with `daemon.workers.assigned`
- `packages/cli/src/daemon-worker-assignment.ts`
  - resolve assigned workers from config/env with env precedence
- `packages/cli/src/commands/daemon.ts`
  - propagate resolved worker assignment env to daemon child process
- `packages/daemon/src/worker-assignment.ts`
  - parse and normalize assignment env values
  - detect duplicate entries and ignored empty entries
- `packages/daemon/src/runtime.ts`
  - add `assignedWorkerTypes` runtime config
  - apply assignment gating on startup registrations, runtime registrations, and running transitions
  - return `NOT_ASSIGNED` when transition to `running` is blocked by assignment
  - log duplicate assignment entries from runtime config
- `packages/daemon/src/workers.ts`
  - add `NOT_ASSIGNED` worker registry error code
  - add `createWorkerNotAssignedReason(...)` helper

## Tests
- `packages/cli/src/daemon-worker-assignment.test.ts`
- `packages/daemon/src/worker-assignment.test.ts`
- `packages/daemon/src/workers.test.ts` (assignment gating + duplicate logging coverage)
- `make pre-pr`

## Docs
- `docs/ARCHITECTURE.md`
- `docs/plans/phase-6-worker-foundation.md`
- `docs/plans/phase-8-ops-controls.md`
- `docs/cli-daemon-usage.md`
- `docs/daemon-service-operations.md`

Closes #1952
