### PR TITLE
fix: remove playful text from version output

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ const program = new Command();
 program
   .name("toduai")
   .description("Local-first task management")
-  .version(`${VERSION} (now with extra checkbox energy)`)
+  .version(VERSION)
   .option("--format <type>", "output format (text or json)", "text")
   .option("--config <path>", "path to config file")
   .option("--no-color", "disable color output")

--- a/packages/cli/src/version-command.test.ts
+++ b/packages/cli/src/version-command.test.ts
@@ -11,14 +11,13 @@ describe("CLI version output", { timeout: 30000 }, () => {
     execSync("npm run build", { cwd: rootDir, stdio: "pipe" });
   });
 
-  it("keeps the version token and adds the playful suffix", () => {
+  it("prints only the version token", () => {
     const output = execSync(`node ${cliPath} --version`, {
       cwd: rootDir,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
 
-    expect(output.startsWith(VERSION)).toBe(true);
-    expect(output).toContain("(now with extra checkbox energy)");
+    expect(output).toBe(VERSION);
   });
 });


### PR DESCRIPTION
## Summary

Restore plain `todu --version` output so the CLI prints only the version string.

## Task

- Task: #2065

## Changes

- remove the playful suffix from the CLI version output
- update the CLI version test to assert the output is exactly the version token

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/cli/src/version-command.test.ts`
- `make check`
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] No unrelated changes included
- [x] No doc change needed for this scoped CLI output fix
