### PR TITLE
feat: add recurring missPolicy Electron UI

### DIFF
--- a/docs/electron-recurring-templates.md
+++ b/docs/electron-recurring-templates.md
@@ -1,0 +1,35 @@
+# Electron recurring templates: miss policy
+
+Recurring templates in the Electron app let you choose how missed occurrences behave.
+
+## Where to set it
+
+### Create flow
+
+When creating a recurring template, use the **Miss Policy** field in the new-template dialog.
+
+### Edit flow
+
+When viewing an existing recurring template, use the **Miss Policy** control in the detail view to change the behavior later.
+
+## Options
+
+- `accumulate` — missed occurrences stack and catch up
+- `rollForward` — only the latest due occurrence stays actionable
+
+## Default behavior
+
+The default is `accumulate`.
+
+If you do not change the setting, the template stays on the backlog-catching-up behavior that existing recurring templates already use.
+
+Older templates without a stored `missPolicy` value are shown in the Electron UI as `accumulate` for backward compatibility.
+
+## Where it is displayed
+
+The current miss policy is shown in:
+
+- the recurring template list
+- the recurring template detail view
+
+Use `rollForward` when you want one current actionable occurrence instead of a stack of missed backlog tasks.

--- a/packages/electron/src/renderer/lib/recurring-miss-policy.ts
+++ b/packages/electron/src/renderer/lib/recurring-miss-policy.ts
@@ -1,0 +1,39 @@
+import type { RecurringMissPolicy } from "@todu/core/browser";
+
+export const RECURRING_MISS_POLICY_OPTIONS: Array<{
+  value: RecurringMissPolicy;
+  label: string;
+}> = [
+  {
+    value: "accumulate",
+    label: "accumulate — missed occurrences stack and catch up",
+  },
+  {
+    value: "rollForward",
+    label: "rollForward — only the latest due occurrence stays actionable",
+  },
+];
+
+const RECURRING_MISS_POLICY_EXPLANATIONS: Record<RecurringMissPolicy, string> = {
+  accumulate: "Missed occurrences stack and catch up.",
+  rollForward: "Only the latest due occurrence stays actionable.",
+};
+
+const RECURRING_MISS_POLICY_SHORT_LABELS: Record<RecurringMissPolicy, string> = {
+  accumulate: "stacks missed occurrences",
+  rollForward: "latest due only",
+};
+
+export function getRecurringMissPolicy(value: {
+  missPolicy?: RecurringMissPolicy;
+}): RecurringMissPolicy {
+  return value.missPolicy ?? "accumulate";
+}
+
+export function getRecurringMissPolicyExplanation(policy: RecurringMissPolicy): string {
+  return RECURRING_MISS_POLICY_EXPLANATIONS[policy];
+}
+
+export function getRecurringMissPolicyShortLabel(policy: RecurringMissPolicy): string {
+  return RECURRING_MISS_POLICY_SHORT_LABELS[policy];
+}

--- a/packages/electron/src/renderer/views/CreateRecurringDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateRecurringDialog.tsx
@@ -1,7 +1,11 @@
-import { createProjectId } from "@todu/core/browser";
+import type { ProjectId, RecurringMissPolicy } from "@todu/core/browser";
 import { type ReactNode, useState } from "react";
 import { SchedulePresetPicker } from "../components/SchedulePresetPicker.js";
 import { useCreateRecurring, useProjects } from "../hooks/useTodu.js";
+import {
+  getRecurringMissPolicyExplanation,
+  RECURRING_MISS_POLICY_OPTIONS,
+} from "../lib/recurring-miss-policy.js";
 
 export function CreateRecurringDialog({ onClose }: { onClose: () => void }): ReactNode {
   const { data: projects } = useProjects();
@@ -11,6 +15,7 @@ export function CreateRecurringDialog({ onClose }: { onClose: () => void }): Rea
   const [schedule, setSchedule] = useState("FREQ=DAILY");
   const [projectId, setProjectId] = useState("");
   const [priority, setPriority] = useState("medium");
+  const [missPolicy, setMissPolicy] = useState<RecurringMissPolicy>("accumulate");
   const [description, setDescription] = useState("");
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
   const [endDate, setEndDate] = useState("");
@@ -37,10 +42,11 @@ export function CreateRecurringDialog({ onClose }: { onClose: () => void }): Rea
       {
         title: title.trim(),
         schedule,
-        projectId: createProjectId(effectiveProjectId),
+        projectId: effectiveProjectId as ProjectId,
         timezone,
         startDate,
         priority: priority as "high" | "medium" | "low",
+        missPolicy,
         description: description.trim() || undefined,
         endDate: endDate || undefined,
       },
@@ -106,6 +112,25 @@ export function CreateRecurringDialog({ onClose }: { onClose: () => void }): Rea
               </option>
             ))}
           </select>
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="rec-miss-policy">
+            Miss Policy
+          </label>
+          <select
+            id="rec-miss-policy"
+            className="input"
+            value={missPolicy}
+            onChange={(e) => setMissPolicy(e.target.value as RecurringMissPolicy)}
+          >
+            {RECURRING_MISS_POLICY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <div className="detail-meta-label">{getRecurringMissPolicyExplanation(missPolicy)}</div>
         </div>
 
         <div className="form-row">

--- a/packages/electron/src/renderer/views/RecurringDetail.tsx
+++ b/packages/electron/src/renderer/views/RecurringDetail.tsx
@@ -1,4 +1,4 @@
-import { createProjectId, type RecurringId } from "@todu/core/browser";
+import type { ProjectId, RecurringId, RecurringMissPolicy } from "@todu/core/browser";
 import { type ReactNode, useEffect, useState } from "react";
 import { CommentThread } from "../components/CommentThread.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
@@ -17,6 +17,11 @@ import {
   useUpdateRecurring,
 } from "../hooks/useTodu.js";
 import { describeSchedule } from "../lib/describe-schedule.js";
+import {
+  getRecurringMissPolicy,
+  getRecurringMissPolicyExplanation,
+  RECURRING_MISS_POLICY_OPTIONS,
+} from "../lib/recurring-miss-policy.js";
 
 // ============================================================================
 // Upcoming Occurrences
@@ -162,6 +167,8 @@ export function RecurringDetail({
       </div>
     );
   }
+
+  const missPolicy = getRecurringMissPolicy(template);
 
   const handleTitleSave = () => {
     setEditingTitle(false);
@@ -316,7 +323,7 @@ export function RecurringDetail({
             onChange={(e) =>
               updateRecurring.mutate({
                 id: template.id as RecurringId,
-                input: { projectId: createProjectId(e.target.value) },
+                input: { projectId: e.target.value as ProjectId },
               })
             }
           >
@@ -326,6 +333,27 @@ export function RecurringDetail({
               </option>
             ))}
           </select>
+        </div>
+        <div className="detail-meta-cell">
+          <span className="detail-meta-label">Miss Policy</span>
+          <select
+            aria-label="Miss Policy"
+            className="filter-select inline-select"
+            value={missPolicy}
+            onChange={(e) =>
+              updateRecurring.mutate({
+                id: template.id as RecurringId,
+                input: { missPolicy: e.target.value as RecurringMissPolicy },
+              })
+            }
+          >
+            {RECURRING_MISS_POLICY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <span className="detail-meta-label">{getRecurringMissPolicyExplanation(missPolicy)}</span>
         </div>
       </div>
 

--- a/packages/electron/src/renderer/views/RecurringList.tsx
+++ b/packages/electron/src/renderer/views/RecurringList.tsx
@@ -3,6 +3,11 @@ import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { PriorityChip } from "../components/PriorityChip.js";
 import { useProjects, useRecurringList } from "../hooks/useTodu.js";
 import { describeSchedule } from "../lib/describe-schedule.js";
+import {
+  getRecurringMissPolicy,
+  getRecurringMissPolicyExplanation,
+  getRecurringMissPolicyShortLabel,
+} from "../lib/recurring-miss-policy.js";
 
 export function RecurringList({
   onSelectTemplate,
@@ -125,34 +130,47 @@ export function RecurringList({
               <th>Schedule</th>
               <th>Project</th>
               <th>Priority</th>
+              <th>Miss Policy</th>
               <th>Next Due</th>
               <th>Status</th>
             </tr>
           </thead>
           <tbody>
-            {templates.map((t) => (
-              <tr
-                key={t.id}
-                className="clickable-row"
-                onClick={() => onSelectTemplate(t.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") onSelectTemplate(t.id);
-                }}
-              >
-                <td className="cell-name">{t.title}</td>
-                <td className="cell-schedule">{describeSchedule(t.schedule)}</td>
-                <td className="cell-project">{projectMap.get(t.projectId) ?? "—"}</td>
-                <td>
-                  <PriorityChip priority={t.priority} />
-                </td>
-                <td className="cell-date">{t.nextDue?.slice(0, 10) ?? "—"}</td>
-                <td>
-                  <span className={`chip ${t.paused ? "status-paused" : "status-active"}`}>
-                    {t.paused ? "paused" : "active"}
-                  </span>
-                </td>
-              </tr>
-            ))}
+            {templates.map((t) => {
+              const missPolicy = getRecurringMissPolicy(t);
+              return (
+                <tr
+                  key={t.id}
+                  className="clickable-row"
+                  onClick={() => onSelectTemplate(t.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") onSelectTemplate(t.id);
+                  }}
+                >
+                  <td className="cell-name">{t.title}</td>
+                  <td className="cell-schedule">{describeSchedule(t.schedule)}</td>
+                  <td className="cell-project">{projectMap.get(t.projectId) ?? "—"}</td>
+                  <td>
+                    <PriorityChip priority={t.priority} />
+                  </td>
+                  <td aria-label={`Miss Policy ${missPolicy}`}>
+                    <div>{missPolicy}</div>
+                    <div
+                      className="detail-meta-label"
+                      title={getRecurringMissPolicyExplanation(missPolicy)}
+                    >
+                      {getRecurringMissPolicyShortLabel(missPolicy)}
+                    </div>
+                  </td>
+                  <td className="cell-date">{t.nextDue?.slice(0, 10) ?? "—"}</td>
+                  <td>
+                    <span className={`chip ${t.paused ? "status-paused" : "status-active"}`}>
+                      {t.paused ? "paused" : "active"}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx
+++ b/packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { RecurringTemplate } from "@todu/core/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as hooks from "../hooks/useTodu.js";
+import { CreateRecurringDialog } from "./CreateRecurringDialog.js";
+import { RecurringDetail } from "./RecurringDetail.js";
+import { RecurringList } from "./RecurringList.js";
+
+vi.mock("../hooks/useTodu.js", () => ({
+  useProjects: vi.fn(),
+  useCreateRecurring: vi.fn(),
+  useRecurringDetail: vi.fn(),
+  useUpdateRecurring: vi.fn(),
+  useDeleteRecurring: vi.fn(),
+  usePauseRecurring: vi.fn(),
+  useResumeRecurring: vi.fn(),
+  useUpcoming: vi.fn(),
+  useGenerateOccurrence: vi.fn(),
+  useRecurringList: vi.fn(),
+}));
+
+vi.mock("../components/SchedulePresetPicker.js", () => ({
+  SchedulePresetPicker: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <input aria-label="Schedule preset" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock("../components/PriorityChip.js", () => ({
+  PriorityChip: ({ priority }: { priority: string }) => <span>{priority}</span>,
+}));
+
+vi.mock("../components/CommentThread.js", () => ({
+  CommentThread: () => <div>Comments</div>,
+}));
+
+vi.mock("../components/ConfirmDialog.js", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("../components/MarkdownEditor.js", () => ({
+  MarkdownEditor: () => <div>Markdown Editor</div>,
+}));
+
+vi.mock("../components/TabBar.js", () => ({
+  TabBar: () => <div>Tab Bar</div>,
+}));
+
+function makeTemplate(overrides: Partial<RecurringTemplate> = {}): RecurringTemplate {
+  return {
+    id: "rec-1" as RecurringTemplate["id"],
+    title: "Water plants",
+    projectId: "proj-1" as RecurringTemplate["projectId"],
+    labels: [],
+    priority: "medium",
+    schedule: "FREQ=WEEKLY",
+    timezone: "UTC",
+    startDate: "2026-03-01",
+    endDate: undefined,
+    nextDue: "2026-03-08",
+    skippedDates: [],
+    paused: false,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const createRecurringMutate = vi.fn();
+const updateRecurringMutate = vi.fn();
+const deleteRecurringMutate = vi.fn();
+const pauseRecurringMutate = vi.fn();
+const resumeRecurringMutate = vi.fn();
+const generateOccurrenceMutate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  Object.defineProperty(window, "todu", {
+    configurable: true,
+    value: {
+      agent: {
+        focusEntity: vi.fn().mockResolvedValue(undefined),
+        clearFocusedEntity: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+  });
+
+  vi.mocked(hooks.useProjects).mockReturnValue({
+    data: [{ id: "proj-1", name: "Home" }],
+  } as ReturnType<typeof hooks.useProjects>);
+
+  vi.mocked(hooks.useCreateRecurring).mockReturnValue({
+    mutate: createRecurringMutate,
+    isPending: false,
+  } as ReturnType<typeof hooks.useCreateRecurring>);
+
+  vi.mocked(hooks.useRecurringDetail).mockReturnValue({
+    data: makeTemplate(),
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof hooks.useRecurringDetail>);
+
+  vi.mocked(hooks.useUpdateRecurring).mockReturnValue({
+    mutate: updateRecurringMutate,
+  } as ReturnType<typeof hooks.useUpdateRecurring>);
+
+  vi.mocked(hooks.useDeleteRecurring).mockReturnValue({
+    mutate: deleteRecurringMutate,
+  } as ReturnType<typeof hooks.useDeleteRecurring>);
+
+  vi.mocked(hooks.usePauseRecurring).mockReturnValue({
+    mutate: pauseRecurringMutate,
+  } as ReturnType<typeof hooks.usePauseRecurring>);
+
+  vi.mocked(hooks.useResumeRecurring).mockReturnValue({
+    mutate: resumeRecurringMutate,
+  } as ReturnType<typeof hooks.useResumeRecurring>);
+
+  vi.mocked(hooks.useUpcoming).mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as ReturnType<typeof hooks.useUpcoming>);
+
+  vi.mocked(hooks.useGenerateOccurrence).mockReturnValue({
+    mutate: generateOccurrenceMutate,
+    isPending: false,
+  } as ReturnType<typeof hooks.useGenerateOccurrence>);
+
+  vi.mocked(hooks.useRecurringList).mockReturnValue({
+    data: [makeTemplate()],
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof hooks.useRecurringList>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreateRecurringDialog missPolicy", () => {
+  it("submits rollForward when selected in the create flow", () => {
+    render(<CreateRecurringDialog onClose={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Title *"), {
+      target: { value: "Water plants" },
+    });
+    fireEvent.change(screen.getByLabelText("Miss Policy"), {
+      target: { value: "rollForward" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Template" }));
+
+    expect(createRecurringMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Water plants",
+        missPolicy: "rollForward",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("defaults the create flow to accumulate", () => {
+    render(<CreateRecurringDialog onClose={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Title *"), {
+      target: { value: "Pay rent" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Template" }));
+
+    expect(screen.getByText("Missed occurrences stack and catch up.")).toBeDefined();
+    expect(createRecurringMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Pay rent",
+        missPolicy: "accumulate",
+      }),
+      expect.any(Object),
+    );
+  });
+});
+
+describe("RecurringDetail missPolicy", () => {
+  it("shows accumulate for legacy templates without a stored missPolicy and updates edits", () => {
+    vi.mocked(hooks.useRecurringDetail).mockReturnValue({
+      data: makeTemplate({ missPolicy: undefined }),
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof hooks.useRecurringDetail>);
+
+    render(<RecurringDetail templateId="rec-1" onBack={() => {}} />);
+
+    const select = screen.getByLabelText("Miss Policy") as HTMLSelectElement;
+    expect(select.value).toBe("accumulate");
+    expect(screen.getByText("Missed occurrences stack and catch up.")).toBeDefined();
+
+    fireEvent.change(select, { target: { value: "rollForward" } });
+
+    expect(updateRecurringMutate).toHaveBeenCalledWith({
+      id: "rec-1",
+      input: { missPolicy: "rollForward" },
+    });
+  });
+});
+
+describe("RecurringList missPolicy", () => {
+  it("shows current missPolicy in the list and defaults legacy values to accumulate", () => {
+    vi.mocked(hooks.useRecurringList).mockReturnValue({
+      data: [
+        makeTemplate({ id: "rec-1" as RecurringTemplate["id"], title: "Water plants" }),
+        makeTemplate({
+          id: "rec-2" as RecurringTemplate["id"],
+          title: "Weekly review",
+          missPolicy: "rollForward",
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof hooks.useRecurringList>);
+
+    render(
+      <RecurringList
+        onSelectTemplate={() => {}}
+        onCreateTemplate={() => {}}
+        externalFilter={null}
+      />,
+    );
+
+    expect(screen.getByText("Miss Policy")).toBeDefined();
+    expect(screen.getByLabelText("Miss Policy accumulate")).toBeDefined();
+    expect(screen.getByLabelText("Miss Policy rollForward")).toBeDefined();
+    expect(screen.getByText("stacks missed occurrences")).toBeDefined();
+    expect(screen.getByText("latest due only")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add Electron UI support for recurring template `missPolicy` so users can choose, edit, and inspect `accumulate` vs `rollForward` behavior in recurring template views.

## Task

- Task: #2166

## Changes

- add recurring miss policy selection to the Electron create-template dialog
- add recurring miss policy editing and explanation text to the recurring detail view
- show recurring miss policy in the recurring template list with legacy default display as `accumulate`
- add renderer tests covering create, edit, display, and default behavior
- add Electron UI documentation for recurring miss policy selection and meaning

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx`
- `make check`
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
