### PR TITLE
feat: add integration binding core schema

### DIFF
--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   createEmptyCatalog,
+  createIntegrationBindingStatusDocument,
+  createIntegrationRegistryDocument,
   createNotesDocument,
   createTaskDetailDocument,
   createTaskListDocument,
   SCHEMA_VERSION,
 } from "./schema.js";
-import { createProjectId } from "./types.js";
+import { createIntegrationBindingId, createProjectId } from "./types.js";
 
 describe("schema", () => {
   it("exports schema version", () => {
@@ -44,6 +46,11 @@ describe("schema", () => {
       expect(catalog.noteBucketByNoteId).toEqual({});
     });
 
+    it("creates a catalog with empty integrationStatusDocIds", () => {
+      const catalog = createEmptyCatalog();
+      expect(catalog.integrationStatusDocIds).toEqual({});
+    });
+
     it("creates a catalog with settings", () => {
       const catalog = createEmptyCatalog();
       expect(catalog.settings.schemaVersion).toBe(SCHEMA_VERSION);
@@ -72,6 +79,27 @@ describe("schema", () => {
     it("creates an empty notes document", () => {
       const doc = createNotesDocument();
       expect(doc.notes).toEqual([]);
+    });
+  });
+
+  describe("createIntegrationRegistryDocument", () => {
+    it("creates an empty integration registry document", () => {
+      const doc = createIntegrationRegistryDocument();
+      expect(doc.bindings).toEqual([]);
+    });
+  });
+
+  describe("createIntegrationBindingStatusDocument", () => {
+    it("creates a default idle status document", () => {
+      const bindingId = createIntegrationBindingId("ibind-123");
+      const doc = createIntegrationBindingStatusDocument(bindingId, "2026-03-08T00:00:00Z");
+      expect(doc.bindingId).toBe(bindingId);
+      expect(doc.state).toBe("idle");
+      expect(doc.authorityId).toBeNull();
+      expect(doc.lastSuccessfulSyncAt).toBeNull();
+      expect(doc.lastAttemptedSyncAt).toBeNull();
+      expect(doc.lastErrorSummary).toBeNull();
+      expect(doc.updatedAt).toBe("2026-03-08T00:00:00Z");
     });
   });
 });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -2,6 +2,9 @@ import type {
   Habit,
   HabitEntry,
   HabitId,
+  IntegrationBinding,
+  IntegrationBindingId,
+  IntegrationBindingStatus,
   Label,
   Note,
   Project,
@@ -47,6 +50,12 @@ export interface CatalogDocument {
 
   /** Recurring task templates */
   recurringTemplates: RecurringTemplate[];
+
+  /** Automerge document ID for the shared integration binding registry */
+  integrationRegistryDocId?: string;
+
+  /** Map of integrationBindingId → Automerge document ID for that binding's status doc */
+  integrationStatusDocIds: Record<string, string>;
 
   /** Habit definitions */
   habits: Habit[];
@@ -103,6 +112,24 @@ export interface NotesDocument {
 }
 
 /**
+ * Integration registry document (one per dataset).
+ * Stores all shared integration bindings.
+ */
+export interface IntegrationRegistryDocument {
+  /** Shared integration bindings for this dataset */
+  bindings: IntegrationBinding[];
+}
+
+/**
+ * Integration binding status document (one per integration binding).
+ * Stores synced operational status separately from desired state.
+ */
+export interface IntegrationBindingStatusDocument extends IntegrationBindingStatus {
+  /** Which integration binding this status belongs to */
+  bindingId: IntegrationBindingId;
+}
+
+/**
  * Habit log document (one per habit).
  * Contains check-in entries keyed by date for deterministic multi-device merging.
  */
@@ -133,6 +160,7 @@ export function createEmptyCatalog(): CatalogDocument {
     notesBucketDocIds: {},
     noteBucketByNoteId: {},
     recurringTemplates: [],
+    integrationStatusDocIds: {},
     habits: [],
     habitLogDocIds: {},
     settings: {
@@ -159,6 +187,27 @@ export function createTaskDetailDocument(taskId: string, description: string): T
 export function createNotesDocument(): NotesDocument {
   return {
     notes: [],
+  };
+}
+
+export function createIntegrationRegistryDocument(): IntegrationRegistryDocument {
+  return {
+    bindings: [],
+  };
+}
+
+export function createIntegrationBindingStatusDocument(
+  bindingId: IntegrationBindingId,
+  updatedAt: string,
+): IntegrationBindingStatusDocument {
+  return {
+    bindingId,
+    state: "idle",
+    authorityId: null,
+    lastSuccessfulSyncAt: null,
+    lastAttemptedSyncAt: null,
+    lastErrorSummary: null,
+    updatedAt,
   };
 }
 

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
-import type { HabitId, LabelId, NoteId, ProjectId, RecurringId, TaskId } from "./types.js";
+import type {
+  HabitId,
+  IntegrationBindingId,
+  LabelId,
+  NoteId,
+  ProjectId,
+  RecurringId,
+  TaskId,
+} from "./types.js";
 import {
   createHabitId,
+  createIntegrationBindingId,
   createLabelId,
   createNoteId,
   createProjectId,
   createRecurringId,
   createTaskId,
   err,
+  isIntegrationBindingState,
   isNoteEntityType,
   isProjectStatus,
   isSyncStrategy,
@@ -50,6 +60,11 @@ describe("branded IDs", () => {
   it("creates a branded RecurringId", () => {
     const id = createRecurringId("recurring-303");
     expect(id).toBe("recurring-303" as RecurringId);
+  });
+
+  it("creates a branded IntegrationBindingId", () => {
+    const id = createIntegrationBindingId("ibind-404");
+    expect(id).toBe("ibind-404" as IntegrationBindingId);
   });
 });
 
@@ -139,6 +154,20 @@ describe("type guards", () => {
     it("rejects invalid strategies", () => {
       expect(isSyncStrategy("sync")).toBe(false);
       expect(isSyncStrategy("")).toBe(false);
+    });
+  });
+
+  describe("isIntegrationBindingState", () => {
+    it("accepts valid integration binding states", () => {
+      expect(isIntegrationBindingState("running")).toBe(true);
+      expect(isIntegrationBindingState("idle")).toBe(true);
+      expect(isIntegrationBindingState("blocked")).toBe(true);
+      expect(isIntegrationBindingState("error")).toBe(true);
+    });
+
+    it("rejects invalid integration binding states", () => {
+      expect(isIntegrationBindingState("pending")).toBe(false);
+      expect(isIntegrationBindingState("")).toBe(false);
     });
   });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,7 @@ export type LabelId = string & { readonly __brand: "LabelId" };
 export type NoteId = string & { readonly __brand: "NoteId" };
 export type HabitId = string & { readonly __brand: "HabitId" };
 export type RecurringId = string & { readonly __brand: "RecurringId" };
+export type IntegrationBindingId = string & { readonly __brand: "IntegrationBindingId" };
 
 export function createTaskId(id: string): TaskId {
   return id as TaskId;
@@ -31,6 +32,10 @@ export function createHabitId(id: string): HabitId {
 
 export function createRecurringId(id: string): RecurringId {
   return id as RecurringId;
+}
+
+export function createIntegrationBindingId(id: string): IntegrationBindingId {
+  return id as IntegrationBindingId;
 }
 
 // ============================================================================
@@ -63,6 +68,13 @@ export type SyncStrategy = (typeof SYNC_STRATEGIES)[number];
 
 export function isSyncStrategy(value: string): value is SyncStrategy {
   return (SYNC_STRATEGIES as readonly string[]).includes(value);
+}
+
+export const INTEGRATION_BINDING_STATES = ["running", "idle", "blocked", "error"] as const;
+export type IntegrationBindingState = (typeof INTEGRATION_BINDING_STATES)[number];
+
+export function isIntegrationBindingState(value: string): value is IntegrationBindingState {
+  return (INTEGRATION_BINDING_STATES as readonly string[]).includes(value);
 }
 
 // ============================================================================
@@ -138,6 +150,32 @@ export interface ProjectFilter {
 }
 
 // ============================================================================
+// Integration binding entities — shared desired state for external integrations
+// ============================================================================
+
+export interface IntegrationBinding {
+  id: IntegrationBindingId;
+  provider: string;
+  projectId: ProjectId;
+  targetKind: string;
+  targetRef: string;
+  strategy: SyncStrategy;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IntegrationBindingStatus {
+  bindingId: IntegrationBindingId;
+  state: IntegrationBindingState;
+  authorityId: string | null;
+  lastSuccessfulSyncAt: string | null;
+  lastAttemptedSyncAt: string | null;
+  lastErrorSummary: string | null;
+  updatedAt: string;
+}
+
+// ============================================================================
 // Task entity — metadata stored in TaskListDocument
 // ============================================================================
 
@@ -209,6 +247,24 @@ export interface UpdateProjectInput {
   description?: string;
   status?: ProjectStatus;
   priority?: TaskPriority;
+}
+
+export interface CreateIntegrationBindingInput {
+  provider: string;
+  projectId: ProjectId;
+  targetKind: string;
+  targetRef: string;
+  strategy?: SyncStrategy;
+  enabled?: boolean;
+}
+
+export interface UpdateIntegrationBindingInput {
+  provider?: string;
+  projectId?: ProjectId;
+  targetKind?: string;
+  targetRef?: string;
+  strategy?: SyncStrategy;
+  enabled?: boolean;
 }
 
 export interface CreateTaskInput {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -1,23 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { createProjectId } from "./types.js";
+import { createIntegrationBindingId, createProjectId } from "./types.js";
 import {
   MAX_DESCRIPTION_LENGTH,
+  MAX_INTEGRATION_FIELD_LENGTH,
   MAX_LABEL_NAME_LENGTH,
   MAX_NOTE_CONTENT_LENGTH,
   MAX_PROJECT_NAME_LENGTH,
   MAX_TASK_TITLE_LENGTH,
+  validateCreateIntegrationBindingInput,
   validateCreateLabelInput,
   validateCreateNoteInput,
   validateCreateProjectInput,
   validateCreateRecurringInput,
   validateCreateTaskInput,
   validateDescription,
+  validateIntegrationBindingField,
+  validateIntegrationBindingProjectUniqueness,
   validateISODate,
   validateLabelColor,
   validateLabelName,
   validateNoteContent,
   validateProjectName,
   validateTaskTitle,
+  validateUpdateIntegrationBindingInput,
   validateUpdateLabelInput,
   validateUpdateNoteInput,
   validateUpdateProjectInput,
@@ -141,6 +146,182 @@ describe("validateUpdateProjectInput", () => {
   it("rejects empty name", () => {
     const error = validateUpdateProjectInput({ name: "" });
     expect(error?.field).toBe("name");
+  });
+});
+
+describe("validateIntegrationBindingField", () => {
+  it("accepts a valid integration field", () => {
+    expect(validateIntegrationBindingField("provider", "github")).toBeNull();
+  });
+
+  it("rejects empty values", () => {
+    const error = validateIntegrationBindingField("targetRef", "");
+    expect(error?.field).toBe("targetRef");
+    expect(error?.message).toContain("required");
+  });
+
+  it("rejects values exceeding max length", () => {
+    const error = validateIntegrationBindingField(
+      "targetKind",
+      "a".repeat(MAX_INTEGRATION_FIELD_LENGTH + 1),
+    );
+    expect(error?.field).toBe("targetKind");
+    expect(error?.message).toContain(`${MAX_INTEGRATION_FIELD_LENGTH}`);
+  });
+});
+
+describe("validateIntegrationBindingProjectUniqueness", () => {
+  const bindingId = createIntegrationBindingId("ibind-1");
+  const otherBindingId = createIntegrationBindingId("ibind-2");
+  const projectId = createProjectId("proj-1");
+
+  const bindings = [
+    {
+      id: bindingId,
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      strategy: "bidirectional" as const,
+      enabled: true,
+      createdAt: "2026-03-08T00:00:00Z",
+      updatedAt: "2026-03-08T00:00:00Z",
+    },
+  ];
+
+  it("accepts a project without an existing binding", () => {
+    expect(
+      validateIntegrationBindingProjectUniqueness(createProjectId("proj-2"), bindings),
+    ).toBeNull();
+  });
+
+  it("rejects a second binding for the same project", () => {
+    const error = validateIntegrationBindingProjectUniqueness(projectId, bindings);
+    expect(error?.field).toBe("projectId");
+    expect(error?.message).toContain("already has an integration binding");
+  });
+
+  it("allows the current binding to keep the same project", () => {
+    expect(validateIntegrationBindingProjectUniqueness(projectId, bindings, bindingId)).toBeNull();
+  });
+
+  it("rejects a different binding using the same project", () => {
+    const error = validateIntegrationBindingProjectUniqueness(projectId, bindings, otherBindingId);
+    expect(error?.field).toBe("projectId");
+  });
+});
+
+describe("validateCreateIntegrationBindingInput", () => {
+  const projectId = createProjectId("proj-test");
+
+  it("accepts valid input", () => {
+    expect(
+      validateCreateIntegrationBindingInput({
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+        strategy: "bidirectional",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects invalid strategy", () => {
+    const error = validateCreateIntegrationBindingInput({
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      strategy: "sync" as "pull",
+    });
+    expect(error?.field).toBe("strategy");
+  });
+
+  it("rejects a duplicate project binding", () => {
+    const error = validateCreateIntegrationBindingInput(
+      {
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+      },
+      [
+        {
+          id: createIntegrationBindingId("ibind-existing"),
+          provider: "forgejo",
+          projectId,
+          targetKind: "repository",
+          targetRef: "owner/other",
+          strategy: "pull",
+          enabled: true,
+          createdAt: "2026-03-08T00:00:00Z",
+          updatedAt: "2026-03-08T00:00:00Z",
+        },
+      ],
+    );
+    expect(error?.field).toBe("projectId");
+  });
+});
+
+describe("validateUpdateIntegrationBindingInput", () => {
+  const bindingId = createIntegrationBindingId("ibind-existing");
+  const projectId = createProjectId("proj-1");
+  const otherProjectId = createProjectId("proj-2");
+
+  const bindings = [
+    {
+      id: bindingId,
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      strategy: "bidirectional" as const,
+      enabled: true,
+      createdAt: "2026-03-08T00:00:00Z",
+      updatedAt: "2026-03-08T00:00:00Z",
+    },
+    {
+      id: createIntegrationBindingId("ibind-other"),
+      provider: "forgejo",
+      projectId: otherProjectId,
+      targetKind: "repository",
+      targetRef: "owner/forgejo",
+      strategy: "pull" as const,
+      enabled: true,
+      createdAt: "2026-03-08T00:00:00Z",
+      updatedAt: "2026-03-08T00:00:00Z",
+    },
+  ];
+
+  it("accepts a valid partial update", () => {
+    expect(validateUpdateIntegrationBindingInput({ targetRef: "owner/new-repo" })).toBeNull();
+  });
+
+  it("rejects empty updates", () => {
+    const error = validateUpdateIntegrationBindingInput({});
+    expect(error?.field).toBe("input");
+  });
+
+  it("rejects invalid strategy", () => {
+    const error = validateUpdateIntegrationBindingInput({ strategy: "sync" as "push" });
+    expect(error?.field).toBe("strategy");
+  });
+
+  it("rejects moving to a project that already has a binding", () => {
+    const error = validateUpdateIntegrationBindingInput(
+      { projectId: otherProjectId },
+      { bindings, currentBindingId: bindingId },
+    );
+    expect(error?.field).toBe("projectId");
+  });
+
+  it("allows keeping the current project", () => {
+    expect(
+      validateUpdateIntegrationBindingInput(
+        { projectId },
+        { bindings, currentBindingId: bindingId },
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,13 +1,17 @@
 import { validateDateString, validateRRule, validateTimezone } from "./schedule.js";
 import type {
   CreateHabitInput,
+  CreateIntegrationBindingInput,
   CreateLabelInput,
   CreateNoteInput,
   CreateProjectInput,
   CreateRecurringInput,
   CreateTaskInput,
+  IntegrationBinding,
+  IntegrationBindingId,
   TaskStatus,
   UpdateHabitInput,
+  UpdateIntegrationBindingInput,
   UpdateLabelInput,
   UpdateNoteInput,
   UpdateProjectInput,
@@ -18,6 +22,7 @@ import type {
 import {
   isNoteEntityType,
   isProjectStatus,
+  isSyncStrategy,
   isTaskPriority,
   isTaskStatus,
   isValidStatusTransition,
@@ -34,6 +39,7 @@ export const MAX_TASK_TITLE_LENGTH = 200;
 export const MAX_DESCRIPTION_LENGTH = 2000;
 export const MAX_LABEL_NAME_LENGTH = 50;
 export const MAX_NOTE_CONTENT_LENGTH = 5000;
+export const MAX_INTEGRATION_FIELD_LENGTH = 255;
 export const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
 // ============================================================================
@@ -60,6 +66,40 @@ export function validateDescription(description: string): ValidationError | null
       `Description must be ${MAX_DESCRIPTION_LENGTH} characters or less`,
     );
   }
+  return null;
+}
+
+export function validateIntegrationBindingField(
+  field: "provider" | "targetKind" | "targetRef",
+  value: string,
+): ValidationError | null {
+  if (!value || value.trim().length === 0) {
+    return validationError(field, `${field} is required`);
+  }
+
+  if (value.trim().length > MAX_INTEGRATION_FIELD_LENGTH) {
+    return validationError(
+      field,
+      `${field} must be ${MAX_INTEGRATION_FIELD_LENGTH} characters or less`,
+    );
+  }
+
+  return null;
+}
+
+export function validateIntegrationBindingProjectUniqueness(
+  projectId: string,
+  bindings: IntegrationBinding[],
+  currentBindingId?: IntegrationBindingId,
+): ValidationError | null {
+  const hasConflict = bindings.some(
+    (binding) => binding.projectId === projectId && binding.id !== currentBindingId,
+  );
+
+  if (hasConflict) {
+    return validationError("projectId", `Project already has an integration binding: ${projectId}`);
+  }
+
   return null;
 }
 
@@ -110,6 +150,76 @@ export function validateUpdateProjectInput(input: UpdateProjectInput): Validatio
 
   if (input.priority !== undefined && !isTaskPriority(input.priority)) {
     return validationError("priority", `Invalid priority: ${input.priority}`);
+  }
+
+  return null;
+}
+
+export function validateCreateIntegrationBindingInput(
+  input: CreateIntegrationBindingInput,
+  bindings: IntegrationBinding[] = [],
+): ValidationError | null {
+  const providerError = validateIntegrationBindingField("provider", input.provider);
+  if (providerError) return providerError;
+
+  const targetKindError = validateIntegrationBindingField("targetKind", input.targetKind);
+  if (targetKindError) return targetKindError;
+
+  const targetRefError = validateIntegrationBindingField("targetRef", input.targetRef);
+  if (targetRefError) return targetRefError;
+
+  if (input.strategy !== undefined && !isSyncStrategy(input.strategy)) {
+    return validationError("strategy", `Invalid sync strategy: ${input.strategy}`);
+  }
+
+  return validateIntegrationBindingProjectUniqueness(input.projectId, bindings);
+}
+
+export interface ValidateUpdateIntegrationBindingOptions {
+  bindings?: IntegrationBinding[];
+  currentBindingId?: IntegrationBindingId;
+}
+
+export function validateUpdateIntegrationBindingInput(
+  input: UpdateIntegrationBindingInput,
+  options: ValidateUpdateIntegrationBindingOptions = {},
+): ValidationError | null {
+  if (
+    input.provider === undefined &&
+    input.projectId === undefined &&
+    input.targetKind === undefined &&
+    input.targetRef === undefined &&
+    input.strategy === undefined &&
+    input.enabled === undefined
+  ) {
+    return validationError("input", "At least one field must be provided");
+  }
+
+  if (input.provider !== undefined) {
+    const providerError = validateIntegrationBindingField("provider", input.provider);
+    if (providerError) return providerError;
+  }
+
+  if (input.targetKind !== undefined) {
+    const targetKindError = validateIntegrationBindingField("targetKind", input.targetKind);
+    if (targetKindError) return targetKindError;
+  }
+
+  if (input.targetRef !== undefined) {
+    const targetRefError = validateIntegrationBindingField("targetRef", input.targetRef);
+    if (targetRefError) return targetRefError;
+  }
+
+  if (input.strategy !== undefined && !isSyncStrategy(input.strategy)) {
+    return validationError("strategy", `Invalid sync strategy: ${input.strategy}`);
+  }
+
+  if (input.projectId !== undefined) {
+    return validateIntegrationBindingProjectUniqueness(
+      input.projectId,
+      options.bindings ?? [],
+      options.currentBindingId,
+    );
   }
 
   return null;

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -8,6 +8,26 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
 
+async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const handle = await repo.find<CatalogDocument>(catalogId);
+    await handle.whenReady();
+    const doc = handle.doc();
+    if (!doc) {
+      throw new Error("catalog document not available");
+    }
+    return JSON.parse(JSON.stringify(doc)) as CatalogDocument;
+  } finally {
+    await repo.shutdown();
+  }
+}
+
 describe("createTodu", () => {
   let tmpDir: string;
   let todu: Todu | null = null;
@@ -133,7 +153,8 @@ describe("createTodu", () => {
     handle.change((doc) => {
       doc.version = 1;
       doc.projects = [];
-      // Deliberately missing: labels, taskListDocIds, settings
+      // Deliberately missing: labels, taskListDocIds, notes bucket fields,
+      // integration status doc IDs, recurring templates, habits, and settings.
     });
     const markerPath = path.join(tmpDir, "todu-catalog.id");
     fs.writeFileSync(markerPath, handle.documentId, "utf-8");
@@ -156,5 +177,18 @@ describe("createTodu", () => {
 
     const notes = await todu.note.list();
     expect(notes.ok).toBe(true);
+
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const migratedCatalog = await readCatalogDocument(tmpDir);
+    expect(migratedCatalog.taskListDocIds).toEqual({});
+    expect(migratedCatalog.notesBucketDocIds).toEqual({});
+    expect(migratedCatalog.noteBucketByNoteId).toEqual({});
+    expect(migratedCatalog.integrationStatusDocIds).toEqual({});
+    expect(migratedCatalog.recurringTemplates).toEqual([]);
+    expect(migratedCatalog.habits).toEqual([]);
+    expect(migratedCatalog.settings.schemaVersion).toBe(1);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -138,8 +138,10 @@ export async function createTodu(
       ...Object.values(catalogDoc.taskListDocIds ?? {}),
       ...Object.values(catalogDoc.habitLogDocIds ?? {}),
       ...Object.values(catalogDoc.notesBucketDocIds ?? {}),
+      ...Object.values(catalogDoc.integrationStatusDocIds ?? {}),
     ];
     if (catalogDoc.notesDocId) docIds.push(catalogDoc.notesDocId);
+    if (catalogDoc.integrationRegistryDocId) docIds.push(catalogDoc.integrationRegistryDocId);
     if (docIds.length > 0) {
       const settled = await Promise.allSettled(
         docIds.map((id) =>

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -367,6 +367,7 @@ function createBootstrapCatalog(repo: Repo, markerPath: string): DocHandle<Catal
     doc.taskListDocIds = empty.taskListDocIds;
     doc.notesBucketDocIds = empty.notesBucketDocIds;
     doc.noteBucketByNoteId = empty.noteBucketByNoteId;
+    doc.integrationStatusDocIds = empty.integrationStatusDocIds;
     doc.settings = empty.settings;
   });
 
@@ -397,6 +398,8 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
   if (doc.notesBucketDocIds === undefined || doc.notesBucketDocIds === null) needsMigration = true;
   if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null)
     needsMigration = true;
+  if (doc.integrationStatusDocIds === undefined || doc.integrationStatusDocIds === null)
+    needsMigration = true;
   if (doc.settings === undefined || doc.settings === null) needsMigration = true;
   if (doc.version === undefined || doc.version === null) needsMigration = true;
 
@@ -415,6 +418,8 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
       d.notesBucketDocIds = defaults.notesBucketDocIds;
     if (d.noteBucketByNoteId === undefined || d.noteBucketByNoteId === null)
       d.noteBucketByNoteId = defaults.noteBucketByNoteId;
+    if (d.integrationStatusDocIds === undefined || d.integrationStatusDocIds === null)
+      d.integrationStatusDocIds = defaults.integrationStatusDocIds;
     if (d.settings === undefined || d.settings === null) d.settings = defaults.settings;
     if (d.version === undefined || d.version === null) d.version = SCHEMA_VERSION;
   });


### PR DESCRIPTION
## Summary

Add the core integration binding types, validation, and catalog graph references for Phase 10 external integrations.

## Task

- #2187

## Changes

- Added core integration binding and integration binding status types.
- Added validation for integration binding fields and zero-or-one binding per project.
- Added schema support for a shared integration registry document and per-integration-binding status documents.
- Updated storage bootstrap/migration and engine prefetch logic for the new catalog graph references.
- Added tests covering schema creation, validation, and catalog migration behavior.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/core/src/types.test.ts packages/core/src/schema.test.ts packages/core/src/validation.test.ts packages/engine/src/index.test.ts`
- `make check`
- `make pre-pr`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
