### PR TITLE
feat: add recurring missPolicy CLI support

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -169,6 +169,53 @@ Retry policy:
 - A successful cycle resets retry attempt state.
 - Changes require daemon restart to apply.
 
+## Recurring miss policy via CLI
+
+Recurring templates support two miss policies:
+
+- `accumulate` — default behavior; missed occurrences still stack up and can be materialized as backlog tasks
+- `rollForward` — only the latest due occurrence is represented; older missed dates do not create backlog debt
+
+Create a recurring template with the default policy:
+
+```bash
+toduai recurring create \
+  --title "Pay rent" \
+  --schedule "FREQ=MONTHLY;BYMONTHDAY=1" \
+  --project Home \
+  --timezone America/Chicago \
+  --start-date 2026-01-01
+```
+
+Create a recurring template that rolls forward instead of accumulating backlog:
+
+```bash
+toduai recurring create \
+  --title "Water plants" \
+  --schedule "FREQ=WEEKLY" \
+  --project Home \
+  --timezone America/Chicago \
+  --start-date 2026-01-01 \
+  --miss-policy rollForward
+```
+
+Update an existing template to change the policy:
+
+```bash
+toduai recurring update <template-id> --miss-policy accumulate
+toduai recurring update <template-id> --miss-policy rollForward
+```
+
+Inspect the current policy in text or JSON output:
+
+```bash
+toduai recurring show <template-id>
+toduai recurring list
+toduai --format json recurring show <template-id>
+```
+
+Text output includes a `Miss Policy` field/column. JSON output includes `missPolicy`, and older templates without a stored field are displayed as `accumulate` for backward compatibility.
+
 ## Validate connectivity
 
 ```bash

--- a/packages/cli/src/commands/recurring.test.ts
+++ b/packages/cli/src/commands/recurring.test.ts
@@ -48,42 +48,51 @@ describe("recurring CLI commands", { timeout: 30000 }, () => {
   }
 
   it("recurring create → list → show → upcoming → generate → pause → resume → delete flow", () => {
-    // Create a project
     const projectJson = run('project create --name "RecurringTest" --format json');
     const project = JSON.parse(projectJson) as { id: string };
 
-    // Create a recurring template
     const createOutput = run(
-      'recurring create --title "Daily standup" --schedule "FREQ=DAILY" --project RecurringTest --timezone UTC --start-date 2026-02-01 --priority high --format json',
+      'recurring create --title "Daily standup" --schedule "FREQ=DAILY" --project RecurringTest --timezone UTC --start-date 2026-02-01 --priority high --miss-policy rollForward --format json',
     );
-    const created = JSON.parse(createOutput);
+    const created = JSON.parse(createOutput) as {
+      id: string;
+      title: string;
+      schedule: string;
+      priority: string;
+      paused: boolean;
+      missPolicy: string;
+    };
     expect(created.id).toMatch(/^rec-/);
     expect(created.title).toBe("Daily standup");
     expect(created.schedule).toBe("FREQ=DAILY");
     expect(created.priority).toBe("high");
     expect(created.paused).toBe(false);
+    expect(created.missPolicy).toBe("rollForward");
 
-    // List
     const listOutput = run("recurring list");
     expect(listOutput).toContain("Daily standup");
     expect(listOutput).toContain("Daily");
+    expect(listOutput).toContain("Miss Policy");
+    expect(listOutput).toContain("rollForward");
 
-    // List JSON
-    const listJson = JSON.parse(run("recurring list --format json"));
+    const listJson = JSON.parse(run("recurring list --format json")) as Array<{
+      id: string;
+      title: string;
+      missPolicy: string;
+    }>;
     expect(listJson).toHaveLength(1);
     expect(listJson[0].title).toBe("Daily standup");
+    expect(listJson[0].missPolicy).toBe("rollForward");
 
-    // Show
     const showOutput = run(`recurring show ${created.id}`);
     expect(showOutput).toContain("Daily standup");
     expect(showOutput).toContain("FREQ=DAILY");
     expect(showOutput).toContain("UTC");
+    expect(showOutput).toContain("Miss Policy: rollForward");
 
-    // Upcoming
     const upcomingOutput = run("recurring upcoming --days 7");
     expect(upcomingOutput).toContain("Daily standup");
 
-    // Early materialization
     const genOutput = run(`recurring generate ${created.id} 2026-03-15 --format json`);
     const genTask = JSON.parse(genOutput);
     expect(genTask.id).toMatch(/^sched-/);
@@ -91,7 +100,6 @@ describe("recurring CLI commands", { timeout: 30000 }, () => {
     expect(genTask.scheduledDate).toBe("2026-03-15");
     expect(genTask.templateId).toBe(created.id);
 
-    // Verify task appears in task list for the target project
     const taskList = JSON.parse(run(`task list --project "${project.id}" --format json`));
     const scheduledTask = taskList.find(
       (t: { scheduledDate?: string; title: string }) =>
@@ -99,30 +107,66 @@ describe("recurring CLI commands", { timeout: 30000 }, () => {
     );
     expect(scheduledTask).toBeDefined();
 
-    // Update
-    run(`recurring update ${created.id} --title "Morning sync" --priority medium`);
-    const updated = JSON.parse(run(`recurring show ${created.id} --format json`));
+    const updateOutput = run(
+      `recurring update ${created.id} --title "Morning sync" --priority medium --miss-policy accumulate`,
+    );
+    expect(updateOutput).toContain("Updated recurring template");
+    expect(updateOutput).toContain("Miss Policy: accumulate");
+    const updated = JSON.parse(run(`recurring show ${created.id} --format json`)) as {
+      title: string;
+      priority: string;
+      missPolicy: string;
+    };
     expect(updated.title).toBe("Morning sync");
     expect(updated.priority).toBe("medium");
+    expect(updated.missPolicy).toBe("accumulate");
 
-    // Pause
     run(`recurring pause ${created.id}`);
-    const paused = JSON.parse(run(`recurring show ${created.id} --format json`));
+    const paused = JSON.parse(run(`recurring show ${created.id} --format json`)) as {
+      paused: boolean;
+    };
     expect(paused.paused).toBe(true);
 
-    // List active only
     const activeOnly = JSON.parse(run("recurring list --active --format json"));
     expect(activeOnly).toHaveLength(0);
 
-    // Resume
     run(`recurring resume ${created.id}`);
-    const resumed = JSON.parse(run(`recurring show ${created.id} --format json`));
+    const resumed = JSON.parse(run(`recurring show ${created.id} --format json`)) as {
+      paused: boolean;
+      missPolicy: string;
+    };
     expect(resumed.paused).toBe(false);
+    expect(resumed.missPolicy).toBe("accumulate");
 
-    // Delete
     run(`recurring delete ${created.id}`);
     const afterDelete = JSON.parse(run("recurring list --format json"));
     expect(afterDelete).toHaveLength(0);
+  });
+
+  it("defaults recurring missPolicy to accumulate when omitted", () => {
+    run('project create --name "RecurringDefaultTest" --format json');
+
+    const createOutput = run(
+      'recurring create --title "Pay rent" --schedule "FREQ=MONTHLY;BYMONTHDAY=1" --project RecurringDefaultTest --timezone UTC --start-date 2026-02-01 --format json',
+    );
+    const created = JSON.parse(createOutput) as { id: string; missPolicy: string };
+    expect(created.missPolicy).toBe("accumulate");
+
+    const showOutput = run(`recurring show ${created.id}`);
+    expect(showOutput).toContain("Miss Policy: accumulate");
+
+    const listOutput = run("recurring list --project RecurringDefaultTest");
+    expect(listOutput).toContain("Pay rent");
+    expect(listOutput).toContain("Miss Policy");
+    expect(listOutput).toContain("accumulate");
+
+    const listJson = JSON.parse(
+      run("recurring list --project RecurringDefaultTest --format json"),
+    ) as Array<{ id: string; missPolicy: string }>;
+    expect(listJson).toHaveLength(1);
+    expect(listJson[0].missPolicy).toBe("accumulate");
+
+    run(`recurring delete ${created.id}`);
   });
 
   it("handles errors gracefully", () => {

--- a/packages/cli/src/commands/recurring.ts
+++ b/packages/cli/src/commands/recurring.ts
@@ -1,4 +1,4 @@
-import type { RecurringTemplate } from "@todu/core";
+import type { RecurringMissPolicy, RecurringTemplate } from "@todu/core";
 import { describeSchedule } from "@todu/engine";
 import type { Command } from "commander";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
@@ -10,9 +10,23 @@ const TEMPLATE_COLUMNS = [
   { key: "schedule", label: "Schedule" },
   { key: "project", label: "Project" },
   { key: "priority", label: "Priority", colorize: colorPriority },
+  { key: "missPolicy", label: "Miss Policy" },
   { key: "nextDue", label: "Next Due" },
   { key: "status", label: "Status" },
 ];
+
+function getTemplateMissPolicy(
+  template: Pick<RecurringTemplate, "missPolicy">,
+): RecurringMissPolicy {
+  return template.missPolicy ?? "accumulate";
+}
+
+function normalizeTemplateForOutput(template: RecurringTemplate): RecurringTemplate {
+  return {
+    ...template,
+    missPolicy: getTemplateMissPolicy(template),
+  };
+}
 
 function templateToRow(t: RecurringTemplate, projectName?: string): Record<string, string> {
   return {
@@ -21,6 +35,7 @@ function templateToRow(t: RecurringTemplate, projectName?: string): Record<strin
     schedule: describeSchedule(t.schedule),
     project: projectName ?? t.projectId,
     priority: t.priority,
+    missPolicy: getTemplateMissPolicy(t),
     nextDue: t.nextDue,
     status: t.paused ? "paused" : "active",
   };
@@ -35,6 +50,7 @@ function templateDetail(t: RecurringTemplate, projectName?: string): string {
     `Timezone:    ${t.timezone}`,
     `Project:     ${projectName ?? t.projectId}`,
     `Priority:    ${t.priority}`,
+    `Miss Policy: ${getTemplateMissPolicy(t)}`,
     `Status:      ${t.paused ? "paused" : "active"}`,
     `Start Date:  ${t.startDate}`,
   ];
@@ -131,6 +147,7 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
     .requiredOption("--start-date <date>", "start date (YYYY-MM-DD)")
     .option("--end-date <date>", "end date (YYYY-MM-DD)")
     .option("--priority <priority>", "priority (low, medium, high)")
+    .option("--miss-policy <policy>", "miss policy (accumulate, rollForward; default: accumulate)")
     .option("--description <text>", "template description")
     .option("--label <labels...>", "labels to apply to generated tasks")
     .action(async (opts) => {
@@ -151,6 +168,7 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
           description: opts.description,
           priority: opts.priority,
           endDate: opts.endDate,
+          missPolicy: opts.missPolicy,
           labels: opts.label,
         },
       });
@@ -161,13 +179,14 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const output = normalizeTemplateForOutput(result.value);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(result.value));
+        console.log(formatJSON(output));
       } else {
-        const projectName = await getProjectName(invokeDaemon, result.value.projectId);
-        console.log(`Created recurring template: ${result.value.id}`);
-        console.log(templateDetail(result.value, projectName));
+        const projectName = await getProjectName(invokeDaemon, output.projectId);
+        console.log(`Created recurring template: ${output.id}`);
+        console.log(templateDetail(output, projectName));
       }
     });
 
@@ -201,9 +220,10 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const templates = result.value.map(normalizeTemplateForOutput);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(result.value));
+        console.log(formatJSON(templates));
         return;
       }
 
@@ -215,7 +235,7 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         }
       }
 
-      const rows = result.value.map((t) => templateToRow(t, projectNames[t.projectId]));
+      const rows = templates.map((t) => templateToRow(t, projectNames[t.projectId]));
       console.log(formatTable(rows, TEMPLATE_COLUMNS));
     });
 
@@ -230,14 +250,15 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const output = normalizeTemplateForOutput(resolved.value);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(resolved.value));
+        console.log(formatJSON(output));
         return;
       }
 
-      const projectName = await getProjectName(invokeDaemon, resolved.value.projectId);
-      console.log(templateDetail(resolved.value, projectName));
+      const projectName = await getProjectName(invokeDaemon, output.projectId);
+      console.log(templateDetail(output, projectName));
     });
 
   recurring
@@ -247,6 +268,7 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
     .option("--schedule <rrule>", "update RRULE")
     .option("--timezone <tz>", "update timezone")
     .option("--priority <priority>", "update priority")
+    .option("--miss-policy <policy>", "update miss policy (accumulate, rollForward)")
     .option("--description <text>", "update description")
     .option("--end-date <date>", "update end date")
     .option("--label <labels...>", "replace labels")
@@ -264,6 +286,7 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
       if (opts.schedule) input.schedule = opts.schedule;
       if (opts.timezone) input.timezone = opts.timezone;
       if (opts.priority) input.priority = opts.priority;
+      if (opts.missPolicy) input.missPolicy = opts.missPolicy;
       if (opts.description) input.description = opts.description;
       if (opts.endDate) input.endDate = opts.endDate;
       if (opts.label) input.labels = opts.label;
@@ -287,11 +310,14 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const output = normalizeTemplateForOutput(result.value);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(result.value));
+        console.log(formatJSON(output));
       } else {
-        console.log(`Updated recurring template: ${result.value.id}`);
+        const projectName = await getProjectName(invokeDaemon, output.projectId);
+        console.log(`Updated recurring template: ${output.id}`);
+        console.log(templateDetail(output, projectName));
       }
     });
 
@@ -341,9 +367,10 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const output = normalizeTemplateForOutput(result.value);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(result.value));
+        console.log(formatJSON(output));
       } else {
         console.log(`Paused recurring template: ${resolved.value.id}`);
       }
@@ -369,9 +396,10 @@ export function registerRecurringCommands(program: Command, invokeDaemon: CliDae
         return;
       }
 
+      const output = normalizeTemplateForOutput(result.value);
       const format = program.opts().format;
       if (format === "json") {
-        console.log(formatJSON(result.value));
+        console.log(formatJSON(output));
       } else {
         console.log(`Resumed recurring template: ${resolved.value.id}`);
       }


### PR DESCRIPTION
## Summary

Add CLI support for recurring template `missPolicy` so users can choose, update, and inspect `accumulate` vs `rollForward` behavior.

## Task

- Task: #2165

## Changes

- add `--miss-policy` to `recurring create` and `recurring update`
- show `missPolicy` in recurring list/show output and normalize legacy missing values to `accumulate` in CLI output
- add CLI regression coverage for explicit and default missPolicy behavior
- document recurring missPolicy CLI usage in `docs/cli-daemon-usage.md`

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/cli/src/commands/recurring.test.ts`
- `make check`
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
