### PR TITLE
docs: record resolved integration open questions

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -280,6 +280,12 @@ As a result:
 - comment sync is always included
 - there is no separate comment-sync capability flag in v1
 
+## Open Questions
+
+None remaining in the current architecture decision set.
+
+The original design questions for this document were resolved during task #2186 and are now captured as locked decisions in the sections above.
+
 ## Adoption and cutover
 
 No legacy data migration is required for this architecture.


### PR DESCRIPTION
## Summary

Add an explicit `Open Questions` section to the integration architecture doc so the documented deliverables for task #2186 are fully explicit for close-gate review.

## Task

- #2186

## Changes

- Added an `Open Questions` section to `docs/architecture/integrations.md`.
- Recorded that no open questions remain in the current architecture decision set.
- Clarified that the original design questions from task #2186 were resolved in the document.

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
