### PR TITLE
fix: standalone CLI Automerge WASM init for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,16 @@ jobs:
           # Also build native binary for electron bundling
           bun build --compile packages/cli/src/index.ts --outfile dist/cli/toduai
 
+      - name: Smoke test standalone CLI binary (linux x64)
+        run: |
+          dist/cli/toduai-cli-linux-x64 --version
+          dist/cli/toduai-cli-linux-x64 --help > /dev/null
+
+          if strings dist/cli/toduai-cli-linux-x64 | grep -F "/node_modules/@automerge/automerge/dist/mjs/wasm_bindgen_output/nodejs/automerge_wasm_bg.wasm" > /dev/null; then
+            echo "::error::Standalone CLI contains nodejs Automerge wasm file path reference"
+            exit 1
+          fi
+
       - name: Build Electron (linux)
         run: |
           make build-electron

--- a/packages/engine/src/automerge-init.ts
+++ b/packages/engine/src/automerge-init.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import { initializeBase64Wasm, initializeWasm, isWasmInitialized } from "@automerge/automerge/slim";
+
+let initPromise: Promise<void> | null = null;
+
+function isBunRuntime(): boolean {
+  return "Bun" in globalThis;
+}
+
+async function initializeAutomergeWasmRuntime(): Promise<void> {
+  if (isBunRuntime()) {
+    const { automergeWasmBase64 } = await import("@automerge/automerge/automerge.wasm.base64");
+    await initializeBase64Wasm(automergeWasmBase64);
+    return;
+  }
+
+  const require = createRequire(import.meta.url);
+  const wasmPath = require.resolve("@automerge/automerge/automerge.wasm");
+  const wasmBytes = fs.readFileSync(wasmPath);
+  await initializeWasm(wasmBytes);
+}
+
+/**
+ * Ensure Automerge WASM runtime is initialized exactly once per process.
+ *
+ * Node runtimes load bytes from the packaged .wasm file for startup speed.
+ * Bun runtimes initialize from the packaged base64 blob to avoid filesystem
+ * path resolution issues in standalone compiled CLI binaries.
+ */
+export async function ensureAutomergeWasmInitialized(): Promise<void> {
+  if (isWasmInitialized()) {
+    return;
+  }
+
+  if (initPromise === null) {
+    initPromise = initializeAutomergeWasmRuntime().catch((error) => {
+      initPromise = null;
+      throw error;
+    });
+  }
+
+  await initPromise;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,9 +3,10 @@ import {
   type PeerCandidatePayload,
   type PeerDisconnectedPayload,
   Repo,
-} from "@automerge/automerge-repo";
+} from "@automerge/automerge-repo/slim";
 import type { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 import { observeAllChanges } from "./change-observer.js";
 import { createHabitNamespace } from "./habits.js";
 import { createLabelNamespace } from "./labels.js";
@@ -80,6 +81,8 @@ export async function createTodu(
   const resolvedConfig: ToduConfig = {
     storagePath: config.storagePath,
   };
+
+  await ensureAutomergeWasmInitialized();
 
   // Sync client mode: ephemeral in-memory repo that syncs with server
   // Sync server mode: persistent repo that serves sync clients

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { DocHandle, DocumentId } from "@automerge/automerge-repo";
-import { Repo } from "@automerge/automerge-repo";
+import type { DocHandle, DocumentId } from "@automerge/automerge-repo/slim";
+import { Repo } from "@automerge/automerge-repo/slim";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   CATALOG_DOC_KEY,
@@ -9,6 +9,7 @@ import {
   createEmptyCatalog,
   SCHEMA_VERSION,
 } from "@todu/core";
+import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 
 // ============================================================================
 // Storage layer — Automerge repo + document management
@@ -127,6 +128,7 @@ export function beginCatalogJoinSwitch(
  * - Existing but unreachable marker: fail (do not implicitly create a new catalog)
  */
 export async function initBootstrapStorage(storagePath: string, repo?: Repo): Promise<Storage> {
+  await ensureAutomergeWasmInitialized();
   fs.mkdirSync(storagePath, { recursive: true });
 
   const ownsRepo = repo === undefined;
@@ -159,6 +161,7 @@ export async function initJoinStorage(
   targetCatalogId: DocumentId,
   repo?: Repo,
 ): Promise<Storage> {
+  await ensureAutomergeWasmInitialized();
   fs.mkdirSync(storagePath, { recursive: true });
 
   const ownsRepo = repo === undefined;
@@ -205,6 +208,8 @@ export async function initEphemeralStorage(storagePath: string): Promise<
     findCatalog(): Promise<Storage>;
   }
 > {
+  await ensureAutomergeWasmInitialized();
+
   // Read the catalog document ID from the marker file
   const markerPath = getCatalogMarkerPath(storagePath);
   if (!fs.existsSync(markerPath)) {


### PR DESCRIPTION
## Summary
- switch engine runtime repo imports to `@automerge/automerge-repo/slim`
- add explicit Automerge WASM initialization in `@todu/engine` via new `automerge-init` helper
- initialize from base64 in Bun runtimes (standalone compile-safe) and from exported wasm bytes in Node runtimes
- add release workflow smoke gate for linux standalone CLI binary (`--version`, `--help`, and bad path-string check)

## Why
Release `v0.2.0` standalone CLI artifacts referenced a build-host absolute path for `automerge_wasm_bg.wasm` and crashed at startup.

## Verification
- `make pre-pr` (pass)
- bundle inspection confirms no `wasm_bindgen_output/nodejs` path references in the bun-target bundle

Task: #2143
