### PR TITLE
fix: remove recurring template comments UI

### DIFF
--- a/packages/electron/src/renderer/views/RecurringDetail.tsx
+++ b/packages/electron/src/renderer/views/RecurringDetail.tsx
@@ -1,6 +1,5 @@
 import type { ProjectId, RecurringId, RecurringMissPolicy } from "@todu/core/browser";
 import { type ReactNode, useEffect, useState } from "react";
-import { CommentThread } from "../components/CommentThread.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { MarkdownEditor } from "../components/MarkdownEditor.js";
 import { PriorityChip } from "../components/PriorityChip.js";
@@ -107,7 +106,6 @@ function SkipList({ dates }: { dates: string[] }): ReactNode {
 const TABS = [
   { id: "description", label: "Description" },
   { id: "upcoming", label: "Upcoming" },
-  { id: "comments", label: "Comments" },
 ];
 
 // ============================================================================
@@ -433,12 +431,6 @@ export function RecurringDetail({
               <h3 className="section-title">Skipped Dates</h3>
               <SkipList dates={template.skippedDates ?? []} />
             </div>
-          </div>
-        )}
-
-        {activeTab === "comments" && (
-          <div className="detail-tab-content">
-            <CommentThread entityType="recurring" entityId={templateId} />
           </div>
         )}
       </div>

--- a/packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx
+++ b/packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx
@@ -51,7 +51,13 @@ vi.mock("../components/MarkdownEditor.js", () => ({
 }));
 
 vi.mock("../components/TabBar.js", () => ({
-  TabBar: () => <div>Tab Bar</div>,
+  TabBar: ({ tabs }: { tabs: Array<{ id: string; label: string }> }) => (
+    <div>
+      {tabs.map((tab) => (
+        <span key={tab.id}>{tab.label}</span>
+      ))}
+    </div>
+  ),
 }));
 
 function makeTemplate(overrides: Partial<RecurringTemplate> = {}): RecurringTemplate {
@@ -209,6 +215,14 @@ describe("RecurringDetail missPolicy", () => {
       id: "rec-1",
       input: { missPolicy: "rollForward" },
     });
+  });
+
+  it("keeps recurring detail focused on description and upcoming tabs only", () => {
+    render(<RecurringDetail templateId="rec-1" onBack={() => {}} />);
+
+    expect(screen.getByText("Description")).toBeDefined();
+    expect(screen.getByText("Upcoming")).toBeDefined();
+    expect(screen.queryByText("Comments")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Remove recurring template comments from the Electron detail view so recurring templates remain configuration-only and align with the existing notes model.

## Task

- Task: #2097

## Changes

- remove the recurring comments tab and comment thread from the Electron recurring detail view
- keep recurring description editing intact
- add renderer coverage that verifies recurring detail only exposes description and upcoming tabs

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/electron/src/renderer/views/RecurringMissPolicy.test.tsx`
- `make check`
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] No unrelated changes included
- [x] No doc change needed for this UI/model alignment fix
