### PR TITLE
docs: capture plugin boundaries and recurring direction

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,7 +226,8 @@ Baseline worker lifecycle states are:
 - Daemon plugin module paths resolve from `TODUAI_DAEMON_PLUGIN_PATHS` first, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.
-- Author-facing contract and policy details are documented in `docs/worker-plugin-api.md` and `docs/plugin-sync-provider-api.md`.
+- Author-facing contract details are documented in `docs/worker-plugin-api.md` and `docs/plugin-sync-provider-api.md`.
+- Product/plugin boundary policy is documented in `docs/adr/0001-plugin-boundaries-and-data-ownership.md` and `docs/architecture/plugins.md`.
 
 ### Recurring behavior
 

--- a/docs/adr/0001-plugin-boundaries-and-data-ownership.md
+++ b/docs/adr/0001-plugin-boundaries-and-data-ownership.md
@@ -1,0 +1,158 @@
+# ADR 0001: Plugin Boundaries and Data Ownership
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-07
+
+## Context
+
+Plugin-related decisions were being captured inside
+`docs/plans/recurring-task-habit-redesign-candidate.md`.
+
+Those decisions are broader than the recurring redesign itself. They define
+how plugins relate to the core product, what data plugins may own, and what
+safety/compatibility guarantees the host should enforce. That policy needs a
+more durable home than a candidate redesign document.
+
+Relevant current context:
+
+- Core product direction is task-first.
+- Recurring behavior is part of core task workflows.
+- Richer niche workflows, including habit-style extensions, are expected to
+  live in plugins when they are not mainstream core requirements.
+- Existing architecture already uses daemon-loaded worker and sync-provider
+  plugins.
+
+## Decision
+
+### 1. Core remains task-first and complete without plugins
+
+Users who only care about tasks and projects should get a complete baseline
+experience without installing plugins.
+
+Plugins are optional extensions, not a requirement for baseline task use.
+
+### 2. Plugins are permanent extension points for niche workflows
+
+Plugins are not a staging area for future core features by default.
+
+A plugin may inform a future core decision, but the existence of a plugin does
+not imply planned promotion into core.
+
+### 3. Core should not expand primarily to host plugin internals
+
+Do not add broad schema or metadata expansion to core entities solely to make
+plugin-specific behavior easier to store.
+
+In particular, plugin internals should not drive generic key/value blobs or
+similar default expansion of synced core models.
+
+### 4. Plugin internals must not be stored in Automerge core entities
+
+Plugin-owned internal state must live outside synced core entities.
+
+This prevents plugin-specific internal data from leaking into installs that do
+not have the plugin and keeps core data understandable without plugin-specific
+knowledge.
+
+### 5. Plugin-owned state should use local plugin-managed storage
+
+Plugin internal state should be stored in plugin-managed local paths.
+
+Plugins may associate their local state with core entities by foreign keys,
+using identifiers such as:
+
+- `catalogId`
+- `entityType`
+- `entityId`
+
+### 6. Promote outputs, not internals
+
+If a plugin produces user-visible outcomes, those outcomes may be written to
+normal core entities such as tasks or notes.
+
+Plugin internal metadata should remain plugin-owned and local.
+
+### 7. Plugin contracts must be explicit, versioned, and validated
+
+Plugin host contracts must be versioned and checked at load/install time.
+
+Incompatible plugins should fail closed with clear errors rather than running
+in a partially compatible state.
+
+### 8. Plugin failure must not break baseline task workflows
+
+A plugin may fail, be blocked, or be disabled without breaking core task and
+project workflows.
+
+Operational status should be visible through normal daemon status/logging.
+
+### 9. Plugin lifecycle must be explicit and observable
+
+Install, enable, disable, and remove operations should be explicit and
+observable.
+
+When automation is involved, worker assignment should determine where plugin
+behavior runs, including support for a single authority machine.
+
+## Consequences
+
+### Positive
+
+- Core data stays minimal and understandable.
+- Plugin behavior remains optional and isolated.
+- Multi-install safety is improved because plugin internals do not leak into
+  shared synced models.
+- Product boundaries are clearer for future work such as habit-oriented
+  extensions.
+
+### Trade-offs
+
+- Plugins must manage their own local storage and migration concerns.
+- Cross-device plugin experiences may require more explicit operational setup.
+- Some richer workflows may feel less integrated than if they were modeled
+  directly in core.
+
+### Immediate implications
+
+- Habit-style presentation, streak-heavy behavior, and metrics-heavy workflows
+  should be treated as plugin territory unless they become clear mainstream
+  task requirements.
+- Do not add default `pluginData`-style bags to core entities as the primary
+  plugin architecture.
+- Core/product docs should distinguish core behavior from plugin behavior.
+
+## Alternatives Considered
+
+### 1. Plugin-first experimentation as the normal path to core
+
+Not chosen.
+
+This weakens the task-first product boundary and encourages plugins to become a
+shadow staging area for core features.
+
+### 2. Namespaced plugin data stored directly on core entities
+
+Not chosen as the default architecture.
+
+This would expand synced core models to carry plugin internals and would leak
+plugin-specific state into installations that do not use the plugin.
+
+### 3. Expand core to cover richer habit UI, streaks, and metrics now
+
+Not chosen.
+
+That would increase core model and UI surface area beyond the current
+minimal-core direction.
+
+## Related Documents
+
+- `docs/plans/recurring-task-habit-redesign-candidate.md`
+- `docs/ARCHITECTURE.md`
+- `docs/architecture/plugins.md`
+- `docs/worker-plugin-api.md`
+- `docs/plugin-sync-provider-api.md`

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -1,0 +1,174 @@
+# Plugin Architecture and Boundaries
+
+## Purpose
+
+This document captures the product and architecture rules that plugins must
+follow in todu.
+
+It complements:
+
+- `docs/adr/0001-plugin-boundaries-and-data-ownership.md` for the durable
+  decision and rationale
+- `docs/worker-plugin-api.md` for worker plugin authoring details
+- `docs/plugin-sync-provider-api.md` for sync provider plugin authoring details
+
+This document is a reference for how plugins fit into the system. It is not a
+proposal for a broad new UI plugin platform.
+
+## Product Role of Plugins
+
+Plugins are optional extensions for niche workflows.
+
+Core product behavior should remain complete for task/project users without any
+plugin dependency.
+
+Plugins may provide:
+
+- alternative automation policies beyond core defaults
+- niche routine or habit-oriented workflows
+- domain-specific enrichment and reporting
+- external system integration
+
+Plugins should not redefine baseline task behavior through hidden conventions.
+
+## Current Plugin Host Surfaces
+
+Current implemented plugin host surfaces are daemon-loaded plugins.
+
+### Worker plugins
+
+Worker plugins add automation capabilities while remaining outside the core
+baseline domain model.
+
+See `docs/worker-plugin-api.md` for the author-facing contract.
+
+### Sync provider plugins
+
+Sync provider plugins integrate todu with external systems.
+
+See `docs/plugin-sync-provider-api.md` for the author-facing contract.
+
+### Future plugin surfaces
+
+Additional plugin surfaces may be introduced later, but they require separate
+explicit design.
+
+This document does not define a general CLI or Electron UI plugin platform.
+
+## Data Ownership Model
+
+### Core entities own core user data
+
+Core entities should contain the data needed for baseline task/project
+workflows.
+
+### Plugin internals stay outside synced core entities
+
+Do not store plugin internal state in Automerge core entities.
+
+Reasons:
+
+- installations without the plugin should not receive plugin-specific internals
+- synced core data should remain understandable without plugin-specific
+  interpretation
+- plugin removal should not leave opaque internal blobs behind in normal core
+  models
+
+### Plugin-owned local storage
+
+Plugin internal state should live in plugin-managed local storage.
+
+That storage is the right place for plugin-specific caches, indexes, metrics,
+state machines, and other internal bookkeeping.
+
+### Association with core entities
+
+When a plugin needs to relate local plugin state to a core entity, use foreign
+keys such as:
+
+- `catalogId`
+- `entityType`
+- `entityId`
+
+This preserves clean boundaries while still allowing plugins to attach meaning
+and behavior to normal core entities.
+
+### Promote outputs, not internals
+
+If a plugin produces user-visible outcomes, write those outcomes to normal core
+entities where appropriate.
+
+Examples include:
+
+- tasks created as a visible result of plugin behavior
+- notes or records that users should see in baseline product surfaces
+
+Keep plugin-owned internal metadata local.
+
+## Lifecycle Expectations
+
+Plugin lifecycle should be explicit and observable.
+
+Expected operations include:
+
+- install
+- enable
+- disable
+- remove
+
+For automation-oriented plugins:
+
+- worker assignment controls where automation runs
+- a single authority machine is a supported operating model
+- daemon status/logs should make plugin state visible
+
+Plugin failures should be isolated from baseline task workflows.
+
+## Compatibility and Safety Expectations
+
+Plugin contracts must be:
+
+- explicit
+- versioned
+- validated at load/install time
+
+Incompatible plugins should fail closed with clear errors.
+
+Plugins should not run in a partially compatible state.
+
+Plugin documentation should clearly describe:
+
+- required domains
+- configuration requirements
+- operational behavior
+- any assumptions about daemon placement or assignment
+
+## Core Boundaries Plugins Must Respect
+
+Plugins must not force the following into core as a default architecture:
+
+- generic key/value expansion on core entities solely for plugin internals
+- hidden conventions that redefine baseline recurring semantics
+- plugin-only behavior that baseline task users must install to get a complete
+  task workflow
+
+For the recurring redesign specifically, this means the current core direction
+remains focused on a minimal recurring `missPolicy`, while richer habit-style
+presentation and streak/metrics-heavy behavior remain outside current core
+scope.
+
+## Operational Notes
+
+Recurring automation already runs through worker/plugin execution in the
+current daemon-first architecture.
+
+That means plugin behavior should continue to align with the daemon/worker
+operational model documented in `docs/ARCHITECTURE.md`.
+
+## Related Documents
+
+- `docs/adr/0001-plugin-boundaries-and-data-ownership.md`
+- `docs/ARCHITECTURE.md`
+- `docs/worker-plugin-api.md`
+- `docs/plugin-sync-provider-api.md`
+- `docs/plans/recurring-task-habit-redesign-candidate.md`

--- a/docs/plans/recurring-task-habit-redesign-candidate.md
+++ b/docs/plans/recurring-task-habit-redesign-candidate.md
@@ -1,0 +1,150 @@
+# Recurring Task / Habit Redesign Candidate
+
+> Updated direction: permanent, minimal, task-first design.
+
+## Purpose
+
+Define a long-term direction for recurring work that keeps the core product minimal for task-focused users, while allowing niche extensions through plugins.
+
+## Long-Term Product Stance (Decision)
+
+1. **Core product is task-first.**
+   - Users who only care about tasks/projects should get a complete experience without plugins.
+2. **Plugins are permanent extension points for niche needs.**
+   - Plugins are not a staging area for future core features.
+3. **Core should stay minimal and explicit.**
+   - Avoid adding broad schema/features that primarily serve plugin-specific behavior.
+
+## Current State (Relevant)
+
+- Recurring templates exist in core and include project association.
+- Recurring processing currently performs catch-up generation (stacking behavior).
+- Habit exists as a separate core domain today.
+- Recurring automation runs via worker plugin execution.
+
+## Core Direction to Pursue
+
+## 1) Add minimal recurring miss policy in core
+
+Add one core behavior field to recurring templates:
+
+```ts
+type MissPolicy = "accumulate" | "rollForward";
+```
+
+Recommended template shape change:
+
+```ts
+interface RecurringTemplate {
+  // existing fields...
+  missPolicy?: MissPolicy; // default: "accumulate"
+}
+```
+
+Why this belongs in core:
+- It is mainstream recurring-task behavior, not niche.
+- It removes ambiguity for users and clients.
+- It keeps behavior explicit and testable.
+
+## 2) Keep default behavior unchanged for existing users
+
+- Default should remain `accumulate` to preserve current expectations.
+- `rollForward` is opt-in per template.
+
+## 3) Roll-forward semantics (core)
+
+For `missPolicy=rollForward`:
+
+1. Determine the latest scheduled occurrence due as of "today" (template timezone).
+2. Ensure only one current actionable occurrence is represented.
+3. Missed prior dates do not create debt/backlog tasks.
+4. Completion marks the current occurrence only.
+
+This supports workflows like "process finances daily" where users should not do multiple missed runs tomorrow.
+
+## 4) Maintain deterministic and safe multi-device behavior
+
+- Preserve deterministic generation expectations and idempotency guarantees.
+- Ensure processing remains safe when run from a designated authority daemon.
+
+## Core Scope to Avoid (for this redesign)
+
+Do **not** expand core with these right now:
+
+- recurring `uiMode` fields for habit presentation
+- recurring streak subsystem as a first-class core feature
+- recurring metrics schema in core
+- broad plugin metadata blobs in primary core entities
+
+Rationale: these add model/UI surface area beyond the minimal task-first objective.
+
+## Habit Strategy Under Task-First Direction
+
+- Do not expand Habit as a major core investment in this redesign.
+- Keep current habit functionality stable for compatibility.
+- Treat richer habit-style workflows (streak-heavy, metric-heavy, custom UX) as plugin territory unless they become clearly mainstream task requirements.
+
+## Plugin Policy (Permanent Extension Model)
+
+Plugins remain the home for niche extensions, but the durable plugin policy now
+lives in:
+
+- `docs/adr/0001-plugin-boundaries-and-data-ownership.md`
+- `docs/architecture/plugins.md`
+
+Summary of the current direction:
+
+- plugin features must remain optional for baseline task workflows
+- plugin internals must not live in Automerge core entities
+- plugin-owned internal state should live in local plugin-managed storage
+- plugin outputs may be promoted into normal core entities when user-visible
+- plugin contracts must be explicit, versioned, and fail closed when incompatible
+- plugin failures must not break baseline task workflows
+- plugins should not force generic metadata bags or hidden semantic changes into core
+
+## Explicit Pursue / Do Not Pursue
+
+## Pursue
+
+- Minimal core recurring policy: `missPolicy` (`accumulate`/`rollForward`)
+- Backward-compatible defaults (`accumulate`)
+- Clear processing semantics and tests for both policies
+- Keep worker/plugin automation model for operational flexibility
+
+## Do Not Pursue (now)
+
+- Plugin-first-as-experiment strategy for core product decisions
+- Core recurring UI/habit presentation mode fields
+- Core recurring streak/metrics feature expansion
+- Broad UI plugin platform work as part of this redesign
+- Plugin data bags on core entities as default architecture
+
+## Migration Notes (High-Level)
+
+1. Add `missPolicy` to recurring templates with default `accumulate`.
+2. Keep existing templates behavior unchanged unless explicitly updated.
+3. Add CLI/Electron controls for selecting `rollForward` on recurring templates.
+4. Add focused tests for:
+   - accumulate catch-up behavior
+   - roll-forward no-backlog behavior
+   - cross-device/idempotent processing expectations
+
+## Open Implementation Questions
+
+1. Exact roll-forward representation strategy (update existing open occurrence vs rematerialize latest safely).
+2. Interaction with manual generation commands under roll-forward.
+3. Deletion/skip semantics under roll-forward (how user intent is preserved).
+4. Boundary between core recurring behavior and plugin-owned niche behavior in docs/help text.
+
+## Success Criteria
+
+- Task-only users can model common recurring work with no plugin dependency.
+- `rollForward` solves non-stacking recurring workflows cleanly.
+- Core remains minimal and understandable.
+- Plugins remain clearly optional extensions, not a shadow core.
+
+## Decision Status
+
+- **Status:** Candidate direction updated for task-first minimalism
+- **Decision:** Pending final approval
+- **Next step:** create implementation plan focused only on core `missPolicy` + processing semantics


### PR DESCRIPTION
## Summary

Add the documentation from task 2156 without the unrelated hook/package changes that were on the previous branch version.

## Task

#2156

## Changes

- add ADR for plugin boundaries and data ownership
- add plugin architecture guidance and link it from `docs/ARCHITECTURE.md`
- add the recurring task / habit redesign candidate doc
- keep this PR docs-only; no `.husky`, `package.json`, or lockfile changes

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [x] `./scripts/pre-pr.sh` passes

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
