### PR TITLE
feat: remove recurring startup auto-processing (task #1954)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,6 +214,7 @@ Baseline worker lifecycle states are:
 ### Recurring behavior
 
 - Recurring automation is a worker capability.
+- Client startup paths (CLI/Electron/SDK bootstrap) do not auto-run recurring processing.
 - Without recurring worker:
   - recurring templates remain usable as data
   - manual occurrence generation remains available

--- a/docs/plans/phase-7-recurring-worker.md
+++ b/docs/plans/phase-7-recurring-worker.md
@@ -52,11 +52,16 @@ Migrate recurring automation from implicit client startup behavior to explicit w
 
 ## Acceptance Criteria
 
-- [ ] Recurring is no longer auto-processed during normal client startup
+- [x] Recurring is no longer auto-processed during normal client startup
 - [ ] Assigned recurring worker generates due occurrences correctly
 - [ ] Manual recurring generation works when no recurring worker is active
 - [ ] Deterministic ID behavior remains intact and tested
 - [ ] Clear status messaging exists for recurring automation active/inactive state
+
+## Implementation Notes
+
+- Client startup auto-processing for recurring was removed in task #1954.
+- Recurring materialization remains available through explicit/manual paths while worker-based automation is implemented in later task(s).
 
 ## Non-Goals
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -11,7 +11,7 @@ import { createHabitNamespace, registerHabitProcessor } from "./habits.js";
 import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
-import { createRecurringNamespace, registerRecurringProcessor } from "./recurring.js";
+import { createRecurringNamespace } from "./recurring.js";
 import { processTemplates } from "./scheduling.js";
 import { initBootstrapStorage, initEphemeralStorage, type Storage } from "./storage.js";
 import { addRemoteSyncAdapter, connectSyncClient } from "./sync-client.js";
@@ -63,8 +63,8 @@ export type {
  * Create a Todu SDK instance.
  *
  * Initializes Automerge storage, loads or creates the catalog document,
- * processes any due recurring templates/habits, and returns the SDK
- * with all operation namespaces.
+ * runs startup-safe processors (excluding recurring automation), and
+ * returns the SDK with all operation namespaces.
  *
  * Sync modes:
  * - `syncServer: true` — Start a WebSocket sync server. Other instances
@@ -116,14 +116,16 @@ export async function createTodu(
     }
   }
 
-  // Register processors before processing
-  registerRecurringProcessor(storage.catalog, storage.repo);
+  // Register startup-safe processors before processing.
+  // Recurring automation is intentionally excluded from client startup and
+  // runs through worker/manual paths only.
   registerHabitProcessor(storage.catalog, storage.repo);
 
-  // Process due templates/habits before returning the SDK.
-  // This is the "generate on access" pattern — every CLI invocation
-  // and Electron launch triggers template processing.
-  await processTemplates(storage.catalog);
+  // Process startup-safe processors before returning the SDK.
+  // Explicitly exclude recurring automation from startup execution.
+  await processTemplates(storage.catalog, {
+    excludeTypes: ["recurring"],
+  });
 
   // Prefetch all sub-documents referenced in the catalog so the relay
   // syncs them before the UI renders. Without this, notes and habit logs

--- a/packages/engine/src/recurring.test.ts
+++ b/packages/engine/src/recurring.test.ts
@@ -364,21 +364,35 @@ describe("recurring templates", () => {
       expect(genResult.ok).toBe(false);
     });
 
-    it("process generates tasks for due templates", async () => {
-      // Create a template with startDate in the past
+    it("does not auto-process recurring on startup and still supports manual processing", async () => {
       const createResult = await todu.recurring.create({
         title: "Overdue daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
-        startDate: "2020-01-01", // way in the past — but nextDue should be near today
+        startDate: "2020-01-01",
         projectId,
       });
       expect(createResult.ok).toBe(true);
       if (!createResult.ok) return;
 
-      // Process should have run during createTodu, but let's process again
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const beforeManualProcess = await todu.task.list({ projectId });
+      expect(beforeManualProcess.ok).toBe(true);
+      if (!beforeManualProcess.ok) return;
+      expect(beforeManualProcess.value).toHaveLength(0);
+
       const processResult = await todu.recurring.process();
       expect(processResult.ok).toBe(true);
+      if (!processResult.ok) return;
+      expect(processResult.value.length).toBeGreaterThan(0);
+
+      const afterManualProcess = await todu.task.list({ projectId });
+      expect(afterManualProcess.ok).toBe(true);
+      if (!afterManualProcess.ok) return;
+      expect(afterManualProcess.value.length).toBeGreaterThan(0);
     });
 
     it("deterministic ID matches expected format", async () => {

--- a/packages/engine/src/scheduling.test.ts
+++ b/packages/engine/src/scheduling.test.ts
@@ -114,6 +114,29 @@ describe("processTemplates integration", () => {
     await todu.close();
   });
 
+  it("skips recurring processor during createTodu startup processing", async () => {
+    let recurringCalled = false;
+    let customCalled = false;
+
+    registerProcessor("recurring", async () => {
+      recurringCalled = true;
+      return 0;
+    });
+
+    registerProcessor("custom", async () => {
+      customCalled = true;
+      return 0;
+    });
+
+    const { createTodu } = await import("./index.js");
+    const todu = await createTodu({ storagePath: tmpDir });
+
+    expect(recurringCalled).toBe(false);
+    expect(customCalled).toBe(true);
+
+    await todu.close();
+  });
+
   it("continues processing if one processor fails", async () => {
     const order: string[] = [];
 

--- a/packages/engine/src/scheduling.ts
+++ b/packages/engine/src/scheduling.ts
@@ -70,21 +70,28 @@ export function getRegisteredProcessors(): string[] {
 }
 
 /**
- * Process all due templates and habits.
+ * Process registered template processors.
  *
- * Called during createTodu() initialization. Runs each registered
- * processor in sequence. Each processor is responsible for:
- * 1. Reading its items from the catalog
- * 2. Checking which are due (nextDue <= today, not paused)
- * 3. Performing the appropriate action (generate tasks, advance nextDue, etc.)
- *
- * This function is the single entry point — no daemon, no polling,
- * no on-complete triggers. Just process on access.
+ * Processors run in registration order. Callers may exclude processor types
+ * (for example, skipping recurring during client startup).
  */
-export async function processTemplates(catalog: DocHandle<CatalogDocument>): Promise<void> {
+export async function processTemplates(
+  catalog: DocHandle<CatalogDocument>,
+  options: {
+    excludeTypes?: string[];
+  } = {},
+): Promise<void> {
   if (processors.size === 0) return;
 
+  const excluded = new Set(
+    (options.excludeTypes ?? []).map((type) => type.trim()).filter((type) => type.length > 0),
+  );
+
   for (const [type, processor] of processors) {
+    if (excluded.has(type)) {
+      continue;
+    }
+
     try {
       const context: ProcessingContext = {
         catalog,


### PR DESCRIPTION
## Summary
- remove recurring startup auto-processing from createTodu bootstrap path
- keep recurring generation explicit/manual while worker automation is implemented in later phase-7 tasks
- add regression coverage proving startup no longer materializes recurring tasks and manual recurring.process still works
- document the startup behavior change in architecture + phase-7 plan docs

## Testing
- npm run test -- packages/engine/src/scheduling.test.ts packages/engine/src/recurring.test.ts
- make pre-pr

Task: #1954