### PR TITLE
feat: add engine integration binding APIs

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -267,6 +267,20 @@ export interface UpdateIntegrationBindingInput {
   enabled?: boolean;
 }
 
+export interface IntegrationBindingFilter {
+  provider?: string;
+  projectId?: ProjectId;
+  enabled?: boolean;
+}
+
+export interface UpdateIntegrationBindingStatusInput {
+  state?: IntegrationBindingState;
+  authorityId?: string | null;
+  lastSuccessfulSyncAt?: string | null;
+  lastAttemptedSyncAt?: string | null;
+  lastErrorSummary?: string | null;
+}
+
 export interface CreateTaskInput {
   title: string;
   projectId: ProjectId;

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -23,6 +23,7 @@ import {
   validateProjectName,
   validateTaskTitle,
   validateUpdateIntegrationBindingInput,
+  validateUpdateIntegrationBindingStatusInput,
   validateUpdateLabelInput,
   validateUpdateNoteInput,
   validateUpdateProjectInput,
@@ -322,6 +323,47 @@ describe("validateUpdateIntegrationBindingInput", () => {
         { bindings, currentBindingId: bindingId },
       ),
     ).toBeNull();
+  });
+});
+
+describe("validateUpdateIntegrationBindingStatusInput", () => {
+  it("accepts a valid status update", () => {
+    expect(
+      validateUpdateIntegrationBindingStatusInput({
+        state: "running",
+        authorityId: "authority-daemon-1",
+        lastAttemptedSyncAt: "2026-03-08T10:00:00Z",
+        lastSuccessfulSyncAt: "2026-03-08T10:01:00Z",
+        lastErrorSummary: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects an empty update", () => {
+    const error = validateUpdateIntegrationBindingStatusInput({});
+    expect(error?.field).toBe("input");
+  });
+
+  it("rejects an invalid state", () => {
+    const error = validateUpdateIntegrationBindingStatusInput({ state: "pending" as "idle" });
+    expect(error?.field).toBe("state");
+  });
+
+  it("rejects an invalid timestamp", () => {
+    const error = validateUpdateIntegrationBindingStatusInput({
+      lastAttemptedSyncAt: "not-a-date",
+    });
+    expect(error?.field).toBe("lastAttemptedSyncAt");
+  });
+
+  it("rejects blank authority IDs", () => {
+    const error = validateUpdateIntegrationBindingStatusInput({ authorityId: "   " });
+    expect(error?.field).toBe("authorityId");
+  });
+
+  it("rejects blank error summaries", () => {
+    const error = validateUpdateIntegrationBindingStatusInput({ lastErrorSummary: "   " });
+    expect(error?.field).toBe("lastErrorSummary");
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -12,6 +12,7 @@ import type {
   TaskStatus,
   UpdateHabitInput,
   UpdateIntegrationBindingInput,
+  UpdateIntegrationBindingStatusInput,
   UpdateLabelInput,
   UpdateNoteInput,
   UpdateProjectInput,
@@ -20,6 +21,7 @@ import type {
   ValidationError,
 } from "./types.js";
 import {
+  isIntegrationBindingState,
   isNoteEntityType,
   isProjectStatus,
   isSyncStrategy,
@@ -220,6 +222,61 @@ export function validateUpdateIntegrationBindingInput(
       options.bindings ?? [],
       options.currentBindingId,
     );
+  }
+
+  return null;
+}
+
+export function validateUpdateIntegrationBindingStatusInput(
+  input: UpdateIntegrationBindingStatusInput,
+): ValidationError | null {
+  if (
+    input.state === undefined &&
+    input.authorityId === undefined &&
+    input.lastSuccessfulSyncAt === undefined &&
+    input.lastAttemptedSyncAt === undefined &&
+    input.lastErrorSummary === undefined
+  ) {
+    return validationError("input", "At least one field must be provided");
+  }
+
+  if (input.state !== undefined && !isIntegrationBindingState(input.state)) {
+    return validationError("state", `Invalid integration binding state: ${input.state}`);
+  }
+
+  if (input.authorityId !== undefined && input.authorityId !== null) {
+    const authorityIdError = validateIntegrationBindingField("provider", input.authorityId);
+    if (authorityIdError) {
+      return {
+        ...authorityIdError,
+        field: "authorityId",
+        message: authorityIdError.message.replace("provider", "authorityId"),
+      };
+    }
+  }
+
+  if (input.lastSuccessfulSyncAt !== undefined && input.lastSuccessfulSyncAt !== null) {
+    const timestampError = validateISODate("lastSuccessfulSyncAt", input.lastSuccessfulSyncAt);
+    if (timestampError) return timestampError;
+  }
+
+  if (input.lastAttemptedSyncAt !== undefined && input.lastAttemptedSyncAt !== null) {
+    const timestampError = validateISODate("lastAttemptedSyncAt", input.lastAttemptedSyncAt);
+    if (timestampError) return timestampError;
+  }
+
+  if (input.lastErrorSummary !== undefined && input.lastErrorSummary !== null) {
+    if (input.lastErrorSummary.trim().length === 0) {
+      return validationError("lastErrorSummary", "lastErrorSummary is required");
+    }
+    const summaryError = validateDescription(input.lastErrorSummary);
+    if (summaryError) {
+      return {
+        ...summaryError,
+        field: "lastErrorSummary",
+        message: summaryError.message.replace("Description", "lastErrorSummary"),
+      };
+    }
   }
 
   return null;

--- a/packages/engine/src/index.test.ts
+++ b/packages/engine/src/index.test.ts
@@ -58,6 +58,7 @@ describe("createTodu", () => {
     expect(todu.project).toBeDefined();
     expect(todu.task).toBeDefined();
     expect(todu.label).toBeDefined();
+    expect(todu.integration).toBeDefined();
     expect(todu.note).toBeDefined();
     expect(todu.recurring).toBeDefined();
     expect(todu.habit).toBeDefined();

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,6 +9,7 @@ import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 import { observeAllChanges } from "./change-observer.js";
 import { createHabitNamespace } from "./habits.js";
+import { createIntegrationNamespace } from "./integrations.js";
 import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
@@ -49,6 +50,7 @@ export { addRemoteSyncAdapter, isSyncServerAvailable } from "./sync-client.js";
 export { DEFAULT_SYNC_PORT } from "./sync-server.js";
 export type {
   HabitNamespace,
+  IntegrationNamespace,
   LabelNamespace,
   LocalSyncMode,
   NoteNamespace,
@@ -274,6 +276,7 @@ export async function createTodu(
     project: createProjectNamespace(storage.catalog),
     task: createTaskNamespace(storage.catalog, storage.repo),
     label: createLabelNamespace(storage.catalog, storage.repo),
+    integration: createIntegrationNamespace(storage.catalog, storage.repo),
     note: createNoteNamespace(storage.catalog, storage.repo),
     recurring: createRecurringNamespace(storage.catalog, storage.repo),
     habit: createHabitNamespace(storage.catalog, storage.repo),

--- a/packages/engine/src/integrations.test.ts
+++ b/packages/engine/src/integrations.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IntegrationBindingId, ProjectId } from "@todu/core";
+import { createIntegrationBindingId } from "@todu/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTodu } from "./index.js";
+import type { Todu } from "./todu.js";
+
+describe("integration namespace", () => {
+  let tmpDir: string;
+  let todu: Todu;
+  let projectId: ProjectId;
+  let otherProjectId: ProjectId;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-integrations-"));
+    todu = await createTodu({ storagePath: tmpDir });
+
+    const project = await todu.project.create({ name: "Synced Project" });
+    if (!project.ok) throw new Error("Failed to create project");
+    projectId = project.value.id;
+
+    const otherProject = await todu.project.create({ name: "Other Project" });
+    if (!otherProject.ok) throw new Error("Failed to create second project");
+    otherProjectId = otherProject.value.id;
+  });
+
+  afterEach(async () => {
+    await todu.close();
+    await new Promise((r) => setTimeout(r, 50));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createBinding() {
+    return todu.integration.create({
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+    });
+  }
+
+  describe("CRUD", () => {
+    it("creates a binding with defaults and an initial status document", async () => {
+      const result = await createBinding();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.id).toMatch(/^ibind-/);
+      expect(result.value.provider).toBe("github");
+      expect(result.value.projectId).toBe(projectId);
+      expect(result.value.targetKind).toBe("repository");
+      expect(result.value.targetRef).toBe("owner/repo");
+      expect(result.value.strategy).toBe("bidirectional");
+      expect(result.value.enabled).toBe(true);
+
+      const status = await todu.integration.getStatus(result.value.id);
+      expect(status.ok).toBe(true);
+      if (!status.ok) return;
+
+      expect(status.value.bindingId).toBe(result.value.id);
+      expect(status.value.state).toBe("idle");
+      expect(status.value.authorityId).toBeNull();
+      expect(status.value.lastAttemptedSyncAt).toBeNull();
+      expect(status.value.lastSuccessfulSyncAt).toBeNull();
+      expect(status.value.lastErrorSummary).toBeNull();
+    });
+
+    it("lists bindings and supports provider, project, and enabled filters", async () => {
+      const bindingA = await createBinding();
+      const bindingB = await todu.integration.create({
+        provider: "forgejo",
+        projectId: otherProjectId,
+        targetKind: "repository",
+        targetRef: "owner/other",
+        enabled: false,
+      });
+      if (!bindingA.ok || !bindingB.ok) throw new Error("Failed to create bindings");
+
+      const all = await todu.integration.list();
+      expect(all.ok).toBe(true);
+      if (!all.ok) return;
+      expect(all.value).toHaveLength(2);
+
+      const byProvider = await todu.integration.list({ provider: "github" });
+      expect(byProvider.ok).toBe(true);
+      if (!byProvider.ok) return;
+      expect(byProvider.value).toHaveLength(1);
+      expect(byProvider.value[0].id).toBe(bindingA.value.id);
+
+      const byProject = await todu.integration.list({ projectId: otherProjectId });
+      expect(byProject.ok).toBe(true);
+      if (!byProject.ok) return;
+      expect(byProject.value).toHaveLength(1);
+      expect(byProject.value[0].id).toBe(bindingB.value.id);
+
+      const disabled = await todu.integration.list({ enabled: false });
+      expect(disabled.ok).toBe(true);
+      if (!disabled.ok) return;
+      expect(disabled.value).toHaveLength(1);
+      expect(disabled.value[0].id).toBe(bindingB.value.id);
+    });
+
+    it("gets, updates, and deletes a binding", async () => {
+      const created = await createBinding();
+      if (!created.ok) throw new Error("Failed to create binding");
+
+      const fetched = await todu.integration.get(created.value.id);
+      expect(fetched.ok).toBe(true);
+      if (!fetched.ok) return;
+      expect(fetched.value.targetRef).toBe("owner/repo");
+
+      const updated = await todu.integration.update(created.value.id, {
+        provider: "forgejo",
+        projectId: otherProjectId,
+        targetKind: "project",
+        targetRef: "team/repo",
+        strategy: "pull",
+        enabled: false,
+      });
+      expect(updated.ok).toBe(true);
+      if (!updated.ok) return;
+
+      expect(updated.value.provider).toBe("forgejo");
+      expect(updated.value.projectId).toBe(otherProjectId);
+      expect(updated.value.targetKind).toBe("project");
+      expect(updated.value.targetRef).toBe("team/repo");
+      expect(updated.value.strategy).toBe("pull");
+      expect(updated.value.enabled).toBe(false);
+      expect(updated.value.updatedAt).not.toBe(created.value.updatedAt);
+
+      const deleted = await todu.integration.delete(created.value.id);
+      expect(deleted.ok).toBe(true);
+
+      const missing = await todu.integration.get(created.value.id);
+      expect(missing.ok).toBe(false);
+      if (missing.ok) return;
+      expect(missing.error.type).toBe("not-found");
+
+      const missingStatus = await todu.integration.getStatus(created.value.id);
+      expect(missingStatus.ok).toBe(false);
+      if (missingStatus.ok) return;
+      expect(missingStatus.error.type).toBe("not-found");
+    });
+  });
+
+  describe("status", () => {
+    it("updates binding status fields", async () => {
+      const created = await createBinding();
+      if (!created.ok) throw new Error("Failed to create binding");
+
+      const initialStatus = await todu.integration.getStatus(created.value.id);
+      if (!initialStatus.ok) throw new Error("Failed to get initial status");
+
+      const updated = await todu.integration.updateStatus(created.value.id, {
+        state: "running",
+        authorityId: "authority-daemon-1",
+        lastAttemptedSyncAt: "2026-03-08T12:00:00Z",
+        lastSuccessfulSyncAt: "2026-03-08T12:01:00Z",
+        lastErrorSummary: "Temporary warning",
+      });
+      expect(updated.ok).toBe(true);
+      if (!updated.ok) return;
+
+      expect(updated.value.state).toBe("running");
+      expect(updated.value.authorityId).toBe("authority-daemon-1");
+      expect(updated.value.lastAttemptedSyncAt).toBe("2026-03-08T12:00:00Z");
+      expect(updated.value.lastSuccessfulSyncAt).toBe("2026-03-08T12:01:00Z");
+      expect(updated.value.lastErrorSummary).toBe("Temporary warning");
+      expect(updated.value.updatedAt).not.toBe(initialStatus.value.updatedAt);
+    });
+
+    it("returns validation errors for invalid status updates", async () => {
+      const created = await createBinding();
+      if (!created.ok) throw new Error("Failed to create binding");
+
+      const invalid = await todu.integration.updateStatus(created.value.id, {
+        state: "pending" as "idle",
+      });
+      expect(invalid.ok).toBe(false);
+      if (invalid.ok) return;
+      expect(invalid.error.type).toBe("validation");
+      expect(invalid.error.field).toBe("state");
+    });
+  });
+
+  describe("uniqueness", () => {
+    it("rejects creating a second binding for the same project", async () => {
+      const first = await createBinding();
+      if (!first.ok) throw new Error("Failed to create first binding");
+
+      const second = await todu.integration.create({
+        provider: "forgejo",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/other",
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.type).toBe("validation");
+      expect(second.error.field).toBe("projectId");
+    });
+
+    it("rejects updating a binding onto a project that already has a binding", async () => {
+      const first = await createBinding();
+      const second = await todu.integration.create({
+        provider: "forgejo",
+        projectId: otherProjectId,
+        targetKind: "repository",
+        targetRef: "owner/other",
+      });
+      if (!first.ok || !second.ok) throw new Error("Failed to create bindings");
+
+      const moved = await todu.integration.update(second.value.id, { projectId });
+      expect(moved.ok).toBe(false);
+      if (moved.ok) return;
+      expect(moved.error.type).toBe("validation");
+      expect(moved.error.field).toBe("projectId");
+    });
+  });
+
+  describe("not found behavior", () => {
+    const missingBindingId = createIntegrationBindingId("ibind-missing") as IntegrationBindingId;
+
+    it("returns not-found for unknown bindings", async () => {
+      const result = await todu.integration.get(missingBindingId);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+    });
+
+    it("returns not-found for missing status records", async () => {
+      const result = await todu.integration.getStatus(missingBindingId);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+    });
+  });
+});

--- a/packages/engine/src/integrations.ts
+++ b/packages/engine/src/integrations.ts
@@ -1,0 +1,297 @@
+import crypto from "node:crypto";
+import type { DocHandle, DocumentId, Repo } from "@automerge/automerge-repo";
+import {
+  type CatalogDocument,
+  type CreateIntegrationBindingInput,
+  createIntegrationBindingId,
+  createIntegrationBindingStatusDocument,
+  createIntegrationRegistryDocument,
+  err,
+  type IntegrationBinding,
+  type IntegrationBindingFilter,
+  type IntegrationBindingId,
+  type IntegrationBindingStatus,
+  type IntegrationBindingStatusDocument,
+  type IntegrationRegistryDocument,
+  notFound,
+  ok,
+  type Result,
+  type UpdateIntegrationBindingInput,
+  type UpdateIntegrationBindingStatusInput,
+  validateCreateIntegrationBindingInput,
+  validateUpdateIntegrationBindingInput,
+  validateUpdateIntegrationBindingStatusInput,
+} from "@todu/core";
+import type { IntegrationNamespace } from "./todu.js";
+
+function cloneIntegrationBinding(binding: IntegrationBinding): IntegrationBinding {
+  return { ...binding };
+}
+
+function cloneIntegrationBindingStatus(
+  status: IntegrationBindingStatusDocument,
+): IntegrationBindingStatus {
+  return {
+    bindingId: status.bindingId,
+    state: status.state,
+    authorityId: status.authorityId,
+    lastSuccessfulSyncAt: status.lastSuccessfulSyncAt,
+    lastAttemptedSyncAt: status.lastAttemptedSyncAt,
+    lastErrorSummary: status.lastErrorSummary,
+    updatedAt: status.updatedAt,
+  };
+}
+
+export function createIntegrationNamespace(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+): IntegrationNamespace {
+  function projectExists(projectId: string): boolean {
+    const catalogDoc = catalog.doc();
+    return catalogDoc?.projects.some((project) => project.id === projectId) ?? false;
+  }
+
+  async function getRegistryHandle(): Promise<DocHandle<IntegrationRegistryDocument> | null> {
+    const docId = catalog.doc()?.integrationRegistryDocId;
+    if (!docId) return null;
+    return repo.find<IntegrationRegistryDocument>(docId as DocumentId);
+  }
+
+  async function getOrCreateRegistryHandle(): Promise<DocHandle<IntegrationRegistryDocument>> {
+    const existing = await getRegistryHandle();
+    if (existing) return existing;
+
+    const handle = repo.create<IntegrationRegistryDocument>();
+    const template = createIntegrationRegistryDocument();
+    handle.change((doc) => {
+      doc.bindings = template.bindings;
+    });
+
+    catalog.change((doc) => {
+      doc.integrationRegistryDocId = handle.documentId;
+      if (doc.integrationStatusDocIds === undefined || doc.integrationStatusDocIds === null) {
+        doc.integrationStatusDocIds = {};
+      }
+    });
+
+    return handle;
+  }
+
+  async function getStatusHandle(
+    bindingId: IntegrationBindingId,
+  ): Promise<DocHandle<IntegrationBindingStatusDocument> | null> {
+    const docId = catalog.doc()?.integrationStatusDocIds?.[bindingId];
+    if (!docId) return null;
+    return repo.find<IntegrationBindingStatusDocument>(docId as DocumentId);
+  }
+
+  async function getOrCreateStatusHandle(
+    bindingId: IntegrationBindingId,
+    updatedAt: string,
+  ): Promise<DocHandle<IntegrationBindingStatusDocument>> {
+    const existing = await getStatusHandle(bindingId);
+    if (existing) return existing;
+
+    const handle = repo.create<IntegrationBindingStatusDocument>();
+    const template = createIntegrationBindingStatusDocument(bindingId, updatedAt);
+    handle.change((doc) => {
+      doc.bindingId = template.bindingId;
+      doc.state = template.state;
+      doc.authorityId = template.authorityId;
+      doc.lastSuccessfulSyncAt = template.lastSuccessfulSyncAt;
+      doc.lastAttemptedSyncAt = template.lastAttemptedSyncAt;
+      doc.lastErrorSummary = template.lastErrorSummary;
+      doc.updatedAt = template.updatedAt;
+    });
+
+    catalog.change((doc) => {
+      if (doc.integrationStatusDocIds === undefined || doc.integrationStatusDocIds === null) {
+        doc.integrationStatusDocIds = {};
+      }
+      doc.integrationStatusDocIds[bindingId] = handle.documentId;
+    });
+
+    return handle;
+  }
+
+  async function listBindings(): Promise<IntegrationBinding[]> {
+    const registryHandle = await getRegistryHandle();
+    const registryDoc = registryHandle?.doc();
+    return registryDoc?.bindings.map(cloneIntegrationBinding) ?? [];
+  }
+
+  async function findBinding(id: IntegrationBindingId): Promise<
+    | {
+        found: true;
+        binding: IntegrationBinding;
+        index: number;
+        registryHandle: DocHandle<IntegrationRegistryDocument>;
+      }
+    | { found: false }
+  > {
+    const registryHandle = await getRegistryHandle();
+    const registryDoc = registryHandle?.doc();
+    if (!registryHandle || !registryDoc) return { found: false };
+
+    const index = registryDoc.bindings.findIndex((binding) => binding.id === id);
+    if (index === -1) return { found: false };
+
+    return {
+      found: true,
+      binding: cloneIntegrationBinding(registryDoc.bindings[index]),
+      index,
+      registryHandle,
+    };
+  }
+
+  return {
+    async create(input: CreateIntegrationBindingInput): Promise<Result<IntegrationBinding>> {
+      if (!projectExists(input.projectId)) {
+        return err(notFound("project", input.projectId));
+      }
+
+      const registryHandle = await getOrCreateRegistryHandle();
+      const existingBindings = registryHandle.doc()?.bindings.map(cloneIntegrationBinding) ?? [];
+      const validationErr = validateCreateIntegrationBindingInput(input, existingBindings);
+      if (validationErr) return err(validationErr);
+
+      const now = new Date().toISOString();
+      const bindingId = createIntegrationBindingId(`ibind-${crypto.randomUUID().slice(0, 8)}`);
+      const binding: IntegrationBinding = {
+        id: bindingId,
+        provider: input.provider.trim(),
+        projectId: input.projectId,
+        targetKind: input.targetKind.trim(),
+        targetRef: input.targetRef.trim(),
+        strategy: input.strategy ?? "bidirectional",
+        enabled: input.enabled ?? true,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await getOrCreateStatusHandle(bindingId, now);
+      registryHandle.change((doc) => {
+        doc.bindings.push(binding);
+      });
+
+      return ok(cloneIntegrationBinding(binding));
+    },
+
+    async list(filter?: IntegrationBindingFilter): Promise<Result<IntegrationBinding[]>> {
+      let bindings = await listBindings();
+
+      if (filter?.provider !== undefined) {
+        bindings = bindings.filter((binding) => binding.provider === filter.provider);
+      }
+      if (filter?.projectId !== undefined) {
+        bindings = bindings.filter((binding) => binding.projectId === filter.projectId);
+      }
+      if (filter?.enabled !== undefined) {
+        bindings = bindings.filter((binding) => binding.enabled === filter.enabled);
+      }
+
+      return ok(bindings);
+    },
+
+    async get(id: IntegrationBindingId): Promise<Result<IntegrationBinding>> {
+      const result = await findBinding(id);
+      if (!result.found) return err(notFound("integration binding", id));
+      return ok(result.binding);
+    },
+
+    async update(
+      id: IntegrationBindingId,
+      input: UpdateIntegrationBindingInput,
+    ): Promise<Result<IntegrationBinding>> {
+      const result = await findBinding(id);
+      if (!result.found) return err(notFound("integration binding", id));
+
+      if (input.projectId !== undefined && !projectExists(input.projectId)) {
+        return err(notFound("project", input.projectId));
+      }
+
+      const bindings = result.registryHandle.doc()?.bindings.map(cloneIntegrationBinding) ?? [];
+      const validationErr = validateUpdateIntegrationBindingInput(input, {
+        bindings,
+        currentBindingId: id,
+      });
+      if (validationErr) return err(validationErr);
+
+      const now = new Date().toISOString();
+      result.registryHandle.change((doc) => {
+        const binding = doc.bindings[result.index];
+        if (input.provider !== undefined) binding.provider = input.provider.trim();
+        if (input.projectId !== undefined) binding.projectId = input.projectId;
+        if (input.targetKind !== undefined) binding.targetKind = input.targetKind.trim();
+        if (input.targetRef !== undefined) binding.targetRef = input.targetRef.trim();
+        if (input.strategy !== undefined) binding.strategy = input.strategy;
+        if (input.enabled !== undefined) binding.enabled = input.enabled;
+        binding.updatedAt = now;
+      });
+
+      return ok(cloneIntegrationBinding(result.registryHandle.doc()!.bindings[result.index]));
+    },
+
+    async delete(id: IntegrationBindingId): Promise<Result<void>> {
+      const result = await findBinding(id);
+      if (!result.found) return err(notFound("integration binding", id));
+
+      result.registryHandle.change((doc) => {
+        doc.bindings.splice(result.index, 1);
+      });
+
+      catalog.change((doc) => {
+        if (!doc.integrationStatusDocIds) return;
+        delete doc.integrationStatusDocIds[id];
+      });
+
+      return ok(undefined);
+    },
+
+    async getStatus(id: IntegrationBindingId): Promise<Result<IntegrationBindingStatus>> {
+      const bindingResult = await findBinding(id);
+      if (!bindingResult.found) return err(notFound("integration binding", id));
+
+      const statusHandle = await getStatusHandle(id);
+      const statusDoc = statusHandle?.doc();
+      if (!statusHandle || !statusDoc) {
+        return err(notFound("integration binding status", id));
+      }
+
+      return ok(cloneIntegrationBindingStatus(statusDoc));
+    },
+
+    async updateStatus(
+      id: IntegrationBindingId,
+      input: UpdateIntegrationBindingStatusInput,
+    ): Promise<Result<IntegrationBindingStatus>> {
+      const bindingResult = await findBinding(id);
+      if (!bindingResult.found) return err(notFound("integration binding", id));
+
+      const validationErr = validateUpdateIntegrationBindingStatusInput(input);
+      if (validationErr) return err(validationErr);
+
+      const now = new Date().toISOString();
+      const statusHandle = await getOrCreateStatusHandle(id, now);
+      statusHandle.change((doc) => {
+        if (input.state !== undefined) doc.state = input.state;
+        if (input.authorityId !== undefined) {
+          doc.authorityId = input.authorityId === null ? null : input.authorityId.trim();
+        }
+        if (input.lastSuccessfulSyncAt !== undefined) {
+          doc.lastSuccessfulSyncAt = input.lastSuccessfulSyncAt;
+        }
+        if (input.lastAttemptedSyncAt !== undefined) {
+          doc.lastAttemptedSyncAt = input.lastAttemptedSyncAt;
+        }
+        if (input.lastErrorSummary !== undefined) {
+          doc.lastErrorSummary =
+            input.lastErrorSummary === null ? null : input.lastErrorSummary.trim();
+        }
+        doc.updatedAt = now;
+      });
+
+      return ok(cloneIntegrationBindingStatus(statusHandle.doc()!));
+    },
+  };
+}

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -1,5 +1,6 @@
 import type {
   CreateHabitInput,
+  CreateIntegrationBindingInput,
   CreateLabelInput,
   CreateNoteInput,
   CreateProjectInput,
@@ -11,6 +12,10 @@ import type {
   HabitHistoryEntry,
   HabitId,
   HabitStreak,
+  IntegrationBinding,
+  IntegrationBindingFilter,
+  IntegrationBindingId,
+  IntegrationBindingStatus,
   Label,
   LabelId,
   Note,
@@ -31,6 +36,8 @@ import type {
   TaskWithDetail,
   ToduError,
   UpdateHabitInput,
+  UpdateIntegrationBindingInput,
+  UpdateIntegrationBindingStatusInput,
   UpdateLabelInput,
   UpdateNoteInput,
   UpdateProjectInput,
@@ -108,6 +115,22 @@ export interface LabelNamespace {
   list(): Promise<Result<Label[]>>;
   update(id: LabelId, input: UpdateLabelInput): Promise<Result<Label>>;
   delete(id: LabelId): Promise<Result<void>>;
+}
+
+export interface IntegrationNamespace {
+  create(input: CreateIntegrationBindingInput): Promise<Result<IntegrationBinding>>;
+  list(filter?: IntegrationBindingFilter): Promise<Result<IntegrationBinding[]>>;
+  get(id: IntegrationBindingId): Promise<Result<IntegrationBinding>>;
+  update(
+    id: IntegrationBindingId,
+    input: UpdateIntegrationBindingInput,
+  ): Promise<Result<IntegrationBinding>>;
+  delete(id: IntegrationBindingId): Promise<Result<void>>;
+  getStatus(id: IntegrationBindingId): Promise<Result<IntegrationBindingStatus>>;
+  updateStatus(
+    id: IntegrationBindingId,
+    input: UpdateIntegrationBindingStatusInput,
+  ): Promise<Result<IntegrationBindingStatus>>;
 }
 
 export interface NoteNamespace {
@@ -200,6 +223,7 @@ export interface Todu {
   project: ProjectNamespace;
   task: TaskNamespace;
   label: LabelNamespace;
+  integration: IntegrationNamespace;
   note: NoteNamespace;
   recurring: RecurringNamespace;
   habit: HabitNamespace;
@@ -248,6 +272,15 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
       list: stub,
       update: stub,
       delete: stub,
+    },
+    integration: {
+      create: stub,
+      list: stub,
+      get: stub,
+      update: stub,
+      delete: stub,
+      getStatus: stub,
+      updateStatus: stub,
     },
     note: {
       create: stub,


### PR DESCRIPTION
## Summary

Add engine CRUD and status APIs for integration bindings so Phase 10 can build daemon and CLI surfaces on a stable binding-driven engine contract.

## Task

- #2188

## Changes

- Added an engine `integration` namespace for create/list/get/update/delete operations on shared integration bindings.
- Added engine read/update support for per-binding integration status documents.
- Added core filter and status-update input types plus validation for integration status writes.
- Enforced zero-or-one integration binding per project through engine create/update flows.
- Added targeted engine and core tests covering lifecycle, status behavior, and conflict handling.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/core/src/validation.test.ts packages/engine/src/index.test.ts packages/engine/src/integrations.test.ts`
- `make check`
- `make pre-pr`

## Docs

- No doc changes needed; this PR implements the already-approved Phase 10 engine API surface and does not change the documented architecture or invariants.

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated or intentionally not needed
- [x] No unrelated changes included
