### PR TITLE
feat(daemon): implement plugin loader and config path resolution

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,6 +222,8 @@ Baseline worker lifecycle states are:
 - External sync plugins use the `SyncProvider` contract from `@todu/core`.
 - Plugin load paths must validate provider registrations at load time, including required lifecycle methods and API version compatibility.
 - Compatibility baseline is API-version based (current provider API version: `1`).
+- Daemon plugin module paths resolve from `TODUAI_DAEMON_PLUGIN_PATHS` first, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
+- Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.
 - Author-facing contract and policy details are documented in `docs/plugin-sync-provider-api.md`.
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -96,6 +96,31 @@ Notes:
 - Empty assignment (`TODUAI_DAEMON_ASSIGNED_WORKERS=""`) means no local workers are assigned.
 - Duplicate entries are tolerated and logged; first occurrence wins.
 
+## Sync plugin module configuration
+
+Configure sync plugin module entrypoints in config file:
+
+```yaml
+daemon:
+  plugins:
+    paths:
+      - ./plugins/github-plugin/dist/index.js
+      - ./plugins/forgejo-plugin/dist/index.js
+```
+
+Override with env var (comma-separated module paths):
+
+```bash
+export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
+```
+
+Notes:
+- Env var overrides config file plugin paths.
+- Config file plugin paths are resolved relative to the config file directory.
+- Empty plugin path list (`TODUAI_DAEMON_PLUGIN_PATHS=""`) disables plugin loading.
+- Duplicate entries are tolerated and logged; first occurrence wins.
+- Changes require daemon restart to apply.
+
 ## Validate connectivity
 
 ```bash

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -167,6 +167,17 @@ tail -f ~/Library/Logs/toduai-daemon.out.log ~/Library/Logs/toduai-daemon.err.lo
 export TODUAI_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
 ```
 
+- Sync plugin module paths can be defined in config file under `daemon.plugins.paths`.
+- Sync plugin module path env override (comma-separated module paths):
+
+```bash
+export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
+```
+
+- Plugin path resolution order is env first, then config file.
+- Config file plugin paths resolve relative to the config file directory.
+- Plugin path/config changes apply on daemon restart.
+
 - Optional socket override:
 
 ```bash

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -78,6 +78,21 @@ Validation errors use structured codes:
 - `API_VERSION_MISMATCH`
 - `IDENTITY_MISMATCH`
 
+## Daemon Host Configuration
+
+Daemon plugin host loads sync plugin modules from configured local module paths.
+
+Resolution order:
+
+1. `TODUAI_DAEMON_PLUGIN_PATHS` env var (comma-separated module paths)
+2. `daemon.plugins.paths` in config file (paths resolved relative to config file location)
+
+Runtime behavior:
+
+- Plugin loading occurs at daemon startup.
+- Path/config changes apply on daemon restart.
+- Duplicate path entries are tolerated and logged; first occurrence wins.
+
 ## Conflict Resolution Baseline
 
 Provider sync conflict resolution baseline is `last-write-wins` based on `updatedAt` timestamps. Providers should preserve external timestamps where available and provide deterministic mapping behavior under repeated pull/push runs.

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -11,6 +11,10 @@ import {
   resolveDaemonSocketPath,
 } from "../daemon-command-client.js";
 import {
+  resolveDaemonPluginPaths,
+  TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+} from "../daemon-plugin-paths.js";
+import {
   resolveDaemonAssignedWorkers,
   TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
 } from "../daemon-worker-assignment.js";
@@ -58,6 +62,7 @@ interface DaemonCommandContext {
   daemonEntrypoint: string;
   remoteSyncServer: string | null;
   assignedWorkersEnvValue: string | undefined;
+  pluginPathsEnvValue: string | undefined;
 }
 
 const DIRECT_PID_FILENAME = "daemon.pid";
@@ -742,6 +747,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
   const storagePath = resolveDataDir(configPath, fileConfig);
   const remoteSync = resolveRemoteSyncConfig(fileConfig);
   const assignedWorkers = resolveDaemonAssignedWorkers(fileConfig);
+  const pluginPaths = resolveDaemonPluginPaths(configPath, fileConfig);
 
   return {
     storagePath,
@@ -750,6 +756,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
     daemonEntrypoint: resolveDaemonEntrypoint(),
     remoteSyncServer: remoteSync?.server ?? null,
     assignedWorkersEnvValue: assignedWorkers.value,
+    pluginPathsEnvValue: pluginPaths.value,
   };
 }
 
@@ -770,6 +777,10 @@ function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv 
 
   if (context.assignedWorkersEnvValue !== undefined) {
     childEnv[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV] = context.assignedWorkersEnvValue;
+  }
+
+  if (context.pluginPathsEnvValue !== undefined) {
+    childEnv[TODUAI_DAEMON_PLUGIN_PATHS_ENV] = context.pluginPathsEnvValue;
   }
 
   return childEnv;

--- a/packages/cli/src/daemon-plugin-paths.test.ts
+++ b/packages/cli/src/daemon-plugin-paths.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { resolveDaemonPluginPaths, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./daemon-plugin-paths.js";
+
+describe("resolveDaemonPluginPaths", () => {
+  it("prefers env override over config file plugin paths", () => {
+    const resolved = resolveDaemonPluginPaths(
+      "/tmp/config.yaml",
+      {
+        daemon: {
+          plugins: {
+            paths: ["./plugins/github.js"],
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/opt/plugins/github.js",
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: "/opt/plugins/github.js",
+      source: "env",
+    });
+  });
+
+  it("resolves config file plugin paths relative to config location", () => {
+    const resolved = resolveDaemonPluginPaths(
+      "/workspace/.toduai/config.yaml",
+      {
+        daemon: {
+          plugins: {
+            paths: [" ./plugins/github.js ", "../shared/forgejo.js"],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: "/workspace/.toduai/plugins/github.js,/workspace/shared/forgejo.js",
+      source: "file",
+    });
+  });
+
+  it("keeps explicit empty plugin path list from config", () => {
+    const resolved = resolveDaemonPluginPaths(
+      "/workspace/.toduai/config.yaml",
+      {
+        daemon: {
+          plugins: {
+            paths: [],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: "",
+      source: "file",
+    });
+  });
+
+  it("ignores empty plugin path entries from config file", () => {
+    const resolved = resolveDaemonPluginPaths(
+      "/workspace/.toduai/config.yaml",
+      {
+        daemon: {
+          plugins: {
+            paths: [" ", "./plugins/github.js", ""],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: "/workspace/.toduai/plugins/github.js",
+      source: "file",
+    });
+  });
+
+  it("returns unset when neither env nor config plugin paths are present", () => {
+    const resolved = resolveDaemonPluginPaths("/tmp/config.yaml", {}, {});
+
+    expect(resolved).toEqual({
+      value: undefined,
+      source: "unset",
+    });
+  });
+});

--- a/packages/cli/src/daemon-plugin-paths.ts
+++ b/packages/cli/src/daemon-plugin-paths.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import type { ToduFileConfig } from "@todu/core";
+
+export const TODUAI_DAEMON_PLUGIN_PATHS_ENV = "TODUAI_DAEMON_PLUGIN_PATHS";
+
+export interface ResolvedDaemonPluginPaths {
+  value: string | undefined;
+  source: "env" | "file" | "unset";
+}
+
+export function resolveDaemonPluginPaths(
+  configPath: string,
+  config: ToduFileConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedDaemonPluginPaths {
+  const envValue = env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
+  if (envValue !== undefined) {
+    return {
+      value: envValue,
+      source: "env",
+    };
+  }
+
+  const filePluginPaths = config.daemon?.plugins?.paths;
+  if (!filePluginPaths) {
+    return {
+      value: undefined,
+      source: "unset",
+    };
+  }
+
+  const configDir = path.dirname(configPath);
+  const normalizedPaths = filePluginPaths
+    .map((pluginPath) => pluginPath.trim())
+    .filter((pluginPath) => pluginPath.length > 0)
+    .map((pluginPath) => path.resolve(configDir, pluginPath));
+
+  return {
+    value: normalizedPaths.join(","),
+    source: "file",
+  };
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -33,6 +33,10 @@ export interface ToduFileConfig {
       /** Worker types statically assigned to this daemon */
       assigned?: string[];
     };
+    plugins?: {
+      /** Local plugin module entrypoints for daemon startup loading */
+      paths?: string[];
+    };
   };
 }
 

--- a/packages/daemon/src/entrypoint.ts
+++ b/packages/daemon/src/entrypoint.ts
@@ -2,6 +2,7 @@
 
 import { resolveRemoteSyncConfig } from "@todu/core";
 import { createDaemonLogger, resolveDaemonLogLevelFromEnv } from "./logger.js";
+import { parseDaemonPluginPathsFromEnv, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
 import { startDaemonProcess } from "./process.js";
 import { type DaemonRole, isDaemonRole } from "./runtime.js";
 import {
@@ -32,6 +33,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
   const daemonSocketPath = process.env.TODUAI_DAEMON_SOCKET;
   const remoteSync = resolveRemoteSyncConfig({});
   const assignmentConfig = parseAssignedWorkerTypesFromEnv(process.env);
+  const pluginPathsConfig = parseDaemonPluginPathsFromEnv(process.env);
 
   if (assignmentConfig.duplicateWorkerTypes.length > 0) {
     logger.warn("duplicate daemon worker assignment entries detected", {
@@ -47,6 +49,20 @@ export async function runDaemonEntrypoint(): Promise<void> {
     });
   }
 
+  if (pluginPathsConfig.duplicateModulePaths.length > 0) {
+    logger.warn("duplicate daemon plugin path entries detected", {
+      envVar: TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+      duplicateModulePaths: pluginPathsConfig.duplicateModulePaths,
+    });
+  }
+
+  if (pluginPathsConfig.ignoredEntries.length > 0) {
+    logger.warn("ignored empty daemon plugin path entries", {
+      envVar: TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+      ignoredEntryCount: pluginPathsConfig.ignoredEntries.length,
+    });
+  }
+
   const daemon = await startDaemonProcess(
     {
       role: daemonRole,
@@ -54,6 +70,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
       remoteSync: remoteSync ?? undefined,
       logLevel: daemonLogLevel,
       assignedWorkerTypes: assignmentConfig.assignedWorkerTypes,
+      syncPluginModulePaths: pluginPathsConfig.modulePaths,
     },
     {
       hooks: {
@@ -63,6 +80,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
             socketPath: status.transport?.path ?? "-",
             catalogId: status.catalogId ?? "-",
             assignedWorkerTypes: assignmentConfig.assignedWorkerTypes ?? "all",
+            configuredPluginModulePaths: pluginPathsConfig.modulePaths ?? [],
           });
         },
         onStopping: (reason) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -9,6 +9,11 @@ export {
   resolveDaemonLogLevelFromEnv,
 } from "./logger.js";
 export {
+  type ParsedDaemonPluginPathsEnv,
+  parseDaemonPluginPathsFromEnv,
+  TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+} from "./plugin-paths.js";
+export {
   type DaemonProcess,
   type DaemonProcessHooks,
   type StartDaemonProcessOptions,
@@ -32,7 +37,6 @@ export {
   parseProtocolRequestFrame,
   parseProtocolRequestJson,
 } from "./protocol.js";
-
 export {
   CORE_DAEMON_NAMESPACE_METHODS,
   type CoreDaemonNamespace,
@@ -58,7 +62,6 @@ export {
   type EventsSubscribeResult,
   type EventsUnsubscribeResult,
 } from "./rpc.js";
-
 export {
   createDaemonRuntime,
   DAEMON_ROLES,
@@ -70,7 +73,13 @@ export {
   isDaemonRole,
   type ResolvedDaemonRuntimeConfig,
 } from "./runtime.js";
-
+export {
+  type LoadedSyncPlugin,
+  loadConfiguredSyncPlugins,
+  SYNC_PLUGIN_LOAD_ERROR_CODES,
+  type SyncPluginLoadError,
+  type SyncPluginLoadErrorCode,
+} from "./sync-plugin-loader.js";
 export {
   createUdsTransport,
   DEFAULT_DAEMON_SOCKET_FILENAME,

--- a/packages/daemon/src/plugin-paths.test.ts
+++ b/packages/daemon/src/plugin-paths.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseDaemonPluginPathsFromEnv, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
+
+describe("parseDaemonPluginPathsFromEnv", () => {
+  it("returns undefined module paths when env var is not set", () => {
+    const parsed = parseDaemonPluginPathsFromEnv({});
+
+    expect(parsed).toEqual({
+      modulePaths: undefined,
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("parses module paths from comma-separated env value", () => {
+    const parsed = parseDaemonPluginPathsFromEnv({
+      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: " /plugins/github.js,/plugins/forgejo.js ",
+    });
+
+    expect(parsed).toEqual({
+      modulePaths: ["/plugins/github.js", "/plugins/forgejo.js"],
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("reports duplicates and ignored empty entries", () => {
+    const parsed = parseDaemonPluginPathsFromEnv({
+      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/plugins/github.js,,/plugins/github.js, ",
+    });
+
+    expect(parsed).toEqual({
+      modulePaths: ["/plugins/github.js"],
+      duplicateModulePaths: ["/plugins/github.js"],
+      ignoredEntries: ["", " "],
+    });
+  });
+
+  it("supports explicit empty module path list", () => {
+    const parsed = parseDaemonPluginPathsFromEnv({
+      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "",
+    });
+
+    expect(parsed).toEqual({
+      modulePaths: [],
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    });
+  });
+});

--- a/packages/daemon/src/plugin-paths.ts
+++ b/packages/daemon/src/plugin-paths.ts
@@ -1,0 +1,55 @@
+export const TODUAI_DAEMON_PLUGIN_PATHS_ENV = "TODUAI_DAEMON_PLUGIN_PATHS";
+
+export interface ParsedDaemonPluginPathsEnv {
+  modulePaths: string[] | undefined;
+  duplicateModulePaths: string[];
+  ignoredEntries: string[];
+}
+
+export function parseDaemonPluginPathsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ParsedDaemonPluginPathsEnv {
+  const rawModulePaths = env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
+  if (rawModulePaths === undefined) {
+    return {
+      modulePaths: undefined,
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    };
+  }
+
+  if (rawModulePaths.trim().length === 0) {
+    return {
+      modulePaths: [],
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    };
+  }
+
+  const modulePaths: string[] = [];
+  const duplicateModulePaths: string[] = [];
+  const ignoredEntries: string[] = [];
+
+  for (const rawEntry of rawModulePaths.split(",")) {
+    const modulePath = rawEntry.trim();
+    if (!modulePath) {
+      ignoredEntries.push(rawEntry);
+      continue;
+    }
+
+    if (modulePaths.includes(modulePath)) {
+      if (!duplicateModulePaths.includes(modulePath)) {
+        duplicateModulePaths.push(modulePath);
+      }
+      continue;
+    }
+
+    modulePaths.push(modulePath);
+  }
+
+  return {
+    modulePaths,
+    duplicateModulePaths,
+    ignoredEntries,
+  };
+}

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -1134,6 +1134,147 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
+  it("loads configured sync plugins and surfaces runtime state via worker.status", async () => {
+    const pluginPath = writeValidSyncPluginModule(tmpDir, "github-plugin.mjs", {
+      providerName: "github",
+      providerVersion: "1.0.0",
+    });
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      syncPluginModulePaths: [pluginPath],
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await runtime.start();
+
+    expect(runtime.getWorker("github-sync")).toMatchObject({
+      state: "running",
+      manifest: {
+        type: "github-sync",
+        requiredDomains: ["sync", "task"],
+      },
+    });
+
+    const workerStatusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-plugin-1",
+      method: "worker.status",
+      params: {
+        workerType: "github-sync",
+      },
+    });
+
+    expect(workerStatusResponse).toEqual({
+      id: "worker-status-plugin-1",
+      result: {
+        workers: [
+          {
+            type: "github-sync",
+            state: "running",
+            blockedReason: null,
+            errorMessage: null,
+            updatedAt: expect.any(String),
+            requiredDomains: ["sync", "task"],
+            optionalDomains: [],
+            roleHints: ["node"],
+            isAssigned: true,
+            missingRequiredDomains: [],
+          },
+        ],
+        assignment: {
+          assignedWorkerTypes: null,
+        },
+        enabledWorkerDomains: ["project", "task", "sync"],
+      },
+    });
+
+    await runtime.stop();
+
+    expect(runtime.getWorker("github-sync")?.state).toBe("stopped");
+  });
+
+  it("fails invalid or unreachable sync plugin modules safely with diagnostics", async () => {
+    const incompatiblePluginPath = writeInvalidSyncPluginModule(tmpDir, "bad-plugin.mjs");
+    const missingPluginPath = path.join(tmpDir, "missing-plugin.mjs");
+
+    const warnings: Array<{ message: string; context?: Record<string, unknown> }> = [];
+    const runtimeLogger = {
+      level: "info" as const,
+      debug: () => {},
+      info: () => {},
+      warn: (message: string, context?: Record<string, unknown>) => {
+        warnings.push({ message, context });
+      },
+      error: () => {},
+      child: () => runtimeLogger,
+    };
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      syncPluginModulePaths: [incompatiblePluginPath, missingPluginPath],
+      logger: runtimeLogger,
+    });
+
+    await runtime.start();
+
+    expect(runtime.status().state).toBe("running");
+    expect(runtime.listWorkers()).toEqual([]);
+
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "sync plugin load failed",
+          context: expect.objectContaining({
+            code: "INVALID_PROVIDER",
+            modulePath: incompatiblePluginPath,
+          }),
+        }),
+        expect.objectContaining({
+          message: "sync plugin load failed",
+          context: expect.objectContaining({
+            code: "IMPORT_FAILED",
+            modulePath: missingPluginPath,
+          }),
+        }),
+      ]),
+    );
+
+    await runtime.stop();
+  });
+
+  it("loads sync plugin workers deterministically across daemon restarts", async () => {
+    const pluginPath = writeValidSyncPluginModule(tmpDir, "forgejo-plugin.mjs", {
+      providerName: "forgejo",
+      providerVersion: "1.0.0",
+    });
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      syncPluginModulePaths: [pluginPath],
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await runtime.start();
+
+    expect(
+      runtime.listWorkers().filter((worker) => worker.manifest.type === "forgejo-sync"),
+    ).toHaveLength(1);
+    expect(runtime.getWorker("forgejo-sync")?.state).toBe("running");
+
+    await runtime.stop();
+
+    expect(runtime.getWorker("forgejo-sync")?.state).toBe("stopped");
+
+    await runtime.start();
+
+    expect(
+      runtime.listWorkers().filter((worker) => worker.manifest.type === "forgejo-sync"),
+    ).toHaveLength(1);
+    expect(runtime.getWorker("forgejo-sync")?.state).toBe("running");
+
+    await runtime.stop();
+  });
+
   it("maps domain and request validation errors for project/task/label/note/recurring/habit/sync methods", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
@@ -1431,6 +1572,101 @@ describe("createDaemonRuntime", () => {
     await expect(runtime.stop()).resolves.toBeUndefined();
   });
 });
+
+function writeValidSyncPluginModule(
+  directory: string,
+  filename: string,
+  options: {
+    providerName: string;
+    providerVersion: string;
+  },
+): string {
+  const modulePath = path.join(directory, filename);
+
+  const moduleSource = `export const syncProvider = {
+  manifest: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    apiVersion: 1,
+  },
+  provider: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    async initialize() {},
+    async shutdown() {},
+    async pull() {
+      return { tasks: [] };
+    },
+    async push() {},
+    mapToTask() {
+      return {
+        id: "task-1",
+        title: "Example",
+        status: "active",
+        priority: "medium",
+        projectId: "project-1",
+        labels: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      };
+    },
+    mapFromTask() {
+      return {
+        externalId: "ext-1",
+        title: "Example",
+      };
+    },
+  },
+};`;
+
+  fs.writeFileSync(modulePath, moduleSource, "utf8");
+
+  return modulePath;
+}
+
+function writeInvalidSyncPluginModule(directory: string, filename: string): string {
+  const modulePath = path.join(directory, filename);
+
+  const moduleSource = `export default {
+  manifest: {
+    name: "github",
+    version: "1.0.0",
+    apiVersion: 999,
+  },
+  provider: {
+    name: "github",
+    version: "1.0.0",
+    async initialize() {},
+    async shutdown() {},
+    async pull() {
+      return { tasks: [] };
+    },
+    async push() {},
+    mapToTask() {
+      return {
+        id: "task-1",
+        title: "Example",
+        status: "active",
+        priority: "medium",
+        projectId: "project-1",
+        labels: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      };
+    },
+    mapFromTask() {
+      return {
+        externalId: "ext-1",
+        title: "Example",
+      };
+    },
+  },
+};`;
+
+  fs.writeFileSync(modulePath, moduleSource, "utf8");
+
+  return modulePath;
+}
 
 async function createAlternateCatalogDocument(storagePath: string): Promise<string> {
   const storage = await engine.initBootstrapStorage(storagePath);

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
   DEFAULT_DAEMON_VERSION,
 } from "./rpc.js";
+import { type LoadedSyncPlugin, loadConfiguredSyncPlugins } from "./sync-plugin-loader.js";
 import {
   createUdsTransport,
   resolveUdsSocketPath,
@@ -73,6 +74,7 @@ export interface DaemonRuntimeConfig {
   workerRegistrations?: WorkerRegistration[];
   enabledWorkerDomains?: WorkerDomainCapability[];
   assignedWorkerTypes?: string[];
+  syncPluginModulePaths?: string[];
 }
 
 export interface ResolvedDaemonRuntimeConfig {
@@ -86,6 +88,7 @@ export interface ResolvedDaemonRuntimeConfig {
   logLevel: DaemonLogLevel;
   enabledWorkerDomains: WorkerDomainCapability[];
   assignedWorkerTypes?: string[];
+  syncPluginModulePaths?: string[];
 }
 
 export interface DaemonRuntimeStatus {
@@ -127,6 +130,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   const resolvedLogLevel = config.logLevel ?? resolveDaemonLogLevelFromEnv(process.env);
   const resolvedEnabledWorkerDomains = resolveEnabledWorkerDomains(config.enabledWorkerDomains);
   const assignmentResolution = resolveAssignedWorkerTypes(config.assignedWorkerTypes);
+  const pluginPathResolution = resolveSyncPluginModulePaths(config.syncPluginModulePaths);
 
   const resolvedConfig: ResolvedDaemonRuntimeConfig = {
     storagePath: resolvedStoragePath,
@@ -143,6 +147,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     logLevel: resolvedLogLevel,
     enabledWorkerDomains: resolvedEnabledWorkerDomains,
     assignedWorkerTypes: assignmentResolution.assignedWorkerTypes,
+    syncPluginModulePaths: pluginPathResolution.modulePaths,
   };
 
   let todu: Todu | null = null;
@@ -153,6 +158,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   let syncStatusSubscriptionCleanup: (() => void) | null = null;
   const workerRuntimes = new Map<string, WorkerRegistration["runtime"]>();
   const activeWorkerRuntimeHandles = new Map<string, WorkerRuntimeHandle>();
+  const loadedSyncPlugins = new Map<string, LoadedSyncPlugin>();
 
   const runtimeStatus: DaemonRuntimeStatus = {
     state: "stopped",
@@ -172,6 +178,13 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     runtimeLogger.warn("duplicate worker assignment entries detected", {
       duplicateWorkerTypes: assignmentResolution.duplicateWorkerTypes,
       assignedWorkerTypes: resolvedConfig.assignedWorkerTypes ?? null,
+    });
+  }
+
+  if (pluginPathResolution.duplicateModulePaths.length > 0) {
+    runtimeLogger.warn("duplicate sync plugin module path entries detected", {
+      duplicateModulePaths: pluginPathResolution.duplicateModulePaths,
+      syncPluginModulePaths: resolvedConfig.syncPluginModulePaths ?? null,
     });
   }
 
@@ -302,34 +315,54 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     return blockedTransition;
   }
 
-  for (const registration of config.workerRegistrations ?? []) {
+  function registerRuntimeWorker(
+    registration: WorkerRegistration,
+    options: { throwOnFailure: boolean },
+  ): Result<RegisteredWorkerSnapshot, WorkerRegistryError> {
     const registerResult = workerRegistry.register(registration);
     if (!registerResult.ok) {
-      const workerType = registration.manifest?.type ?? "unknown";
-      throw new Error(
-        `Invalid worker registration for daemon runtime (${workerType}): ${registerResult.error.message}`,
-      );
+      if (options.throwOnFailure) {
+        const workerType = registration.manifest?.type ?? "unknown";
+        throw new Error(
+          `Invalid worker registration for daemon runtime (${workerType}): ${registerResult.error.message}`,
+        );
+      }
+      return registerResult;
     }
 
     workerRuntimes.set(registerResult.value.manifest.type, registration.runtime);
 
     const assignmentGateResult = applyWorkerAssignmentGating(registerResult.value.manifest.type);
     if (!assignmentGateResult.ok) {
-      throw new Error(
-        `Failed to apply worker assignment gating for daemon runtime (${registerResult.value.manifest.type}): ${assignmentGateResult.error.message}`,
-      );
+      if (options.throwOnFailure) {
+        throw new Error(
+          `Failed to apply worker assignment gating for daemon runtime (${registerResult.value.manifest.type}): ${assignmentGateResult.error.message}`,
+        );
+      }
+      return assignmentGateResult;
     }
 
     if (!isWorkerAssigned(registerResult.value.manifest.type)) {
-      continue;
+      return assignmentGateResult;
     }
 
     const dependencyGateResult = applyWorkerDependencyGating(registerResult.value.manifest.type);
     if (!dependencyGateResult.ok) {
-      throw new Error(
-        `Failed to apply worker dependency gating for daemon runtime (${registerResult.value.manifest.type}): ${dependencyGateResult.error.message}`,
-      );
+      if (options.throwOnFailure) {
+        throw new Error(
+          `Failed to apply worker dependency gating for daemon runtime (${registerResult.value.manifest.type}): ${dependencyGateResult.error.message}`,
+        );
+      }
+      return dependencyGateResult;
     }
+
+    return dependencyGateResult;
+  }
+
+  for (const registration of config.workerRegistrations ?? []) {
+    registerRuntimeWorker(registration, {
+      throwOnFailure: true,
+    });
   }
 
   const defaultNamespaceHandlers = mergeNamespaceHandlerSets(
@@ -594,6 +627,62 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     }
   }
 
+  async function loadConfiguredSyncPluginWorkers(): Promise<void> {
+    if (
+      !resolvedConfig.syncPluginModulePaths ||
+      resolvedConfig.syncPluginModulePaths.length === 0
+    ) {
+      return;
+    }
+
+    const unresolvedModulePaths = resolvedConfig.syncPluginModulePaths.filter((modulePath) =>
+      Array.from(loadedSyncPlugins.values()).every((plugin) => plugin.modulePath !== modulePath),
+    );
+
+    if (unresolvedModulePaths.length === 0) {
+      return;
+    }
+
+    const loadResult = await loadConfiguredSyncPlugins({
+      modulePaths: unresolvedModulePaths,
+    });
+
+    for (const failure of loadResult.failures) {
+      runtimeLogger.warn("sync plugin load failed", {
+        code: failure.code,
+        message: failure.message,
+        ...(failure.details ?? {}),
+      });
+    }
+
+    for (const loadedPlugin of loadResult.loadedPlugins) {
+      const registrationResult = registerRuntimeWorker(loadedPlugin.workerRegistration, {
+        throwOnFailure: false,
+      });
+
+      if (!registrationResult.ok) {
+        runtimeLogger.warn("sync plugin worker registration failed", {
+          modulePath: loadedPlugin.modulePath,
+          pluginName: loadedPlugin.manifest.name,
+          pluginVersion: loadedPlugin.manifest.version,
+          workerType: loadedPlugin.workerRegistration.manifest.type,
+          code: registrationResult.error.code,
+          message: registrationResult.error.message,
+        });
+        continue;
+      }
+
+      loadedSyncPlugins.set(registrationResult.value.manifest.type, loadedPlugin);
+
+      runtimeLogger.info("sync plugin loaded", {
+        modulePath: loadedPlugin.modulePath,
+        pluginName: loadedPlugin.manifest.name,
+        pluginVersion: loadedPlugin.manifest.version,
+        workerType: registrationResult.value.manifest.type,
+      });
+    }
+  }
+
   async function createHostOwnedTodu(): Promise<Todu> {
     registerHabitProcessor();
 
@@ -624,6 +713,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       runtimeStatus.catalogId = startedTodu.sync.getCatalogId();
       runtimeStatus.transport = endpoint;
 
+      await loadConfiguredSyncPluginWorkers();
       attachEventSubscriptions(startedTodu);
       startRegisteredWorkers();
 
@@ -1124,6 +1214,9 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         assignedWorkerTypes: resolvedConfig.assignedWorkerTypes
           ? [...resolvedConfig.assignedWorkerTypes]
           : undefined,
+        syncPluginModulePaths: resolvedConfig.syncPluginModulePaths
+          ? [...resolvedConfig.syncPluginModulePaths]
+          : undefined,
       };
     },
   };
@@ -1195,6 +1288,42 @@ function resolveAssignedWorkerTypes(workerTypes: readonly string[] | undefined):
   return {
     assignedWorkerTypes: normalized,
     duplicateWorkerTypes: duplicates,
+  };
+}
+
+function resolveSyncPluginModulePaths(modulePaths: readonly string[] | undefined): {
+  modulePaths: string[] | undefined;
+  duplicateModulePaths: string[];
+} {
+  if (!modulePaths) {
+    return {
+      modulePaths: undefined,
+      duplicateModulePaths: [],
+    };
+  }
+
+  const normalized: string[] = [];
+  const duplicates: string[] = [];
+
+  for (const modulePath of modulePaths) {
+    const trimmedModulePath = modulePath.trim();
+    if (!trimmedModulePath) {
+      continue;
+    }
+
+    if (normalized.includes(trimmedModulePath)) {
+      if (!duplicates.includes(trimmedModulePath)) {
+        duplicates.push(trimmedModulePath);
+      }
+      continue;
+    }
+
+    normalized.push(trimmedModulePath);
+  }
+
+  return {
+    modulePaths: normalized,
+    duplicateModulePaths: duplicates,
   };
 }
 

--- a/packages/daemon/src/sync-plugin-loader.ts
+++ b/packages/daemon/src/sync-plugin-loader.ts
@@ -1,0 +1,182 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  type SyncProviderRegistration,
+  type SyncProviderValidationError,
+  validateSyncProviderRegistration,
+} from "@todu/core";
+import {
+  createNoopWorkerRuntime,
+  type WorkerManifest,
+  type WorkerRegistration,
+} from "./workers.js";
+
+export const SYNC_PLUGIN_LOAD_ERROR_CODES = [
+  "IMPORT_FAILED",
+  "INVALID_EXPORT",
+  "INVALID_PROVIDER",
+  "DUPLICATE_WORKER_TYPE",
+] as const;
+
+export type SyncPluginLoadErrorCode = (typeof SYNC_PLUGIN_LOAD_ERROR_CODES)[number];
+
+export interface SyncPluginLoadError {
+  code: SyncPluginLoadErrorCode;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface LoadedSyncPlugin {
+  workerRegistration: WorkerRegistration;
+  manifest: SyncProviderRegistration["manifest"];
+  modulePath: string;
+}
+
+export interface LoadConfiguredSyncPluginsResult {
+  loadedPlugins: LoadedSyncPlugin[];
+  failures: SyncPluginLoadError[];
+}
+
+export interface LoadConfiguredSyncPluginsOptions {
+  modulePaths: string[];
+  importModule?: (specifier: string) => Promise<unknown>;
+}
+
+interface SyncPluginModuleShape {
+  default?: unknown;
+  syncProvider?: unknown;
+}
+
+export async function loadConfiguredSyncPlugins(
+  options: LoadConfiguredSyncPluginsOptions,
+): Promise<LoadConfiguredSyncPluginsResult> {
+  const importModule = options.importModule ?? ((specifier) => import(specifier));
+  const loadedPlugins: LoadedSyncPlugin[] = [];
+  const failures: SyncPluginLoadError[] = [];
+  const seenWorkerTypes = new Set<string>();
+
+  for (const modulePath of options.modulePaths) {
+    const importSpecifier = resolveSyncPluginImportSpecifier(modulePath);
+
+    let moduleExports: unknown;
+    try {
+      moduleExports = await importModule(importSpecifier);
+    } catch (error) {
+      failures.push({
+        code: "IMPORT_FAILED",
+        message: `Failed to import sync plugin module: ${modulePath}`,
+        details: {
+          modulePath,
+          importSpecifier,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      continue;
+    }
+
+    const registrationCandidate = extractSyncProviderRegistration(moduleExports);
+    if (!registrationCandidate) {
+      failures.push({
+        code: "INVALID_EXPORT",
+        message: `Sync plugin module must export syncProvider or default registration: ${modulePath}`,
+        details: {
+          modulePath,
+          exportNames: Object.keys((moduleExports ?? {}) as Record<string, unknown>),
+        },
+      });
+      continue;
+    }
+
+    const validation = validateSyncProviderRegistration(registrationCandidate);
+    if (!validation.ok) {
+      failures.push(createInvalidProviderError(modulePath, validation.error));
+      continue;
+    }
+
+    const workerType = createSyncPluginWorkerType(validation.value.manifest.name);
+    if (seenWorkerTypes.has(workerType)) {
+      failures.push({
+        code: "DUPLICATE_WORKER_TYPE",
+        message: `Sync plugin worker type collision: ${workerType}`,
+        details: {
+          modulePath,
+          workerType,
+          pluginName: validation.value.manifest.name,
+        },
+      });
+      continue;
+    }
+
+    seenWorkerTypes.add(workerType);
+
+    loadedPlugins.push({
+      modulePath,
+      manifest: validation.value.manifest,
+      workerRegistration: {
+        manifest: createSyncPluginWorkerManifest(workerType),
+        runtime: createNoopWorkerRuntime(),
+      },
+    });
+  }
+
+  return {
+    loadedPlugins,
+    failures,
+  };
+}
+
+function createInvalidProviderError(
+  modulePath: string,
+  validationError: SyncProviderValidationError,
+): SyncPluginLoadError {
+  return {
+    code: "INVALID_PROVIDER",
+    message: `Invalid sync plugin provider registration: ${modulePath}`,
+    details: {
+      modulePath,
+      validationError,
+    },
+  };
+}
+
+function extractSyncProviderRegistration(moduleExports: unknown): SyncProviderRegistration | null {
+  if (!moduleExports || typeof moduleExports !== "object") {
+    return null;
+  }
+
+  const moduleShape = moduleExports as SyncPluginModuleShape;
+  const candidate = moduleShape.syncProvider ?? moduleShape.default;
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  return candidate as SyncProviderRegistration;
+}
+
+function createSyncPluginWorkerManifest(workerType: string): WorkerManifest {
+  return {
+    type: workerType,
+    requiredDomains: ["sync", "task"],
+    roleHints: ["node"],
+  };
+}
+
+function createSyncPluginWorkerType(pluginName: string): string {
+  const normalizedName = pluginName
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_-]+/g, "-");
+  const workerTypeBase = normalizedName.endsWith("-sync")
+    ? normalizedName
+    : `${normalizedName}-sync`;
+  return workerTypeBase;
+}
+
+function resolveSyncPluginImportSpecifier(modulePath: string): string {
+  if (path.isAbsolute(modulePath) || modulePath.startsWith(".")) {
+    const absolutePath = path.resolve(modulePath);
+    return pathToFileURL(absolutePath).href;
+  }
+
+  return modulePath;
+}


### PR DESCRIPTION
## Summary
- add daemon sync plugin module path parsing (`TODUAI_DAEMON_PLUGIN_PATHS`) with deterministic dedupe/ignore behavior
- add CLI-side plugin path resolution from config (`daemon.plugins.paths`) with env override precedence and config-relative path normalization
- implement sync plugin loading in daemon runtime startup via `loadConfiguredSyncPlugins(...)`, validating registrations with `@todu/core` and safely logging structured failures
- register loaded sync plugins as worker registrations so they flow through existing worker lifecycle + `worker.status` visibility
- apply restart-based activation semantics by loading configured plugins at daemon startup and reusing existing worker lifecycle start/stop behavior across runtime restarts
- document plugin path configuration, precedence, and restart behavior in architecture + daemon/CLI/plugin docs

## Testing
- make pre-pr
