### PR TITLE
feat(daemon): add sync plugin scheduler with retry policy

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -140,6 +140,27 @@ Behavior notes:
 - `plugin remove` and `plugin install` report when daemon restart is required for activation/removal.
 - `plugin config --set` requires a JSON object.
 
+Per-plugin sync scheduler fields are configured through `plugin config --set`:
+
+```bash
+toduai plugin config github --set '{"projectId":"proj-123","strategy":"bidirectional","intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}'
+```
+
+Supported scheduler fields:
+- `projectId` (string): local project to sync for this plugin.
+- `strategy` (`bidirectional` | `pull` | `push` | `none`): operation mode per cycle.
+- `intervalSeconds` (positive number): steady-state cycle interval.
+- `retryInitialSeconds` (positive number): first retry delay after a failed cycle.
+- `retryMaxSeconds` (positive number): upper bound for exponential backoff.
+- `enabled` (boolean, optional): disables execution when false.
+- `settings` (object, optional): provider-specific settings passed to `initialize(...)`.
+
+Retry policy:
+- Failures are logged with plugin name, attempt count, and next retry delay.
+- Backoff uses `retryInitialSeconds * 2^attempt`, capped at `retryMaxSeconds`.
+- A successful cycle resets retry attempt state.
+- Changes require daemon restart to apply.
+
 ## Validate connectivity
 
 ```bash

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -177,6 +177,11 @@ export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/p
 - Plugin path resolution order is env first, then config file.
 - Config file plugin paths resolve relative to the config file directory.
 - Plugin path/config changes apply on daemon restart.
+- Sync plugin scheduler config can be overridden via `TODUAI_DAEMON_PLUGIN_CONFIG` (JSON object keyed by plugin name).
+
+```bash
+export TODUAI_DAEMON_PLUGIN_CONFIG='{"github":{"projectId":"proj-123","intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60}}'
+```
 
 - Optional socket override:
 

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -93,6 +93,22 @@ Runtime behavior:
 - Path/config changes apply on daemon restart.
 - Duplicate path entries are tolerated and logged; first occurrence wins.
 
+Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginName>` in config file or `TODUAI_DAEMON_PLUGIN_CONFIG` env var (JSON object). Supported fields:
+
+- `projectId`: target local project ID.
+- `strategy`: `bidirectional`, `pull`, `push`, or `none`.
+- `intervalSeconds`: steady-state cycle interval.
+- `retryInitialSeconds` / `retryMaxSeconds`: retry backoff controls.
+- `enabled`: optional execution toggle.
+- `settings`: provider-specific object passed to `initialize(...)`.
+
+Retry policy:
+
+- Pull/push cycle failures are logged and retried with exponential backoff.
+- Delay formula is `retryInitialSeconds * 2^attempt`, capped by `retryMaxSeconds`.
+- Retry state resets after a successful cycle.
+- Daemon shutdown stops further scheduling and calls provider `shutdown()`.
+
 ## Conflict Resolution Baseline
 
 Provider sync conflict resolution baseline is `last-write-wins` based on `updatedAt` timestamps. Providers should preserve external timestamps where available and provide deterministic mapping behavior under repeated pull/push runs.

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -11,6 +11,10 @@ import {
   resolveDaemonSocketPath,
 } from "../daemon-command-client.js";
 import {
+  resolveDaemonPluginConfig,
+  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+} from "../daemon-plugin-config.js";
+import {
   resolveDaemonPluginPaths,
   TODUAI_DAEMON_PLUGIN_PATHS_ENV,
 } from "../daemon-plugin-paths.js";
@@ -63,6 +67,7 @@ interface DaemonCommandContext {
   remoteSyncServer: string | null;
   assignedWorkersEnvValue: string | undefined;
   pluginPathsEnvValue: string | undefined;
+  pluginConfigEnvValue: string | undefined;
 }
 
 const DIRECT_PID_FILENAME = "daemon.pid";
@@ -748,6 +753,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
   const remoteSync = resolveRemoteSyncConfig(fileConfig);
   const assignedWorkers = resolveDaemonAssignedWorkers(fileConfig);
   const pluginPaths = resolveDaemonPluginPaths(configPath, fileConfig);
+  const pluginConfig = resolveDaemonPluginConfig(fileConfig);
 
   return {
     storagePath,
@@ -757,6 +763,7 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
     remoteSyncServer: remoteSync?.server ?? null,
     assignedWorkersEnvValue: assignedWorkers.value,
     pluginPathsEnvValue: pluginPaths.value,
+    pluginConfigEnvValue: pluginConfig.value,
   };
 }
 
@@ -781,6 +788,10 @@ function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv 
 
   if (context.pluginPathsEnvValue !== undefined) {
     childEnv[TODUAI_DAEMON_PLUGIN_PATHS_ENV] = context.pluginPathsEnvValue;
+  }
+
+  if (context.pluginConfigEnvValue !== undefined) {
+    childEnv[TODUAI_DAEMON_PLUGIN_CONFIG_ENV] = context.pluginConfigEnvValue;
   }
 
   return childEnv;

--- a/packages/cli/src/daemon-plugin-config.test.ts
+++ b/packages/cli/src/daemon-plugin-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDaemonPluginConfig,
+  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+} from "./daemon-plugin-config.js";
+
+describe("resolveDaemonPluginConfig", () => {
+  it("prefers env override over config file plugin config", () => {
+    const resolved = resolveDaemonPluginConfig(
+      {
+        daemon: {
+          plugins: {
+            config: {
+              github: {
+                intervalSeconds: 300,
+              },
+            },
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"intervalSeconds":60}}',
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: '{"github":{"intervalSeconds":60}}',
+      source: "env",
+    });
+  });
+
+  it("serializes config file plugin config as JSON", () => {
+    const resolved = resolveDaemonPluginConfig(
+      {
+        daemon: {
+          plugins: {
+            config: {
+              github: {
+                projectId: "proj-1",
+                strategy: "pull",
+              },
+            },
+          },
+        },
+      },
+      {},
+    );
+
+    expect(resolved).toEqual({
+      value: '{"github":{"projectId":"proj-1","strategy":"pull"}}',
+      source: "file",
+    });
+  });
+
+  it("returns unset when plugin config is not present", () => {
+    const resolved = resolveDaemonPluginConfig({}, {});
+
+    expect(resolved).toEqual({
+      value: undefined,
+      source: "unset",
+    });
+  });
+});

--- a/packages/cli/src/daemon-plugin-config.ts
+++ b/packages/cli/src/daemon-plugin-config.ts
@@ -1,0 +1,34 @@
+import type { ToduFileConfig } from "@todu/core";
+
+export const TODUAI_DAEMON_PLUGIN_CONFIG_ENV = "TODUAI_DAEMON_PLUGIN_CONFIG";
+
+export interface ResolvedDaemonPluginConfig {
+  value: string | undefined;
+  source: "env" | "file" | "unset";
+}
+
+export function resolveDaemonPluginConfig(
+  config: ToduFileConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedDaemonPluginConfig {
+  const envValue = env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
+  if (envValue !== undefined) {
+    return {
+      value: envValue,
+      source: "env",
+    };
+  }
+
+  const pluginConfig = config.daemon?.plugins?.config;
+  if (!pluginConfig) {
+    return {
+      value: undefined,
+      source: "unset",
+    };
+  }
+
+  return {
+    value: JSON.stringify(pluginConfig),
+    source: "file",
+  };
+}

--- a/packages/daemon/src/entrypoint.ts
+++ b/packages/daemon/src/entrypoint.ts
@@ -2,6 +2,10 @@
 
 import { resolveRemoteSyncConfig } from "@todu/core";
 import { createDaemonLogger, resolveDaemonLogLevelFromEnv } from "./logger.js";
+import {
+  parseDaemonPluginConfigFromEnv,
+  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+} from "./plugin-config.js";
 import { parseDaemonPluginPathsFromEnv, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
 import { startDaemonProcess } from "./process.js";
 import { type DaemonRole, isDaemonRole } from "./runtime.js";
@@ -34,6 +38,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
   const remoteSync = resolveRemoteSyncConfig({});
   const assignmentConfig = parseAssignedWorkerTypesFromEnv(process.env);
   const pluginPathsConfig = parseDaemonPluginPathsFromEnv(process.env);
+  const pluginConfig = parseDaemonPluginConfigFromEnv(process.env);
 
   if (assignmentConfig.duplicateWorkerTypes.length > 0) {
     logger.warn("duplicate daemon worker assignment entries detected", {
@@ -63,6 +68,21 @@ export async function runDaemonEntrypoint(): Promise<void> {
     });
   }
 
+  if (pluginConfig.parseError) {
+    logger.warn("daemon plugin config parse failed", {
+      envVar: TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+      error: pluginConfig.parseError,
+    });
+  }
+
+  if (pluginConfig.ignoredEntries.length > 0) {
+    logger.warn("ignored invalid daemon plugin config entries", {
+      envVar: TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+      ignoredEntryCount: pluginConfig.ignoredEntries.length,
+      ignoredEntries: pluginConfig.ignoredEntries,
+    });
+  }
+
   const daemon = await startDaemonProcess(
     {
       role: daemonRole,
@@ -71,6 +91,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
       logLevel: daemonLogLevel,
       assignedWorkerTypes: assignmentConfig.assignedWorkerTypes,
       syncPluginModulePaths: pluginPathsConfig.modulePaths,
+      syncPluginConfigs: pluginConfig.pluginConfigs,
     },
     {
       hooks: {
@@ -81,6 +102,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
             catalogId: status.catalogId ?? "-",
             assignedWorkerTypes: assignmentConfig.assignedWorkerTypes ?? "all",
             configuredPluginModulePaths: pluginPathsConfig.modulePaths ?? [],
+            configuredPluginNames: Object.keys(pluginConfig.pluginConfigs ?? {}),
           });
         },
         onStopping: (reason) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -9,6 +9,11 @@ export {
   resolveDaemonLogLevelFromEnv,
 } from "./logger.js";
 export {
+  type ParsedDaemonPluginConfigEnv,
+  parseDaemonPluginConfigFromEnv,
+  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+} from "./plugin-config.js";
+export {
   type ParsedDaemonPluginPathsEnv,
   parseDaemonPluginPathsFromEnv,
   TODUAI_DAEMON_PLUGIN_PATHS_ENV,
@@ -80,6 +85,14 @@ export {
   type SyncPluginLoadError,
   type SyncPluginLoadErrorCode,
 } from "./sync-plugin-loader.js";
+export {
+  type CreateSyncPluginWorkerRuntimeOptions,
+  computeRetryDelayMs,
+  createSyncPluginWorkerRuntime,
+  type ResolveSyncPluginExecutionConfigResult,
+  resolveSyncPluginExecutionConfig,
+  type SyncPluginExecutionConfig,
+} from "./sync-worker-runtime.js";
 export {
   createUdsTransport,
   DEFAULT_DAEMON_SOCKET_FILENAME,

--- a/packages/daemon/src/plugin-config.test.ts
+++ b/packages/daemon/src/plugin-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseDaemonPluginConfigFromEnv,
+  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+} from "./plugin-config.js";
+
+describe("parseDaemonPluginConfigFromEnv", () => {
+  it("returns undefined when env var is not set", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({});
+
+    expect(parsed).toEqual({
+      pluginConfigs: undefined,
+      ignoredEntries: [],
+    });
+  });
+
+  it("parses plugin config object from JSON", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({
+      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]:
+        '{"github":{"projectId":"proj-1","intervalSeconds":60},"forgejo":{"enabled":false}}',
+    });
+
+    expect(parsed).toEqual({
+      pluginConfigs: {
+        github: {
+          projectId: "proj-1",
+          intervalSeconds: 60,
+        },
+        forgejo: {
+          enabled: false,
+        },
+      },
+      ignoredEntries: [],
+    });
+  });
+
+  it("reports invalid JSON as parse error", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({
+      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: "{bad",
+    });
+
+    expect(parsed.pluginConfigs).toEqual({});
+    expect(parsed.parseError).toContain("invalid JSON");
+  });
+
+  it("ignores non-object plugin entries", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({
+      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":true,"ok":{"enabled":true}}',
+    });
+
+    expect(parsed).toEqual({
+      pluginConfigs: {
+        ok: {
+          enabled: true,
+        },
+      },
+      ignoredEntries: ["github"],
+    });
+  });
+
+  it("supports explicit empty plugin config object", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({
+      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: "",
+    });
+
+    expect(parsed).toEqual({
+      pluginConfigs: {},
+      ignoredEntries: [],
+    });
+  });
+});

--- a/packages/daemon/src/plugin-config.ts
+++ b/packages/daemon/src/plugin-config.ts
@@ -1,0 +1,68 @@
+export const TODUAI_DAEMON_PLUGIN_CONFIG_ENV = "TODUAI_DAEMON_PLUGIN_CONFIG";
+
+export interface ParsedDaemonPluginConfigEnv {
+  pluginConfigs: Record<string, Record<string, unknown>> | undefined;
+  parseError?: string;
+  ignoredEntries: string[];
+}
+
+export function parseDaemonPluginConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ParsedDaemonPluginConfigEnv {
+  const rawConfig = env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
+  if (rawConfig === undefined) {
+    return {
+      pluginConfigs: undefined,
+      ignoredEntries: [],
+    };
+  }
+
+  if (rawConfig.trim().length === 0) {
+    return {
+      pluginConfigs: {},
+      ignoredEntries: [],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig);
+  } catch (error) {
+    return {
+      pluginConfigs: {},
+      parseError: `invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      ignoredEntries: [],
+    };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      pluginConfigs: {},
+      parseError: "plugin config must be a JSON object keyed by plugin name",
+      ignoredEntries: [],
+    };
+  }
+
+  const pluginConfigs: Record<string, Record<string, unknown>> = {};
+  const ignoredEntries: string[] = [];
+
+  for (const [pluginName, value] of Object.entries(parsed)) {
+    const trimmedName = pluginName.trim();
+    if (!trimmedName) {
+      ignoredEntries.push(pluginName);
+      continue;
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      ignoredEntries.push(pluginName);
+      continue;
+    }
+
+    pluginConfigs[trimmedName] = value as Record<string, unknown>;
+  }
+
+  return {
+    pluginConfigs,
+    ignoredEntries,
+  };
+}

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -29,6 +29,10 @@ import {
 } from "./rpc.js";
 import { type LoadedSyncPlugin, loadConfiguredSyncPlugins } from "./sync-plugin-loader.js";
 import {
+  createSyncPluginWorkerRuntime,
+  resolveSyncPluginExecutionConfig,
+} from "./sync-worker-runtime.js";
+import {
   createUdsTransport,
   resolveUdsSocketPath,
   type UdsEndpoint,
@@ -75,6 +79,7 @@ export interface DaemonRuntimeConfig {
   enabledWorkerDomains?: WorkerDomainCapability[];
   assignedWorkerTypes?: string[];
   syncPluginModulePaths?: string[];
+  syncPluginConfigs?: Record<string, Record<string, unknown>>;
 }
 
 export interface ResolvedDaemonRuntimeConfig {
@@ -89,6 +94,7 @@ export interface ResolvedDaemonRuntimeConfig {
   enabledWorkerDomains: WorkerDomainCapability[];
   assignedWorkerTypes?: string[];
   syncPluginModulePaths?: string[];
+  syncPluginConfigs?: Record<string, Record<string, unknown>>;
 }
 
 export interface DaemonRuntimeStatus {
@@ -131,6 +137,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
   const resolvedEnabledWorkerDomains = resolveEnabledWorkerDomains(config.enabledWorkerDomains);
   const assignmentResolution = resolveAssignedWorkerTypes(config.assignedWorkerTypes);
   const pluginPathResolution = resolveSyncPluginModulePaths(config.syncPluginModulePaths);
+  const pluginConfigResolution = resolveSyncPluginConfigs(config.syncPluginConfigs);
 
   const resolvedConfig: ResolvedDaemonRuntimeConfig = {
     storagePath: resolvedStoragePath,
@@ -148,6 +155,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     enabledWorkerDomains: resolvedEnabledWorkerDomains,
     assignedWorkerTypes: assignmentResolution.assignedWorkerTypes,
     syncPluginModulePaths: pluginPathResolution.modulePaths,
+    syncPluginConfigs: pluginConfigResolution.syncPluginConfigs,
   };
 
   let todu: Todu | null = null;
@@ -656,7 +664,33 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     }
 
     for (const loadedPlugin of loadResult.loadedPlugins) {
-      const registrationResult = registerRuntimeWorker(loadedPlugin.workerRegistration, {
+      const pluginConfigResolution = resolveSyncPluginExecutionConfig(
+        loadedPlugin.manifest.name,
+        resolvedConfig.syncPluginConfigs?.[loadedPlugin.manifest.name],
+      );
+
+      for (const warningMessage of pluginConfigResolution.warnings) {
+        runtimeLogger.warn(warningMessage, {
+          pluginName: loadedPlugin.manifest.name,
+          pluginVersion: loadedPlugin.manifest.version,
+          modulePath: loadedPlugin.modulePath,
+        });
+      }
+
+      const workerRegistration: WorkerRegistration = {
+        manifest: loadedPlugin.workerRegistration.manifest,
+        runtime: createSyncPluginWorkerRuntime({
+          pluginName: loadedPlugin.manifest.name,
+          pluginVersion: loadedPlugin.manifest.version,
+          modulePath: loadedPlugin.modulePath,
+          provider: loadedPlugin.provider,
+          config: pluginConfigResolution.config,
+          logger: runtimeLogger,
+          getTodu: () => todu,
+        }),
+      };
+
+      const registrationResult = registerRuntimeWorker(workerRegistration, {
         throwOnFailure: false,
       });
 
@@ -665,7 +699,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
           modulePath: loadedPlugin.modulePath,
           pluginName: loadedPlugin.manifest.name,
           pluginVersion: loadedPlugin.manifest.version,
-          workerType: loadedPlugin.workerRegistration.manifest.type,
+          workerType: workerRegistration.manifest.type,
           code: registrationResult.error.code,
           message: registrationResult.error.message,
         });
@@ -679,6 +713,9 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         pluginName: loadedPlugin.manifest.name,
         pluginVersion: loadedPlugin.manifest.version,
         workerType: registrationResult.value.manifest.type,
+        intervalMs: pluginConfigResolution.config.intervalMs,
+        strategy: pluginConfigResolution.config.strategy,
+        projectId: pluginConfigResolution.config.projectId ?? null,
       });
     }
   }
@@ -1217,6 +1254,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         syncPluginModulePaths: resolvedConfig.syncPluginModulePaths
           ? [...resolvedConfig.syncPluginModulePaths]
           : undefined,
+        syncPluginConfigs: cloneSyncPluginConfigs(resolvedConfig.syncPluginConfigs),
       };
     },
   };
@@ -1324,6 +1362,49 @@ function resolveSyncPluginModulePaths(modulePaths: readonly string[] | undefined
   return {
     modulePaths: normalized,
     duplicateModulePaths: duplicates,
+  };
+}
+
+function cloneSyncPluginConfigs(
+  pluginConfigs: Record<string, Record<string, unknown>> | undefined,
+): Record<string, Record<string, unknown>> | undefined {
+  if (!pluginConfigs) {
+    return undefined;
+  }
+
+  const cloned: Record<string, Record<string, unknown>> = {};
+
+  for (const [pluginName, pluginConfig] of Object.entries(pluginConfigs)) {
+    cloned[pluginName] = { ...pluginConfig };
+  }
+
+  return cloned;
+}
+
+function resolveSyncPluginConfigs(
+  pluginConfigs: Record<string, Record<string, unknown>> | undefined,
+): {
+  syncPluginConfigs: Record<string, Record<string, unknown>> | undefined;
+} {
+  if (!pluginConfigs) {
+    return {
+      syncPluginConfigs: undefined,
+    };
+  }
+
+  const normalized: Record<string, Record<string, unknown>> = {};
+
+  for (const [pluginName, pluginConfig] of Object.entries(pluginConfigs)) {
+    const trimmedPluginName = pluginName.trim();
+    if (!trimmedPluginName) {
+      continue;
+    }
+
+    normalized[trimmedPluginName] = pluginConfig;
+  }
+
+  return {
+    syncPluginConfigs: normalized,
   };
 }
 

--- a/packages/daemon/src/sync-plugin-loader.ts
+++ b/packages/daemon/src/sync-plugin-loader.ts
@@ -29,6 +29,7 @@ export interface SyncPluginLoadError {
 export interface LoadedSyncPlugin {
   workerRegistration: WorkerRegistration;
   manifest: SyncProviderRegistration["manifest"];
+  provider: SyncProviderRegistration["provider"];
   modulePath: string;
 }
 
@@ -112,6 +113,7 @@ export async function loadConfiguredSyncPlugins(
     loadedPlugins.push({
       modulePath,
       manifest: validation.value.manifest,
+      provider: validation.value.provider,
       workerRegistration: {
         manifest: createSyncPluginWorkerManifest(workerType),
         runtime: createNoopWorkerRuntime(),

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1,0 +1,298 @@
+import {
+  createProjectId,
+  createTaskId,
+  ok,
+  type Project,
+  type SyncProvider,
+  type Task,
+} from "@todu/core";
+import type { Todu } from "@todu/engine";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DaemonLogger } from "./logger.js";
+import {
+  computeRetryDelayMs,
+  createSyncPluginWorkerRuntime,
+  resolveSyncPluginExecutionConfig,
+} from "./sync-worker-runtime.js";
+
+describe("sync-worker-runtime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("executes pull/push cycles on configured interval", async () => {
+    const provider = createProvider();
+    const project = createProject();
+    const task = createTask(project.id);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      provider,
+      config: {
+        enabled: true,
+        projectId: project.id,
+        strategy: "bidirectional",
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => createTodu(project, [task]),
+    });
+
+    const handle = runtime.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(provider.initialize).toHaveBeenCalledTimes(1);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+    expect(provider.push).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(provider.pull).toHaveBeenCalledTimes(2);
+    expect(provider.push).toHaveBeenCalledTimes(2);
+
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(provider.pull).toHaveBeenCalledTimes(2);
+    expect(provider.push).toHaveBeenCalledTimes(2);
+    expect(provider.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries failed cycles with exponential backoff", async () => {
+    const provider = createProvider({
+      pull: vi
+        .fn<SyncProvider["pull"]>()
+        .mockRejectedValueOnce(new Error("network down"))
+        .mockRejectedValueOnce(new Error("network down"))
+        .mockResolvedValue(undefined),
+    });
+    const project = createProject();
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      provider,
+      config: {
+        enabled: true,
+        projectId: project.id,
+        strategy: "pull",
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 400,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => createTodu(project, []),
+    });
+
+    const handle = runtime.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(provider.pull).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(199);
+    expect(provider.pull).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(provider.pull).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(provider.pull).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(provider.pull).toHaveBeenCalledTimes(4);
+
+    expect(provider.initialize).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+
+  it("stops without orphaning scheduled loops and shuts down provider", async () => {
+    const deferred = createDeferred<void>();
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockImplementation(async () => {
+        await deferred.promise;
+      }),
+    });
+    const project = createProject();
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      provider,
+      config: {
+        enabled: true,
+        projectId: project.id,
+        strategy: "pull",
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 400,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => createTodu(project, []),
+    });
+
+    const handle = runtime.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(provider.shutdown).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(provider.pull).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves config defaults and clamps retry max", () => {
+    const resolved = resolveSyncPluginExecutionConfig("github", {
+      retryInitialSeconds: 12,
+      retryMaxSeconds: 5,
+      strategy: "invalid",
+      enabled: "yes",
+      intervalSeconds: -1,
+      settings: "oops",
+    });
+
+    expect(resolved.config).toEqual({
+      enabled: true,
+      projectId: undefined,
+      strategy: "bidirectional",
+      intervalMs: 300_000,
+      retryInitialMs: 12_000,
+      retryMaxMs: 12_000,
+      settings: {},
+    });
+    expect(resolved.warnings.length).toBeGreaterThan(0);
+    expect(computeRetryDelayMs(0, resolved.config)).toBe(12_000);
+    expect(computeRetryDelayMs(3, resolved.config)).toBe(12_000);
+  });
+});
+
+function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
+  return {
+    initialize: vi.fn<SyncProvider["initialize"]>().mockResolvedValue(undefined),
+    pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue(undefined),
+    push: vi.fn<SyncProvider["push"]>().mockResolvedValue(undefined),
+    shutdown: vi.fn<SyncProvider["shutdown"]>().mockResolvedValue(undefined),
+    mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
+      id: createTaskId(String(item.id)),
+      title: String(item.id),
+      status: "todo",
+      priority: "medium",
+      projectId: createProject().id,
+      labels: [],
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    })),
+    mapFromTask: vi.fn<SyncProvider["mapFromTask"]>().mockImplementation((task) => ({
+      id: task.id,
+      title: task.title,
+    })),
+    ...overrides,
+  };
+}
+
+function createProject(): Project {
+  const now = new Date(0).toISOString();
+
+  return {
+    id: createProjectId("proj-1"),
+    name: "Project",
+    status: "active",
+    priority: "medium",
+    syncStrategy: "none",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createTask(projectId: Project["id"]): Task {
+  const now = new Date(0).toISOString();
+
+  return {
+    id: createTaskId("task-1"),
+    title: "Task",
+    status: "todo",
+    priority: "medium",
+    projectId,
+    labels: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createTodu(project: Project, tasks: Task[]): Todu {
+  return {
+    project: {
+      get: vi.fn().mockResolvedValue(ok(project)),
+    },
+    task: {
+      list: vi.fn().mockResolvedValue(ok(tasks)),
+    },
+  } as unknown as Todu;
+}
+
+function createLogger(): DaemonLogger {
+  const logger: DaemonLogger = {
+    level: "debug",
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+
+  (logger.child as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => logger);
+
+  return logger;
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -1,0 +1,386 @@
+import {
+  createProjectId,
+  isSyncStrategy,
+  type SyncProvider,
+  type SyncStrategy,
+  type ToduError,
+} from "@todu/core";
+import type { Todu } from "@todu/engine";
+import type { DaemonLogger } from "./logger.js";
+import type { WorkerRuntime } from "./workers.js";
+
+const DEFAULT_SYNC_INTERVAL_SECONDS = 300;
+const DEFAULT_RETRY_INITIAL_SECONDS = 5;
+const DEFAULT_RETRY_MAX_SECONDS = 60;
+
+export interface SyncPluginExecutionConfig {
+  enabled: boolean;
+  projectId?: string;
+  strategy: SyncStrategy;
+  intervalMs: number;
+  retryInitialMs: number;
+  retryMaxMs: number;
+  settings: Record<string, unknown>;
+}
+
+export interface ResolveSyncPluginExecutionConfigResult {
+  config: SyncPluginExecutionConfig;
+  warnings: string[];
+}
+
+export interface CreateSyncPluginWorkerRuntimeOptions {
+  pluginName: string;
+  pluginVersion: string;
+  modulePath: string;
+  provider: SyncProvider;
+  config: SyncPluginExecutionConfig;
+  logger: DaemonLogger;
+  getTodu: () => Todu | null;
+  scheduler?: {
+    setTimeoutFn?: (handler: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+    clearTimeoutFn?: (timeout: ReturnType<typeof setTimeout>) => void;
+    now?: () => number;
+  };
+}
+
+export function resolveSyncPluginExecutionConfig(
+  pluginName: string,
+  rawConfig: Record<string, unknown> | undefined,
+): ResolveSyncPluginExecutionConfigResult {
+  const warnings: string[] = [];
+
+  const enabled = parseBoolean(rawConfig?.enabled, true, warnings, "enabled", pluginName);
+  const projectId = parseOptionalString(rawConfig?.projectId);
+  const strategy = parseStrategy(rawConfig?.strategy, warnings, pluginName);
+
+  const intervalMs = parseSecondsAsMs(
+    rawConfig?.intervalSeconds,
+    DEFAULT_SYNC_INTERVAL_SECONDS,
+    warnings,
+    "intervalSeconds",
+    pluginName,
+  );
+  const retryInitialMs = parseSecondsAsMs(
+    rawConfig?.retryInitialSeconds,
+    DEFAULT_RETRY_INITIAL_SECONDS,
+    warnings,
+    "retryInitialSeconds",
+    pluginName,
+  );
+  let retryMaxMs = parseSecondsAsMs(
+    rawConfig?.retryMaxSeconds,
+    DEFAULT_RETRY_MAX_SECONDS,
+    warnings,
+    "retryMaxSeconds",
+    pluginName,
+  );
+
+  if (retryMaxMs < retryInitialMs) {
+    warnings.push(
+      `sync plugin config warning (${pluginName}): retryMaxSeconds is less than retryInitialSeconds; using retryInitialSeconds value`,
+    );
+    retryMaxMs = retryInitialMs;
+  }
+
+  const settings = parseSettings(rawConfig?.settings, warnings, pluginName);
+
+  return {
+    config: {
+      enabled,
+      projectId,
+      strategy,
+      intervalMs,
+      retryInitialMs,
+      retryMaxMs,
+      settings,
+    },
+    warnings,
+  };
+}
+
+export function computeRetryDelayMs(attempt: number, config: SyncPluginExecutionConfig): number {
+  const exponent = Math.max(0, attempt);
+  const delay = config.retryInitialMs * 2 ** exponent;
+  return Math.min(config.retryMaxMs, delay);
+}
+
+export function createSyncPluginWorkerRuntime(
+  options: CreateSyncPluginWorkerRuntimeOptions,
+): WorkerRuntime {
+  const setTimeoutFn = options.scheduler?.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = options.scheduler?.clearTimeoutFn ?? clearTimeout;
+  const now = options.scheduler?.now ?? (() => Date.now());
+  const runtimeLogger = options.logger.child(`sync-plugin.${options.pluginName}`);
+
+  return {
+    start() {
+      const config = options.config;
+      let stopped = false;
+      let running = false;
+      let initialized = false;
+      let pendingShutdown = false;
+      let retryAttempt = 0;
+      let missingProjectWarningLogged = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const scheduleNext = (delayMs: number): void => {
+        if (stopped) {
+          return;
+        }
+
+        timer = setTimeoutFn(() => {
+          void runCycle();
+        }, delayMs);
+      };
+
+      const shutdownProvider = async (): Promise<void> => {
+        if (!initialized) {
+          return;
+        }
+
+        initialized = false;
+
+        try {
+          await options.provider.shutdown();
+        } catch (error) {
+          runtimeLogger.warn("sync plugin shutdown failed", {
+            pluginName: options.pluginName,
+            pluginVersion: options.pluginVersion,
+            modulePath: options.modulePath,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      };
+
+      const runCycle = async (): Promise<void> => {
+        if (stopped || running) {
+          return;
+        }
+
+        running = true;
+        const startedAtMs = now();
+
+        try {
+          if (!config.enabled) {
+            retryAttempt = 0;
+            scheduleNext(config.intervalMs);
+            return;
+          }
+
+          if (config.strategy === "none") {
+            retryAttempt = 0;
+            scheduleNext(config.intervalMs);
+            return;
+          }
+
+          if (!config.projectId) {
+            if (!missingProjectWarningLogged) {
+              runtimeLogger.warn("sync plugin projectId is not configured; skipping sync cycle", {
+                pluginName: options.pluginName,
+                pluginVersion: options.pluginVersion,
+                modulePath: options.modulePath,
+              });
+              missingProjectWarningLogged = true;
+            }
+
+            retryAttempt = 0;
+            scheduleNext(config.intervalMs);
+            return;
+          }
+
+          const activeTodu = options.getTodu();
+          if (!activeTodu) {
+            throw new Error("daemon data host unavailable");
+          }
+
+          missingProjectWarningLogged = false;
+
+          if (!initialized) {
+            await options.provider.initialize({
+              projectId: config.projectId,
+              strategy: config.strategy,
+              settings: config.settings,
+            });
+            initialized = true;
+          }
+
+          const projectResult = await activeTodu.project.get(createProjectId(config.projectId));
+          if (!projectResult.ok) {
+            throw new Error(`project load failed: ${formatToduError(projectResult.error)}`);
+          }
+
+          if (config.strategy === "pull" || config.strategy === "bidirectional") {
+            await options.provider.pull(projectResult.value);
+          }
+
+          if (config.strategy === "push" || config.strategy === "bidirectional") {
+            const tasksResult = await activeTodu.task.list({ projectId: projectResult.value.id });
+            if (!tasksResult.ok) {
+              throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+            }
+
+            await options.provider.push(tasksResult.value, projectResult.value);
+          }
+
+          retryAttempt = 0;
+          runtimeLogger.info("sync plugin cycle completed", {
+            pluginName: options.pluginName,
+            pluginVersion: options.pluginVersion,
+            modulePath: options.modulePath,
+            strategy: config.strategy,
+            projectId: config.projectId,
+            durationMs: Math.max(0, Math.round(now() - startedAtMs)),
+          });
+
+          scheduleNext(config.intervalMs);
+        } catch (error) {
+          const delayMs = computeRetryDelayMs(retryAttempt, config);
+          retryAttempt += 1;
+
+          runtimeLogger.warn("sync plugin cycle failed", {
+            pluginName: options.pluginName,
+            pluginVersion: options.pluginVersion,
+            modulePath: options.modulePath,
+            strategy: config.strategy,
+            projectId: config.projectId ?? null,
+            attempt: retryAttempt,
+            nextRetryMs: delayMs,
+            error: error instanceof Error ? error.message : String(error),
+          });
+
+          scheduleNext(delayMs);
+        } finally {
+          running = false;
+
+          if (stopped && pendingShutdown) {
+            pendingShutdown = false;
+            void shutdownProvider();
+          }
+        }
+      };
+
+      scheduleNext(0);
+
+      return {
+        stop() {
+          if (stopped) {
+            return;
+          }
+
+          stopped = true;
+
+          if (timer) {
+            clearTimeoutFn(timer);
+            timer = null;
+          }
+
+          if (running) {
+            pendingShutdown = true;
+            return;
+          }
+
+          void shutdownProvider();
+        },
+      };
+    },
+  };
+}
+
+function formatToduError(error: ToduError): string {
+  switch (error.type) {
+    case "not-found":
+      return `${error.entity} not found: ${error.id}`;
+    case "storage":
+      return error.message;
+    case "validation":
+      return `${error.field}: ${error.message}`;
+  }
+}
+
+function parseSettings(
+  value: unknown,
+  warnings: string[],
+  pluginName: string,
+): Record<string, unknown> {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  warnings.push(
+    `sync plugin config warning (${pluginName}): settings must be an object; using empty settings`,
+  );
+  return {};
+}
+
+function parseStrategy(value: unknown, warnings: string[], pluginName: string): SyncStrategy {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return "bidirectional";
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (isSyncStrategy(normalized)) {
+    return normalized;
+  }
+
+  warnings.push(
+    `sync plugin config warning (${pluginName}): strategy must be one of bidirectional/pull/push/none; using bidirectional`,
+  );
+
+  return "bidirectional";
+}
+
+function parseBoolean(
+  value: unknown,
+  fallback: boolean,
+  warnings: string[],
+  field: string,
+  pluginName: string,
+): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  warnings.push(
+    `sync plugin config warning (${pluginName}): ${field} must be boolean; using ${String(fallback)}`,
+  );
+
+  return fallback;
+}
+
+function parseSecondsAsMs(
+  value: unknown,
+  fallbackSeconds: number,
+  warnings: string[],
+  field: string,
+  pluginName: string,
+): number {
+  if (value === undefined) {
+    return fallbackSeconds * 1_000;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    warnings.push(
+      `sync plugin config warning (${pluginName}): ${field} must be a positive number; using ${fallbackSeconds}`,
+    );
+    return fallbackSeconds * 1_000;
+  }
+
+  return Math.max(1, Math.round(value * 1_000));
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}


### PR DESCRIPTION
## Summary\n- add daemon sync plugin worker runtime that executes plugin pull/push loops on configurable per-plugin intervals\n- add exponential retry policy, failure logging, and graceful shutdown behavior for plugin scheduler loops\n- wire plugin scheduler config through CLI daemon env -> daemon entrypoint -> runtime and document supported scheduler fields/policy\n\n## Testing\n- make pre-pr\n