### PR TITLE
fix: remove plugin-name startup coupling from engine bootstrap

### DIFF
--- a/docs/plans/phase-7-recurring-worker.md
+++ b/docs/plans/phase-7-recurring-worker.md
@@ -61,6 +61,7 @@ Migrate recurring automation from implicit client startup behavior to explicit w
 ## Implementation Notes
 
 - Client startup auto-processing for recurring was removed in task #1954.
+- Engine bootstrap plugin-name coupling was removed in task #2112 by moving startup processor policy ownership to daemon runtime wiring.
 - Recurring materialization remains available through explicit/manual paths while worker-based automation is implemented in later task(s).
 
 ## Non-Goals

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,6 +1,12 @@
 import type { DocumentId } from "@automerge/automerge-repo";
 import { err, ok, type RemoteSyncConfig, type Result, resolveStoragePath } from "@todu/core";
-import { beginCatalogJoinSwitch, createTodu, initJoinStorage, type Todu } from "@todu/engine";
+import {
+  beginCatalogJoinSwitch,
+  createTodu,
+  initJoinStorage,
+  registerHabitProcessor,
+  type Todu,
+} from "@todu/engine";
 import { createCoreNamespaceHandlers, mergeNamespaceHandlerSets } from "./core-rpc-adapters.js";
 import {
   createDaemonLogger,
@@ -405,6 +411,18 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     };
   }
 
+  async function createHostOwnedTodu(): Promise<Todu> {
+    registerHabitProcessor();
+
+    return createTodu({
+      storagePath: resolvedConfig.storagePath,
+      remoteSync: resolvedConfig.remoteSync,
+      startupTemplateProcessing: {
+        enabled: true,
+      },
+    });
+  }
+
   async function startInternal(): Promise<DaemonRuntimeStatus> {
     runtimeStatus.state = "starting";
     runtimeLogger.info("daemon runtime start requested", {
@@ -415,10 +433,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     try {
       const endpoint = await transport.start();
 
-      const startedTodu = await createTodu({
-        storagePath: resolvedConfig.storagePath,
-        remoteSync: resolvedConfig.remoteSync,
-      });
+      const startedTodu = await createHostOwnedTodu();
 
       todu = startedTodu;
       runtimeStatus.state = "running";
@@ -657,10 +672,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       todu = null;
       await previousTodu.close();
 
-      const joinedTodu = await createTodu({
-        storagePath: resolvedConfig.storagePath,
-        remoteSync: resolvedConfig.remoteSync,
-      });
+      const joinedTodu = await createHostOwnedTodu();
 
       todu = joinedTodu;
       runtimeStatus.catalogId = joinedTodu.sync.getCatalogId();
@@ -679,10 +691,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
 
       let restoredCatalogId = previousCatalogId;
       try {
-        const restoredTodu = await createTodu({
-          storagePath: resolvedConfig.storagePath,
-          remoteSync: resolvedConfig.remoteSync,
-        });
+        const restoredTodu = await createHostOwnedTodu();
         todu = restoredTodu;
         runtimeStatus.catalogId = restoredTodu.sync.getCatalogId();
         restoredCatalogId = runtimeStatus.catalogId;

--- a/packages/engine/src/habits.ts
+++ b/packages/engine/src/habits.ts
@@ -430,7 +430,7 @@ export function createHabitNamespace(
 // Habit processor for processTemplates()
 // ============================================================================
 
-export function registerHabitProcessor(_catalog: DocHandle<CatalogDocument>, _repo: Repo): void {
+export function registerHabitProcessor(): void {
   registerProcessor("habit", async (context) => {
     const doc = context.catalog.doc();
     if (!doc?.habits) return 0;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,7 +7,7 @@ import {
 import type { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import { observeAllChanges } from "./change-observer.js";
-import { createHabitNamespace, registerHabitProcessor } from "./habits.js";
+import { createHabitNamespace } from "./habits.js";
 import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
@@ -26,6 +26,7 @@ import {
 } from "./todu.js";
 
 export type { RemoteSyncConfig } from "@todu/core";
+export { registerHabitProcessor } from "./habits.js";
 export type { UpcomingOccurrence } from "./recurring.js";
 // Re-export schedule utilities for consumers
 export {
@@ -63,8 +64,8 @@ export type {
  * Create a Todu SDK instance.
  *
  * Initializes Automerge storage, loads or creates the catalog document,
- * runs startup-safe processors (excluding recurring automation), and
- * returns the SDK with all operation namespaces.
+ * optionally runs host-configured startup processors, and returns the SDK
+ * with all operation namespaces.
  *
  * Sync modes:
  * - `syncServer: true` — Start a WebSocket sync server. Other instances
@@ -116,16 +117,13 @@ export async function createTodu(
     }
   }
 
-  // Register startup-safe processors before processing.
-  // Recurring automation is intentionally excluded from client startup and
-  // runs through worker/manual paths only.
-  registerHabitProcessor(storage.catalog, storage.repo);
-
-  // Process startup-safe processors before returning the SDK.
-  // Explicitly exclude recurring automation from startup execution.
-  await processTemplates(storage.catalog, {
-    excludeTypes: ["recurring"],
-  });
+  // Host-owned startup processing policy. Engine bootstrap does not
+  // register or special-case processor identities.
+  if (config?.startupTemplateProcessing?.enabled === true) {
+    await processTemplates(storage.catalog, {
+      excludeTypes: config.startupTemplateProcessing.excludeTypes,
+    });
+  }
 
   // Prefetch all sub-documents referenced in the catalog so the relay
   // syncs them before the UI renders. Without this, notes and habit logs

--- a/packages/engine/src/scheduling.test.ts
+++ b/packages/engine/src/scheduling.test.ts
@@ -74,7 +74,7 @@ describe("processTemplates integration", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("runs registered processors during createTodu", async () => {
+  it("runs registered processors when startup processing is enabled", async () => {
     let processorCalled = false;
 
     registerProcessor("test", async (ctx: ProcessingContext) => {
@@ -86,14 +86,33 @@ describe("processTemplates integration", () => {
     });
 
     const { createTodu } = await import("./index.js");
-    const todu = await createTodu({ storagePath: tmpDir });
+    const todu = await createTodu({
+      storagePath: tmpDir,
+      startupTemplateProcessing: { enabled: true },
+    });
 
     expect(processorCalled).toBe(true);
 
     await todu.close();
   });
 
-  it("runs multiple processors in sequence", async () => {
+  it("does not run processors by default", async () => {
+    let processorCalled = false;
+
+    registerProcessor("test", async () => {
+      processorCalled = true;
+      return 0;
+    });
+
+    const { createTodu } = await import("./index.js");
+    const todu = await createTodu({ storagePath: tmpDir });
+
+    expect(processorCalled).toBe(false);
+
+    await todu.close();
+  });
+
+  it("runs multiple processors in sequence when startup processing is enabled", async () => {
     const order: string[] = [];
 
     registerProcessor("first", async () => {
@@ -107,14 +126,17 @@ describe("processTemplates integration", () => {
     });
 
     const { createTodu } = await import("./index.js");
-    const todu = await createTodu({ storagePath: tmpDir });
+    const todu = await createTodu({
+      storagePath: tmpDir,
+      startupTemplateProcessing: { enabled: true },
+    });
 
     expect(order).toEqual(["first", "second"]);
 
     await todu.close();
   });
 
-  it("skips recurring processor during createTodu startup processing", async () => {
+  it("does not single out processor types when startup processing is enabled", async () => {
     let recurringCalled = false;
     let customCalled = false;
 
@@ -129,9 +151,12 @@ describe("processTemplates integration", () => {
     });
 
     const { createTodu } = await import("./index.js");
-    const todu = await createTodu({ storagePath: tmpDir });
+    const todu = await createTodu({
+      storagePath: tmpDir,
+      startupTemplateProcessing: { enabled: true },
+    });
 
-    expect(recurringCalled).toBe(false);
+    expect(recurringCalled).toBe(true);
     expect(customCalled).toBe(true);
 
     await todu.close();
@@ -154,7 +179,10 @@ describe("processTemplates integration", () => {
     });
 
     const { createTodu } = await import("./index.js");
-    const todu = await createTodu({ storagePath: tmpDir });
+    const todu = await createTodu({
+      storagePath: tmpDir,
+      startupTemplateProcessing: { enabled: true },
+    });
 
     expect(order).toEqual(["failing", "succeeding"]);
     expect(consoleSpy).toHaveBeenCalledOnce();

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -57,6 +57,19 @@ export interface ToduConfig {
   syncClient?: boolean;
 
   /**
+   * Startup template processing policy.
+   *
+   * Processing is disabled by default. Hosts that own automation policy
+   * (for example daemon runtime) opt in explicitly.
+   */
+  startupTemplateProcessing?: {
+    /** Run registered processors during startup when true. */
+    enabled?: boolean;
+    /** Optional generic exclusions controlled by the host. */
+    excludeTypes?: string[];
+  };
+
+  /**
    * Remote multi-device sync configuration.
    * When provided, connects a second WebSocketClientAdapter to the remote server.
    * Used by Electron and toduai serve.


### PR DESCRIPTION
## Summary
- remove plugin-name coupling from `createTodu()` startup path
- add host-owned startup template processing policy (`startupTemplateProcessing`) to engine config
- move habit startup processor registration into daemon runtime wiring
- remove hardcoded recurring exclusion from engine bootstrap
- update scheduling tests to assert default-off startup processing and no singled-out processor type behavior
- document phase-7 implementation note for this boundary fix

## Why
Engine bootstrap should not know plugin identities. Startup processor policy belongs to the host/runtime layer.

## Verification
- `make pre-pr`
- `npm run test -- packages/engine/src/scheduling.test.ts packages/engine/src/recurring.test.ts packages/daemon/src/runtime.test.ts`
- `npm run check:ci`

Task: #2112
