### PR TITLE
feat: partition notes storage into bucketed documents

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,6 +81,20 @@ daemon(A) <--> relay <--> daemon(B) <--> relay <--> daemon(C)
 - Dataset is rooted by a catalog document ID.
 - All clients/daemons for the same dataset should converge on the same catalog ID and referenced sub-document graph.
 
+### Notes storage partitioning
+
+Notes are partitioned into multiple Automerge documents instead of one global notes document.
+
+- Catalog keeps `notesBucketDocIds` (bucket key → document ID).
+- Catalog keeps `noteBucketByNoteId` (note ID → bucket key) for direct update/delete lookup.
+- Bucket selection:
+  - Entity-attached notes use `entity:<type>:<entityId>`.
+  - Standalone journal notes use monthly buckets `journal:<YYYY-MM>`.
+
+This keeps write contention localized and bounds per-document history growth as note volume increases.
+
+Diagnostics: set `TODU_NOTES_DIAGNOSTICS=1` to log notes bucket usage and legacy migration counts during engine operations.
+
 ### Bootstrap vs Join
 
 - **Bootstrap** (first run, no marker/catalog): creating initial catalog is allowed.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -34,6 +34,16 @@ describe("schema", () => {
       expect(catalog.taskListDocIds).toEqual({});
     });
 
+    it("creates a catalog with empty notesBucketDocIds", () => {
+      const catalog = createEmptyCatalog();
+      expect(catalog.notesBucketDocIds).toEqual({});
+    });
+
+    it("creates a catalog with empty noteBucketByNoteId", () => {
+      const catalog = createEmptyCatalog();
+      expect(catalog.noteBucketByNoteId).toEqual({});
+    });
+
     it("creates a catalog with settings", () => {
       const catalog = createEmptyCatalog();
       expect(catalog.settings.schemaVersion).toBe(SCHEMA_VERSION);

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -36,8 +36,14 @@ export interface CatalogDocument {
    */
   taskListDocIds: Record<string, string>;
 
-  /** Automerge document ID for the notes document */
+  /** Legacy Automerge document ID for the old single notes document model */
   notesDocId?: string;
+
+  /** Map of notes partition key → Automerge document ID */
+  notesBucketDocIds: Record<string, string>;
+
+  /** Map of note ID → notes partition key */
+  noteBucketByNoteId: Record<string, string>;
 
   /** Recurring task templates */
   recurringTemplates: RecurringTemplate[];
@@ -88,12 +94,11 @@ export interface TaskDetailDocument {
 }
 
 /**
- * Notes document (one global).
- * Contains all notes — standalone journal entries and entity-attached notes.
- * Each note is ~200B, so thousands fit comfortably.
+ * Notes document (partition bucket).
+ * Each bucket stores a subset of notes to reduce write contention and history growth.
  */
 export interface NotesDocument {
-  /** All notes */
+  /** Notes for this bucket */
   notes: Note[];
 }
 
@@ -125,6 +130,8 @@ export function createEmptyCatalog(): CatalogDocument {
     projects: [],
     labels: [],
     taskListDocIds: {},
+    notesBucketDocIds: {},
+    noteBucketByNoteId: {},
     recurringTemplates: [],
     habits: [],
     habitLogDocIds: {},

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -174,7 +174,7 @@ export interface Label {
 }
 
 // ============================================================================
-// Note entity — stored in NotesDocument
+// Note entity — stored in partitioned NotesDocument buckets
 // ============================================================================
 
 export const NOTE_ENTITY_TYPES = ["task", "project", "habit"] as const;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -134,6 +134,7 @@ export async function createTodu(
     const docIds: string[] = [
       ...Object.values(catalogDoc.taskListDocIds ?? {}),
       ...Object.values(catalogDoc.habitLogDocIds ?? {}),
+      ...Object.values(catalogDoc.notesBucketDocIds ?? {}),
     ];
     if (catalogDoc.notesDocId) docIds.push(catalogDoc.notesDocId);
     if (docIds.length > 0) {

--- a/packages/engine/src/notes.test.ts
+++ b/packages/engine/src/notes.test.ts
@@ -1,11 +1,39 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ProjectId } from "@todu/core";
-import { createNoteId } from "@todu/core";
+import type { DocumentId } from "@automerge/automerge-repo";
+import { Repo } from "@automerge/automerge-repo";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import {
+  type CatalogDocument,
+  createEmptyCatalog,
+  createNoteId,
+  createNotesDocument,
+  type Note,
+  type ProjectId,
+} from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
+
+async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim() as DocumentId;
+
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalog = await repo.find<CatalogDocument>(catalogId);
+    const doc = catalog.doc();
+    if (!doc) throw new Error("catalog document not available");
+
+    return JSON.parse(JSON.stringify(doc)) as CatalogDocument;
+  } finally {
+    await repo.shutdown();
+  }
+}
 
 describe("note namespace", () => {
   let tmpDir: string;
@@ -308,6 +336,93 @@ describe("note namespace", () => {
       expect(result.value).toHaveLength(1);
       expect(result.value[0].content).toBe("Persistent thought");
       expect(result.value[0].tags).toEqual(["journal"]);
+    });
+
+    it("stores notes in partitioned bucket documents", async () => {
+      const task = await todu.task.create({ title: "Task for notes", projectId });
+      if (!task.ok) throw new Error("create failed");
+
+      const journalNote = await todu.note.create({ content: "Journal" });
+      const taskNote = await todu.note.create({
+        content: "Task attached",
+        entityType: "task",
+        entityId: task.value.id,
+      });
+      if (!journalNote.ok || !taskNote.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const catalogDoc = await readCatalogDocument(tmpDir);
+      const month = journalNote.value.createdAt.slice(0, 7);
+      const journalBucket = `journal:${month}`;
+      const taskBucket = `entity:task:${task.value.id}`;
+
+      expect(catalogDoc.notesDocId).toBeUndefined();
+      expect(Object.keys(catalogDoc.notesBucketDocIds)).toEqual(
+        expect.arrayContaining([journalBucket, taskBucket]),
+      );
+      expect(catalogDoc.noteBucketByNoteId[journalNote.value.id]).toBe(journalBucket);
+      expect(catalogDoc.noteBucketByNoteId[taskNote.value.id]).toBe(taskBucket);
+    });
+
+    it("migrates legacy notesDocId data into partition buckets", async () => {
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const repo = new Repo({
+        storage: new NodeFSStorageAdapter(tmpDir),
+      });
+      const catalogHandle = repo.create<CatalogDocument>();
+      const legacyNotesHandle = repo.create<ReturnType<typeof createNotesDocument>>();
+      const legacyTemplate = createNotesDocument();
+      const legacyNote: Note = {
+        id: createNoteId("note-legacy"),
+        content: "Legacy note",
+        author: "user",
+        tags: ["legacy"],
+        createdAt: "2026-02-24T12:00:00.000Z",
+      };
+
+      legacyNotesHandle.change((doc) => {
+        doc.notes = legacyTemplate.notes;
+        doc.notes.push(legacyNote);
+      });
+
+      catalogHandle.change((doc) => {
+        const empty = createEmptyCatalog();
+        doc.version = empty.version;
+        doc.projects = empty.projects;
+        doc.labels = empty.labels;
+        doc.taskListDocIds = empty.taskListDocIds;
+        doc.notesBucketDocIds = empty.notesBucketDocIds;
+        doc.noteBucketByNoteId = empty.noteBucketByNoteId;
+        doc.notesDocId = legacyNotesHandle.documentId;
+        doc.recurringTemplates = empty.recurringTemplates;
+        doc.habits = empty.habits;
+        doc.habitLogDocIds = empty.habitLogDocIds;
+        doc.settings = empty.settings;
+      });
+
+      fs.writeFileSync(path.join(tmpDir, "todu-catalog.id"), catalogHandle.documentId, "utf-8");
+      await repo.flush();
+      await repo.shutdown();
+      await new Promise((r) => setTimeout(r, 50));
+
+      todu = await createTodu({ storagePath: tmpDir });
+      const notes = await todu.note.list();
+      expect(notes.ok).toBe(true);
+      if (!notes.ok) return;
+      expect(notes.value.map((note) => note.id)).toContain(legacyNote.id);
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const catalogDoc = await readCatalogDocument(tmpDir);
+      expect(catalogDoc.notesDocId).toBeUndefined();
+      expect(catalogDoc.noteBucketByNoteId[legacyNote.id]).toBe("journal:2026-02");
     });
   });
 });

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -20,24 +20,58 @@ import {
 } from "@todu/core";
 import type { NoteNamespace } from "./todu.js";
 
+const NOTES_DIAGNOSTICS_ENV = "TODU_NOTES_DIAGNOSTICS";
+
+interface NoteLocation {
+  bucketKey: string;
+  handle: DocHandle<NotesDocument>;
+  index: number;
+}
+
 // ============================================================================
-// Note namespace — CRUD on NotesDocument
+// Note namespace — CRUD on partitioned NotesDocument buckets
 // ============================================================================
 
 export function createNoteNamespace(
   catalog: DocHandle<CatalogDocument>,
   repo: Repo,
 ): NoteNamespace {
-  /**
-   * Get or create the global NotesDocument.
-   */
-  async function getOrCreateNotesDoc(): Promise<DocHandle<NotesDocument>> {
-    const catalogDoc = catalog.doc();
-    const existingDocId = catalogDoc?.notesDocId;
+  function diagnosticsEnabled(): boolean {
+    const value = process.env[NOTES_DIAGNOSTICS_ENV];
+    return value === "1" || value?.toLowerCase() === "true";
+  }
 
-    if (existingDocId) {
-      return await repo.find<NotesDocument>(existingDocId as DocumentId);
+  function emitDiagnostic(event: string, payload: Record<string, unknown>): void {
+    if (!diagnosticsEnabled()) return;
+    console.info(`[notes] ${event} ${JSON.stringify(payload)}`);
+  }
+
+  function noteBucketKeyForNote(note: Note): string {
+    if (note.entityType && note.entityId) {
+      return `entity:${note.entityType}:${note.entityId}`;
     }
+
+    // Standalone notes partition by month (YYYY-MM)
+    return `journal:${note.createdAt.slice(0, 7)}`;
+  }
+
+  function noteBucketKeyForFilter(filter: NoteFilter): string | null {
+    if (filter.entityType && filter.entityId) {
+      return `entity:${filter.entityType}:${filter.entityId}`;
+    }
+    return null;
+  }
+
+  async function getBucketHandle(bucketKey: string): Promise<DocHandle<NotesDocument> | null> {
+    const catalogDoc = catalog.doc();
+    const docId = catalogDoc?.notesBucketDocIds?.[bucketKey];
+    if (!docId) return null;
+    return repo.find<NotesDocument>(docId as DocumentId);
+  }
+
+  async function getOrCreateBucketHandle(bucketKey: string): Promise<DocHandle<NotesDocument>> {
+    const existing = await getBucketHandle(bucketKey);
+    if (existing) return existing;
 
     const handle = repo.create<NotesDocument>();
     const template = createNotesDocument();
@@ -46,10 +80,166 @@ export function createNoteNamespace(
     });
 
     catalog.change((doc) => {
-      doc.notesDocId = handle.documentId;
+      if (doc.notesBucketDocIds === undefined || doc.notesBucketDocIds === null) {
+        doc.notesBucketDocIds = {};
+      }
+      doc.notesBucketDocIds[bucketKey] = handle.documentId;
     });
 
     return handle;
+  }
+
+  function appendNotesWithoutDuplicates(handle: DocHandle<NotesDocument>, notes: Note[]): void {
+    handle.change((doc) => {
+      const existingIds = new Set(doc.notes.map((note) => note.id));
+      for (const note of notes) {
+        if (!existingIds.has(note.id)) {
+          doc.notes.push(toStorageNote(note));
+          existingIds.add(note.id);
+        }
+      }
+    });
+  }
+
+  async function migrateLegacyGlobalNotesDoc(): Promise<void> {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc?.notesDocId) return;
+
+    const legacyHandle = await repo.find<NotesDocument>(catalogDoc.notesDocId as DocumentId);
+    const legacyDoc = legacyHandle.doc();
+    const notesToMigrate = legacyDoc?.notes.map(cloneNote) ?? [];
+
+    if (notesToMigrate.length === 0) {
+      catalog.change((doc) => {
+        delete doc.notesDocId;
+      });
+      return;
+    }
+
+    const byBucket = new Map<string, Note[]>();
+    for (const note of notesToMigrate) {
+      const bucketKey = noteBucketKeyForNote(note);
+      const bucketNotes = byBucket.get(bucketKey);
+      if (bucketNotes) {
+        bucketNotes.push(note);
+      } else {
+        byBucket.set(bucketKey, [note]);
+      }
+    }
+
+    for (const [bucketKey, notes] of byBucket) {
+      const bucketHandle = await getOrCreateBucketHandle(bucketKey);
+      appendNotesWithoutDuplicates(bucketHandle, notes);
+    }
+
+    catalog.change((doc) => {
+      if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
+        doc.noteBucketByNoteId = {};
+      }
+
+      for (const note of notesToMigrate) {
+        doc.noteBucketByNoteId[note.id] = noteBucketKeyForNote(note);
+      }
+
+      delete doc.notesDocId;
+    });
+
+    // Remove migrated entries from legacy doc to avoid future duplicate migrations.
+    legacyHandle.change((doc) => {
+      doc.notes.splice(0, doc.notes.length);
+    });
+
+    emitDiagnostic("legacy-migration", {
+      migratedNoteCount: notesToMigrate.length,
+      targetBucketCount: byBucket.size,
+    });
+  }
+
+  async function ensurePartitionModelReady(): Promise<void> {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc) return;
+
+    if (
+      catalogDoc.notesBucketDocIds === undefined ||
+      catalogDoc.notesBucketDocIds === null ||
+      catalogDoc.noteBucketByNoteId === undefined ||
+      catalogDoc.noteBucketByNoteId === null
+    ) {
+      catalog.change((doc) => {
+        if (doc.notesBucketDocIds === undefined || doc.notesBucketDocIds === null) {
+          doc.notesBucketDocIds = {};
+        }
+        if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
+          doc.noteBucketByNoteId = {};
+        }
+      });
+    }
+
+    await migrateLegacyGlobalNotesDoc();
+  }
+
+  async function findNoteLocation(id: NoteId): Promise<NoteLocation | null> {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc) return null;
+
+    const indexedBucketKey = catalogDoc.noteBucketByNoteId?.[id];
+    if (indexedBucketKey) {
+      const handle = await getBucketHandle(indexedBucketKey);
+      const notesDoc = handle?.doc();
+      if (handle && notesDoc) {
+        const index = notesDoc.notes.findIndex((n) => n.id === id);
+        if (index !== -1) {
+          return { bucketKey: indexedBucketKey, handle, index };
+        }
+      }
+
+      // Repair stale index entry.
+      catalog.change((doc) => {
+        if (!doc.noteBucketByNoteId) return;
+        delete doc.noteBucketByNoteId[id];
+      });
+    }
+
+    for (const [bucketKey, docId] of Object.entries(catalogDoc.notesBucketDocIds ?? {})) {
+      const handle = await repo.find<NotesDocument>(docId as DocumentId);
+      const notesDoc = handle.doc();
+      if (!notesDoc) continue;
+
+      const index = notesDoc.notes.findIndex((n) => n.id === id);
+      if (index === -1) continue;
+
+      catalog.change((doc) => {
+        if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
+          doc.noteBucketByNoteId = {};
+        }
+        doc.noteBucketByNoteId[id] = bucketKey;
+      });
+
+      return { bucketKey, handle, index };
+    }
+
+    return null;
+  }
+
+  function listBucketKeys(filter?: NoteFilter): string[] {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc?.notesBucketDocIds) return [];
+
+    const allBucketKeys = Object.keys(catalogDoc.notesBucketDocIds);
+
+    if (!filter) return allBucketKeys;
+
+    const exactEntityBucketKey = noteBucketKeyForFilter(filter);
+    if (exactEntityBucketKey) {
+      return catalogDoc.notesBucketDocIds[exactEntityBucketKey] ? [exactEntityBucketKey] : [];
+    }
+
+    if (filter.entityType) {
+      const prefix = `entity:${filter.entityType}:`;
+      return allBucketKeys.filter((bucketKey) => bucketKey.startsWith(prefix));
+    }
+
+    return allBucketKeys;
   }
 
   /**
@@ -81,6 +271,8 @@ export function createNoteNamespace(
       const validationErr = validateCreateNoteInput(input);
       if (validationErr) return err(validationErr);
 
+      await ensurePartitionModelReady();
+
       // Verify entity exists if attached
       if (input.entityType && input.entityId) {
         const exists = await entityExists(input.entityType, input.entityId);
@@ -102,23 +294,42 @@ export function createNoteNamespace(
       if (input.entityType !== undefined) note.entityType = input.entityType;
       if (input.entityId !== undefined) note.entityId = input.entityId;
 
-      const notesHandle = await getOrCreateNotesDoc();
-      notesHandle.change((doc) => {
-        doc.notes.push(note);
+      const bucketKey = noteBucketKeyForNote(note);
+      const notesHandle = await getOrCreateBucketHandle(bucketKey);
+      appendNotesWithoutDuplicates(notesHandle, [note]);
+
+      catalog.change((doc) => {
+        if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
+          doc.noteBucketByNoteId = {};
+        }
+        doc.noteBucketByNoteId[id] = bucketKey;
+      });
+
+      emitDiagnostic("create", {
+        noteId: id,
+        bucketKey,
       });
 
       return ok(note);
     },
 
     async list(filter?: NoteFilter): Promise<Result<Note[]>> {
-      const catalogDoc = catalog.doc();
-      if (!catalogDoc?.notesDocId) return ok([]);
+      await ensurePartitionModelReady();
 
-      const notesHandle = await repo.find<NotesDocument>(catalogDoc.notesDocId as DocumentId);
-      const notesDoc = notesHandle.doc();
-      if (!notesDoc) return ok([]);
+      const bucketKeys = listBucketKeys(filter);
+      if (bucketKeys.length === 0) return ok([]);
 
-      let notes = notesDoc.notes.map(cloneNote);
+      const allNotes: Note[] = [];
+
+      for (const bucketKey of bucketKeys) {
+        const bucketHandle = await getBucketHandle(bucketKey);
+        const bucketDoc = bucketHandle?.doc();
+        if (!bucketDoc) continue;
+
+        allNotes.push(...bucketDoc.notes.map(cloneNote));
+      }
+
+      let notes = allNotes;
 
       // Apply filters
       if (filter?.entityType) {
@@ -128,14 +339,23 @@ export function createNoteNamespace(
         notes = notes.filter((n) => n.entityId === filter.entityId);
       }
       if (filter?.tag) {
-        notes = notes.filter((n) => n.tags.includes(filter.tag!));
+        const tag = filter.tag;
+        notes = notes.filter((n) => n.tags.includes(tag));
       }
       if (filter?.author) {
-        notes = notes.filter((n) => n.author === filter.author);
+        const author = filter.author;
+        notes = notes.filter((n) => n.author === author);
       }
 
       // Sort by createdAt desc (newest first)
       notes.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+      emitDiagnostic("list", {
+        bucketCount: bucketKeys.length,
+        resultCount: notes.length,
+        entityType: filter?.entityType,
+        hasEntityId: filter?.entityId !== undefined,
+      });
 
       return ok(notes);
     },
@@ -144,18 +364,13 @@ export function createNoteNamespace(
       const validationErr = validateUpdateNoteInput(input);
       if (validationErr) return err(validationErr);
 
-      const catalogDoc = catalog.doc();
-      if (!catalogDoc?.notesDocId) return err(notFound("note", id));
+      await ensurePartitionModelReady();
 
-      const notesHandle = await repo.find<NotesDocument>(catalogDoc.notesDocId as DocumentId);
-      const notesDoc = notesHandle.doc();
-      if (!notesDoc) return err(notFound("note", id));
+      const location = await findNoteLocation(id);
+      if (!location) return err(notFound("note", id));
 
-      const index = notesDoc.notes.findIndex((n) => n.id === id);
-      if (index === -1) return err(notFound("note", id));
-
-      notesHandle.change((doc) => {
-        const note = doc.notes[index];
+      location.handle.change((doc) => {
+        const note = doc.notes[location.index];
         if (input.content !== undefined) note.content = input.content.trim();
         if (input.tags !== undefined) {
           // Clear and repopulate tags array for Automerge compatibility
@@ -164,23 +379,47 @@ export function createNoteNamespace(
         }
       });
 
-      const updated = notesHandle.doc()!.notes[index];
+      const updated = location.handle.doc()?.notes[location.index];
+      if (!updated) return err(notFound("note", id));
+
+      emitDiagnostic("update", {
+        noteId: id,
+        bucketKey: location.bucketKey,
+      });
+
       return ok(cloneNote(updated));
     },
 
     async delete(id: NoteId): Promise<Result<void>> {
-      const catalogDoc = catalog.doc();
-      if (!catalogDoc?.notesDocId) return err(notFound("note", id));
+      await ensurePartitionModelReady();
 
-      const notesHandle = await repo.find<NotesDocument>(catalogDoc.notesDocId as DocumentId);
-      const notesDoc = notesHandle.doc();
-      if (!notesDoc) return err(notFound("note", id));
+      const location = await findNoteLocation(id);
+      if (!location) return err(notFound("note", id));
 
-      const index = notesDoc.notes.findIndex((n) => n.id === id);
-      if (index === -1) return err(notFound("note", id));
+      location.handle.change((doc) => {
+        doc.notes.splice(location.index, 1);
+      });
 
-      notesHandle.change((doc) => {
-        doc.notes.splice(index, 1);
+      const bucketIsEmpty = (location.handle.doc()?.notes.length ?? 0) === 0;
+
+      catalog.change((doc) => {
+        if (doc.noteBucketByNoteId !== undefined && doc.noteBucketByNoteId !== null) {
+          delete doc.noteBucketByNoteId[id];
+        }
+
+        if (
+          bucketIsEmpty &&
+          doc.notesBucketDocIds !== undefined &&
+          doc.notesBucketDocIds !== null
+        ) {
+          delete doc.notesBucketDocIds[location.bucketKey];
+        }
+      });
+
+      emitDiagnostic("delete", {
+        noteId: id,
+        bucketKey: location.bucketKey,
+        bucketDeleted: bucketIsEmpty,
       });
 
       return ok(undefined);
@@ -188,14 +427,21 @@ export function createNoteNamespace(
   };
 }
 
-function cloneNote(n: Note): Note {
-  return {
+function toStorageNote(n: Note): Note {
+  const note: Note = {
     id: n.id,
     content: n.content,
     author: n.author,
-    entityType: n.entityType,
-    entityId: n.entityId,
     tags: [...n.tags],
     createdAt: n.createdAt,
   };
+
+  if (n.entityType !== undefined) note.entityType = n.entityType;
+  if (n.entityId !== undefined) note.entityId = n.entityId;
+
+  return note;
+}
+
+function cloneNote(n: Note): Note {
+  return toStorageNote(n);
 }

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -360,6 +360,8 @@ function createBootstrapCatalog(repo: Repo, markerPath: string): DocHandle<Catal
     doc.habits = empty.habits;
     doc.habitLogDocIds = empty.habitLogDocIds;
     doc.taskListDocIds = empty.taskListDocIds;
+    doc.notesBucketDocIds = empty.notesBucketDocIds;
+    doc.noteBucketByNoteId = empty.noteBucketByNoteId;
     doc.settings = empty.settings;
   });
 
@@ -387,6 +389,9 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
   if (!Array.isArray(doc.habits)) needsMigration = true;
   if (doc.taskListDocIds === undefined || doc.taskListDocIds === null) needsMigration = true;
   if (doc.habitLogDocIds === undefined || doc.habitLogDocIds === null) needsMigration = true;
+  if (doc.notesBucketDocIds === undefined || doc.notesBucketDocIds === null) needsMigration = true;
+  if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null)
+    needsMigration = true;
   if (doc.settings === undefined || doc.settings === null) needsMigration = true;
   if (doc.version === undefined || doc.version === null) needsMigration = true;
 
@@ -401,6 +406,10 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
       d.taskListDocIds = defaults.taskListDocIds;
     if (d.habitLogDocIds === undefined || d.habitLogDocIds === null)
       d.habitLogDocIds = defaults.habitLogDocIds;
+    if (d.notesBucketDocIds === undefined || d.notesBucketDocIds === null)
+      d.notesBucketDocIds = defaults.notesBucketDocIds;
+    if (d.noteBucketByNoteId === undefined || d.noteBucketByNoteId === null)
+      d.noteBucketByNoteId = defaults.noteBucketByNoteId;
     if (d.settings === undefined || d.settings === null) d.settings = defaults.settings;
     if (d.version === undefined || d.version === null) d.version = SCHEMA_VERSION;
   });

--- a/packages/engine/src/sync.test.ts
+++ b/packages/engine/src/sync.test.ts
@@ -8,6 +8,17 @@ import type { Todu } from "./todu.js";
 const TEST_SYNC_PORT = 24399; // Avoid conflict with real instances on 24377
 const RUN_SYNC_SERVER_TESTS = process.env.TODUAI_RUN_SYNC_SERVER_TESTS === "1";
 
+async function waitFor<T>(fn: () => Promise<T>, predicate: (value: T) => boolean): Promise<T> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const value = await fn();
+    if (predicate(value)) return value;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  throw new Error("timed out waiting for expected sync state");
+}
+
 (RUN_SYNC_SERVER_TESTS ? describe : describe.skip)("sync: ephemeral client + server", () => {
   let tmpDir: string;
   let server: Todu;
@@ -79,6 +90,69 @@ const RUN_SYNC_SERVER_TESTS = process.env.TODUAI_RUN_SYNC_SERVER_TESTS === "1";
       expect(listResult.value.some((p) => p.name === "Client Project")).toBe(true);
     }
   });
+
+  it(
+    "syncs note create/update across server and ephemeral client",
+    { timeout: 20000 },
+    async () => {
+      const project = await server.project.create({ name: "Notes Sync Project" });
+      expect(project.ok).toBe(true);
+      if (!project.ok) return;
+
+      const task = await server.task.create({
+        title: "Notes Sync Task",
+        projectId: project.value.id,
+      });
+      expect(task.ok).toBe(true);
+      if (!task.ok) return;
+
+      const serverNote = await server.note.create({
+        content: "Created on server",
+        entityType: "task",
+        entityId: task.value.id,
+      });
+      expect(serverNote.ok).toBe(true);
+      if (!serverNote.ok) return;
+
+      client = await createTodu({
+        storagePath: tmpDir,
+        syncClient: true,
+        syncPort: TEST_SYNC_PORT,
+      });
+
+      const clientTaskNotes = await waitFor(
+        () => client.note.list({ entityType: "task", entityId: task.value.id }),
+        (result) => result.ok && result.value.some((note) => note.id === serverNote.value.id),
+      );
+      expect(clientTaskNotes.ok).toBe(true);
+
+      const updateFromClient = await client.note.update(serverNote.value.id, {
+        content: "Updated from client",
+        tags: ["synced"],
+      });
+      expect(updateFromClient.ok).toBe(true);
+
+      const serverTaskNotes = await waitFor(
+        () => server.note.list({ entityType: "task", entityId: task.value.id }),
+        (result) =>
+          result.ok &&
+          result.value.some(
+            (note) => note.id === serverNote.value.id && note.content === "Updated from client",
+          ),
+      );
+      expect(serverTaskNotes.ok).toBe(true);
+
+      const clientJournal = await client.note.create({ content: "Journal from client" });
+      expect(clientJournal.ok).toBe(true);
+      if (!clientJournal.ok) return;
+
+      const serverAllNotes = await waitFor(
+        () => server.note.list(),
+        (result) => result.ok && result.value.some((note) => note.id === clientJournal.value.id),
+      );
+      expect(serverAllNotes.ok).toBe(true);
+    },
+  );
 
   it("ephemeral client does not write to disk", { timeout: 15000 }, async () => {
     // Note the files before client connects


### PR DESCRIPTION
## Summary
- replace single global notes document usage with partitioned notes bucket documents
- add legacy notesDocId migration into buckets and note-to-bucket lookup index
- update catalog schema, storage migration, prefetch behavior, tests, and architecture docs

## Verification
- make check
- make pre-pr
- TODUAI_RUN_SYNC_SERVER_TESTS=1 npm run test -- packages/engine/src/sync.test.ts

Task: #2015