### PR TITLE
feat: expose worker status in daemon protocol

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,6 +132,12 @@ JSON-RPC-style frames:
   - `sync.statusChanged`
 - Delivery is best-effort; clients re-fetch after reconnect
 
+## Worker protocol baseline
+
+- `worker.status` is available for worker lifecycle visibility.
+- Response includes worker state, blocked/error reason fields, assignment inclusion, and dependency context.
+- Non-implemented worker control methods (for example, `worker.start`) return `UNSUPPORTED_CAPABILITY` until control APIs are introduced.
+
 ## Error taxonomy (stable codes)
 
 Includes at least:

--- a/docs/plans/1923-automerge-sync-refactor-research.md
+++ b/docs/plans/1923-automerge-sync-refactor-research.md
@@ -137,8 +137,8 @@ Practical rule: clients should converge on the same catalog document ID and refe
      - CLI: connect timeout 1s, request timeout 10s, no retries, fail-fast on unavailable daemon.
      - Electron: connect timeout 2s, reconnect backoff 250ms → 500ms → 1s → 2s (cap 2s); on reconnect, re-hello + re-subscribe + refresh.
      - Daemon: bounded per-request execution timeout (target 30s cap) returning `TIMEOUT` on overrun.
-   - Initial implemented namespaces: `daemon.*`, core domain namespaces, `events.*`.
-   - `worker.*` reserved for later and should return `UNSUPPORTED_CAPABILITY` until implemented.
+   - Initial implemented namespaces: `daemon.*`, core domain namespaces, `events.*`, and `worker.status`.
+   - Remaining `worker.*` control methods stay unsupported and return `UNSUPPORTED_CAPABILITY` until implemented.
 
 4. **Operational UX for manual worker reassignment/failover**
    - **Resolved in planning (initial model)**.

--- a/docs/plans/phase-6-worker-foundation.md
+++ b/docs/plans/phase-6-worker-foundation.md
@@ -42,8 +42,9 @@ Implement the first worker/plugin runtime layer in daemon architecture. Focus on
    - Surface worker state for operational inspection
 
 6. **Protocol surface baseline**
-   - Provide worker state visibility via daemon protocol
-   - `worker.*` namespace may be minimal initially but must support status visibility
+   - Provide worker state visibility via daemon protocol.
+   - Implement `worker.status` for status visibility.
+   - Keep non-implemented worker control methods returning `UNSUPPORTED_CAPABILITY` until control APIs land.
 
 ### Baseline Worker Contract (Task #1950)
 
@@ -90,6 +91,17 @@ Daemon runtime registration/lifecycle entrypoints:
 - Required-domain checks run for workers loaded at daemon startup and for runtime registrations (reload-equivalent path).
 - If a required domain is unavailable, the worker transitions to `blocked` with a deterministic blocked reason that lists missing/disabled domains.
 - Attempting to transition a dependency-blocked worker to `running` returns a dependency-blocked error and keeps worker state `blocked`.
+
+## Worker Status Protocol Contract (Initial)
+
+- Method: `worker.status`
+- Optional input: `params.workerType` (non-empty string) to query a single worker.
+- Output includes:
+  - `workers[]` entries with `type`, `state`, `blockedReason`, `errorMessage`, `updatedAt`
+  - assignment context (`isAssigned` per worker and global assigned worker list)
+  - dependency context (`missingRequiredDomains` per worker and enabled worker domains)
+- Unknown worker requested via `params.workerType` returns `NOT_FOUND`.
+- Non-implemented worker control methods remain unsupported and return `UNSUPPORTED_CAPABILITY`.
 
 ## Acceptance Criteria
 

--- a/packages/daemon/src/protocol-conformance.test.ts
+++ b/packages/daemon/src/protocol-conformance.test.ts
@@ -263,22 +263,40 @@ describe("daemon protocol conformance suite", () => {
     });
   });
 
-  it("returns UNSUPPORTED_CAPABILITY for reserved worker namespace methods", async () => {
+  it("returns worker status and keeps non-implemented worker control methods unsupported", async () => {
     await withRunningRuntime({}, async (runtime) => {
-      const response = await sendRequest(runtime.config().socketPath, {
-        id: "worker-status-unsupported",
+      const statusResponse = await sendRequest(runtime.config().socketPath, {
+        id: "worker-status-1",
         method: "worker.status",
         params: {},
       });
 
-      expect(response).toEqual({
-        id: "worker-status-unsupported",
+      expect(statusResponse).toEqual({
+        id: "worker-status-1",
+        result: {
+          workers: [],
+          assignment: {
+            assignedWorkerTypes: null,
+          },
+          enabledWorkerDomains: ["project", "task", "label", "note", "recurring", "habit", "sync"],
+        },
+      });
+
+      const unsupportedControlResponse = await sendRequest(runtime.config().socketPath, {
+        id: "worker-start-unsupported",
+        method: "worker.start",
+        params: {},
+      });
+
+      expect(unsupportedControlResponse).toEqual({
+        id: "worker-start-unsupported",
         error: {
           code: "UNSUPPORTED_CAPABILITY",
-          message: "Namespace is reserved but not implemented: worker",
+          message: "Method is not implemented: worker.start",
           details: {
             namespace: "worker",
-            method: "worker.status",
+            method: "worker.start",
+            capability: "worker.start",
           },
         },
       });

--- a/packages/daemon/src/rpc.test.ts
+++ b/packages/daemon/src/rpc.test.ts
@@ -369,6 +369,43 @@ describe("createDaemonRpcRouter", () => {
     });
   });
 
+  it("returns method-level unsupported errors for reserved namespaces with partial handlers", async () => {
+    const router = createDaemonRpcRouter({
+      namespaceHandlers: {
+        worker: {
+          status: (request) =>
+            createProtocolSuccessFrame(request.id, {
+              workers: [],
+            }),
+        },
+      },
+    });
+
+    const response = await router.handleRequest(
+      {
+        id: "worker-start-1",
+        method: "worker.start",
+        params: {},
+      },
+      context,
+    );
+
+    expect("error" in response).toBe(true);
+    if (!("error" in response)) {
+      throw new Error("Expected unsupported capability response");
+    }
+
+    expect(response.error).toEqual({
+      code: "UNSUPPORTED_CAPABILITY",
+      message: "Method is not implemented: worker.start",
+      details: {
+        namespace: "worker",
+        method: "worker.start",
+        capability: "worker.start",
+      },
+    });
+  });
+
   it("maps invalid JSON payloads to BAD_REQUEST through handlePayload", async () => {
     const router = createDaemonRpcRouter();
 

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -63,10 +63,14 @@ export const CORE_DAEMON_NAMESPACE_METHODS = {
 } as const;
 
 export const RESERVED_DAEMON_NAMESPACES = ["worker"] as const;
+export const WORKER_DAEMON_NAMESPACE_METHODS = {
+  worker: ["status"],
+} as const;
 
 export const DAEMON_CAPABILITY_METHODS = [
   ...DAEMON_BASE_METHODS,
-  ...listCoreNamespaceMethods(),
+  ...listNamespaceMethods(CORE_DAEMON_NAMESPACE_METHODS),
+  ...listNamespaceMethods(WORKER_DAEMON_NAMESPACE_METHODS),
 ] as const;
 
 export type DaemonCapabilityEvent = (typeof DAEMON_CAPABILITY_EVENTS)[number];
@@ -217,17 +221,35 @@ export function createDaemonRpcRouter(options: CreateDaemonRpcRouterOptions = {}
     if (!handler) {
       const parsedMethod = parseMethod(request.method);
       if (parsedMethod && isReservedDaemonNamespace(parsedMethod.namespace)) {
-        response = createProtocolErrorFrame(
-          request.id,
-          createProtocolError(
-            "UNSUPPORTED_CAPABILITY",
-            `Namespace is reserved but not implemented: ${parsedMethod.namespace}`,
-            {
-              namespace: parsedMethod.namespace,
-              method: request.method,
-            },
-          ),
-        );
+        const hasNamespaceHandlers =
+          Object.keys(namespaceHandlers[parsedMethod.namespace] ?? {}).length > 0;
+
+        if (hasNamespaceHandlers) {
+          response = createProtocolErrorFrame(
+            request.id,
+            createProtocolError(
+              "UNSUPPORTED_CAPABILITY",
+              `Method is not implemented: ${request.method}`,
+              {
+                namespace: parsedMethod.namespace,
+                method: request.method,
+                capability: request.method,
+              },
+            ),
+          );
+        } else {
+          response = createProtocolErrorFrame(
+            request.id,
+            createProtocolError(
+              "UNSUPPORTED_CAPABILITY",
+              `Namespace is reserved but not implemented: ${parsedMethod.namespace}`,
+              {
+                namespace: parsedMethod.namespace,
+                method: request.method,
+              },
+            ),
+          );
+        }
       } else {
         response = createProtocolErrorFrame(
           request.id,
@@ -487,12 +509,12 @@ export function createDaemonRpcRouter(options: CreateDaemonRpcRouterOptions = {}
   };
 }
 
-function listCoreNamespaceMethods(): string[] {
+function listNamespaceMethods(namespaceMethods: Record<string, readonly string[]>): string[] {
   const methods: string[] = [];
 
-  const namespaces = Object.keys(CORE_DAEMON_NAMESPACE_METHODS).sort() as CoreDaemonNamespace[];
+  const namespaces = Object.keys(namespaceMethods).sort();
   for (const namespace of namespaces) {
-    for (const methodName of CORE_DAEMON_NAMESPACE_METHODS[namespace]) {
+    for (const methodName of namespaceMethods[namespace] ?? []) {
       methods.push(`${namespace}.${methodName}`);
     }
   }

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -973,6 +973,101 @@ describe("createDaemonRuntime", () => {
     }
   });
 
+  it("returns worker status with assignment and dependency metadata", async () => {
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      assignedWorkerTypes: ["sync"],
+      enabledWorkerDomains: ["task", "sync"],
+      workerRegistrations: [
+        {
+          manifest: {
+            type: "recurring",
+            requiredDomains: ["recurring"],
+            optionalDomains: ["task"],
+            roleHints: ["authority"],
+          },
+        },
+      ],
+    });
+
+    await runtime.start();
+
+    const listResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-list-1",
+      method: "worker.status",
+      params: {},
+    });
+
+    expect(listResponse).toEqual({
+      id: "worker-status-list-1",
+      result: {
+        workers: [
+          {
+            type: "recurring",
+            state: "blocked",
+            blockedReason: "worker is not assigned to this daemon: recurring",
+            errorMessage: null,
+            updatedAt: expect.any(String),
+            requiredDomains: ["recurring"],
+            optionalDomains: ["task"],
+            roleHints: ["authority"],
+            isAssigned: false,
+            missingRequiredDomains: ["recurring"],
+          },
+        ],
+        assignment: {
+          assignedWorkerTypes: ["sync"],
+        },
+        enabledWorkerDomains: ["task", "sync"],
+      },
+    });
+
+    const singleResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-single-1",
+      method: "worker.status",
+      params: {
+        workerType: "recurring",
+      },
+    });
+
+    expect(singleResponse.id).toBe("worker-status-single-1");
+    expect((singleResponse.result as { workers: unknown[] }).workers).toHaveLength(1);
+
+    const missingWorkerResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-missing-1",
+      method: "worker.status",
+      params: {
+        workerType: "unknown-worker",
+      },
+    });
+
+    expect(missingWorkerResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "Worker is not registered: unknown-worker",
+      details: {
+        workerType: "unknown-worker",
+      },
+    });
+
+    const invalidWorkerTypeResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-invalid-1",
+      method: "worker.status",
+      params: {
+        workerType: "",
+      },
+    });
+
+    expect(invalidWorkerTypeResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "worker.status requires optional params.workerType as a non-empty string",
+      details: {
+        field: "workerType",
+      },
+    });
+
+    await runtime.stop();
+  });
+
   it("maps domain and request validation errors for project/task/label/note/recurring/habit/sync methods", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
@@ -1119,18 +1214,19 @@ describe("createDaemonRuntime", () => {
       },
     });
 
-    const reservedNamespaceResponse = await sendRequest(runtime.config().socketPath, {
-      id: "worker-status-unsupported",
-      method: "worker.status",
+    const unsupportedWorkerControlResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-start-unsupported",
+      method: "worker.start",
       params: {},
     });
 
-    expect(reservedNamespaceResponse.error).toEqual({
+    expect(unsupportedWorkerControlResponse.error).toEqual({
       code: "UNSUPPORTED_CAPABILITY",
-      message: "Namespace is reserved but not implemented: worker",
+      message: "Method is not implemented: worker.start",
       details: {
         namespace: "worker",
-        method: "worker.status",
+        method: "worker.start",
+        capability: "worker.start",
       },
     });
 

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -322,10 +322,13 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   }
 
   const defaultNamespaceHandlers = mergeNamespaceHandlerSets(
-    createCoreNamespaceHandlers({
-      getTodu: () => todu,
-    }),
-    createJoinSyncNamespaceHandlers(),
+    mergeNamespaceHandlerSets(
+      createCoreNamespaceHandlers({
+        getTodu: () => todu,
+      }),
+      createJoinSyncNamespaceHandlers(),
+    ),
+    createWorkerNamespaceHandlers(),
   );
 
   const rpcLogger = runtimeLogger.child("rpc");
@@ -478,6 +481,81 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
           } finally {
             joinPromise = null;
           }
+        },
+      },
+    };
+  }
+
+  function createWorkerNamespaceHandlers(): DaemonRpcNamespaceHandlers {
+    return {
+      worker: {
+        status: (request) => {
+          const workerTypeParam = request.params.workerType;
+
+          let workers: RegisteredWorkerSnapshot[];
+          if (workerTypeParam === undefined) {
+            workers = workerRegistry.list();
+          } else {
+            if (typeof workerTypeParam !== "string" || workerTypeParam.trim().length === 0) {
+              return createProtocolErrorFrame(
+                request.id,
+                createProtocolError(
+                  "BAD_REQUEST",
+                  "worker.status requires optional params.workerType as a non-empty string",
+                  {
+                    field: "workerType",
+                  },
+                ),
+              );
+            }
+
+            const normalizedWorkerType = workerTypeParam.trim();
+            const worker = workerRegistry.get(normalizedWorkerType);
+            if (!worker) {
+              return createProtocolErrorFrame(
+                request.id,
+                createProtocolError(
+                  "NOT_FOUND",
+                  `Worker is not registered: ${normalizedWorkerType}`,
+                  {
+                    workerType: normalizedWorkerType,
+                  },
+                ),
+              );
+            }
+
+            workers = [worker];
+          }
+
+          return createProtocolSuccessFrame(request.id, {
+            workers: workers.map((worker) => {
+              const missingRequiredDomains = findMissingRequiredWorkerDomains(
+                worker.manifest.requiredDomains,
+                resolvedConfig.enabledWorkerDomains,
+              );
+
+              return {
+                type: worker.manifest.type,
+                state: worker.state,
+                blockedReason: worker.blockedReason ?? null,
+                errorMessage: worker.errorMessage ?? null,
+                updatedAt: worker.updatedAt,
+                requiredDomains: [...worker.manifest.requiredDomains],
+                optionalDomains: worker.manifest.optionalDomains
+                  ? [...worker.manifest.optionalDomains]
+                  : [],
+                roleHints: worker.manifest.roleHints ? [...worker.manifest.roleHints] : [],
+                isAssigned: isWorkerAssigned(worker.manifest.type),
+                missingRequiredDomains,
+              };
+            }),
+            assignment: {
+              assignedWorkerTypes: resolvedConfig.assignedWorkerTypes
+                ? [...resolvedConfig.assignedWorkerTypes]
+                : null,
+            },
+            enabledWorkerDomains: [...resolvedConfig.enabledWorkerDomains],
+          });
         },
       },
     };


### PR DESCRIPTION
## Summary
- implement `worker.status` in daemon runtime so worker lifecycle visibility is queryable over protocol
- include actionable metadata in status output: blocked/error reasons, assignment inclusion, and dependency context
- keep non-implemented worker control methods returning `UNSUPPORTED_CAPABILITY`
- document the worker status protocol baseline and temporary unsupported control behavior

## Implementation details
- `packages/daemon/src/runtime.ts`
  - add `worker.status` namespace handler to runtime default namespace set
  - support optional `params.workerType` filtering for single-worker lookup
  - return structured status payload with `workers`, `assignment`, and `enabledWorkerDomains`
  - return `BAD_REQUEST` for invalid `workerType` and `NOT_FOUND` for unknown worker
- `packages/daemon/src/rpc.ts`
  - add `worker.status` to advertised daemon capability methods
  - refine reserved-namespace unsupported behavior so partially implemented reserved namespaces return method-level unsupported errors for unknown methods
- tests
  - `packages/daemon/src/runtime.test.ts`
  - `packages/daemon/src/rpc.test.ts`
  - `packages/daemon/src/protocol-conformance.test.ts`

## Verification
- `npm run test -- packages/daemon/src/rpc.test.ts packages/daemon/src/runtime.test.ts packages/daemon/src/protocol-conformance.test.ts`
- `make pre-pr`

## Docs
- `docs/ARCHITECTURE.md`
- `docs/plans/1923-automerge-sync-refactor-research.md`
- `docs/plans/phase-6-worker-foundation.md`

Closes #202
