### PR TITLE
feat: add integration daemon rpc methods

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,7 @@ Includes at least:
 
 ## Core domains
 
-Core domains (project/task/label/note/recurring/habit/sync) provide base model + CRUD/query behavior.
+Core domains (project/task/label/integration/note/recurring/habit/sync) provide base model + CRUD/query behavior.
 
 Core domains are usable even with zero workers installed.
 

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -1,17 +1,20 @@
 import {
   type CreateHabitInput,
+  type CreateIntegrationBindingInput,
   type CreateLabelInput,
   type CreateNoteInput,
   type CreateProjectInput,
   type CreateRecurringInput,
   type CreateTaskInput,
   createHabitId,
+  createIntegrationBindingId,
   createLabelId,
   createNoteId,
   createProjectId,
   createRecurringId,
   createTaskId,
   type HabitFilter,
+  type IntegrationBindingFilter,
   type NoteFilter,
   ok,
   type ProjectFilter,
@@ -21,6 +24,7 @@ import {
   type TaskSortOptions,
   type ToduError,
   type UpdateHabitInput,
+  type UpdateIntegrationBindingInput,
   type UpdateLabelInput,
   type UpdateNoteInput,
   type UpdateProjectInput,
@@ -118,6 +122,33 @@ export function createCoreNamespaceHandlers(
       delete: method(async (request, todu) => {
         const id = createLabelId(getRequiredStringParam(request, "id"));
         return todu.label.delete(id);
+      }),
+    },
+    integration: {
+      create: method(async (request, todu) => {
+        const input = getRequiredObjectParam<CreateIntegrationBindingInput>(request, "input");
+        return todu.integration.create(input);
+      }),
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<IntegrationBindingFilter>(request, "filter");
+        return todu.integration.list(filter);
+      }),
+      get: method(async (request, todu) => {
+        const id = createIntegrationBindingId(getRequiredStringParam(request, "id"));
+        return todu.integration.get(id);
+      }),
+      update: method(async (request, todu) => {
+        const id = createIntegrationBindingId(getRequiredStringParam(request, "id"));
+        const input = getRequiredObjectParam<UpdateIntegrationBindingInput>(request, "input");
+        return todu.integration.update(id, input);
+      }),
+      delete: method(async (request, todu) => {
+        const id = createIntegrationBindingId(getRequiredStringParam(request, "id"));
+        return todu.integration.delete(id);
+      }),
+      status: method(async (request, todu) => {
+        const id = createIntegrationBindingId(getRequiredStringParam(request, "id"));
+        return todu.integration.getStatus(id);
       }),
     },
     note: {

--- a/packages/daemon/src/daemon-engine-parity.test.ts
+++ b/packages/daemon/src/daemon-engine-parity.test.ts
@@ -197,6 +197,166 @@ describe("daemon vs engine parity", () => {
     expect((rpcSearch.result as unknown[]).length).toBe(engineSearch.value.length);
   });
 
+  it("matches integration CRUD and status semantics for representative flow", async () => {
+    if (!engine || !runtime) {
+      throw new Error("Expected test harness to initialize engine and daemon runtime");
+    }
+
+    const engineProject = await engine.project.create({ name: "Engine Integration Project" });
+    expect(engineProject.ok).toBe(true);
+    if (!engineProject.ok) {
+      throw new Error("Expected engine integration project create to succeed");
+    }
+
+    const rpcProject = await sendRequest(runtime.config().socketPath, {
+      id: "rpc-project-for-integration",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Daemon Integration Project",
+        },
+      },
+    });
+
+    const rpcProjectId = (rpcProject.result as { id: string }).id;
+
+    const engineCreate = await engine.integration.create({
+      provider: "github",
+      projectId: engineProject.value.id,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+    });
+    expect(engineCreate.ok).toBe(true);
+    if (!engineCreate.ok) {
+      throw new Error("Expected engine integration create to succeed");
+    }
+
+    const rpcCreate = await sendRequest(runtime.config().socketPath, {
+      id: "integration-create-parity",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "github",
+          projectId: rpcProjectId,
+          targetKind: "repository",
+          targetRef: "owner/repo",
+        },
+      },
+    });
+
+    const rpcBinding = rpcCreate.result as {
+      id: string;
+      provider: string;
+      targetKind: string;
+      targetRef: string;
+      strategy: string;
+      enabled: boolean;
+    };
+
+    expect(rpcBinding).toEqual(
+      expect.objectContaining({
+        provider: engineCreate.value.provider,
+        targetKind: engineCreate.value.targetKind,
+        targetRef: engineCreate.value.targetRef,
+        strategy: engineCreate.value.strategy,
+        enabled: engineCreate.value.enabled,
+      }),
+    );
+
+    const engineList = await engine.integration.list({ provider: "github" });
+    expect(engineList.ok).toBe(true);
+    if (!engineList.ok) {
+      throw new Error("Expected engine integration list to succeed");
+    }
+
+    const rpcList = await sendRequest(runtime.config().socketPath, {
+      id: "integration-list-parity",
+      method: "integration.list",
+      params: {
+        filter: {
+          provider: "github",
+        },
+      },
+    });
+
+    expect(Array.isArray(rpcList.result)).toBe(true);
+    expect((rpcList.result as unknown[]).length).toBe(engineList.value.length);
+
+    const engineStatus = await engine.integration.getStatus(engineCreate.value.id);
+    expect(engineStatus.ok).toBe(true);
+    if (!engineStatus.ok) {
+      throw new Error("Expected engine integration status to succeed");
+    }
+
+    const rpcStatus = await sendRequest(runtime.config().socketPath, {
+      id: "integration-status-parity",
+      method: "integration.status",
+      params: {
+        id: rpcBinding.id,
+      },
+    });
+
+    expect(rpcStatus.result).toEqual(
+      expect.objectContaining({
+        state: engineStatus.value.state,
+        authorityId: engineStatus.value.authorityId,
+        lastAttemptedSyncAt: engineStatus.value.lastAttemptedSyncAt,
+        lastSuccessfulSyncAt: engineStatus.value.lastSuccessfulSyncAt,
+        lastErrorSummary: engineStatus.value.lastErrorSummary,
+      }),
+    );
+
+    const engineUpdate = await engine.integration.update(engineCreate.value.id, {
+      targetRef: "owner/updated-repo",
+      strategy: "pull",
+      enabled: false,
+    });
+    expect(engineUpdate.ok).toBe(true);
+    if (!engineUpdate.ok) {
+      throw new Error("Expected engine integration update to succeed");
+    }
+
+    const rpcUpdate = await sendRequest(runtime.config().socketPath, {
+      id: "integration-update-parity",
+      method: "integration.update",
+      params: {
+        id: rpcBinding.id,
+        input: {
+          targetRef: "owner/updated-repo",
+          strategy: "pull",
+          enabled: false,
+        },
+      },
+    });
+
+    expect(rpcUpdate.result).toEqual(
+      expect.objectContaining({
+        targetRef: engineUpdate.value.targetRef,
+        strategy: engineUpdate.value.strategy,
+        enabled: engineUpdate.value.enabled,
+      }),
+    );
+
+    const engineDelete = await engine.integration.delete(engineCreate.value.id);
+    expect(engineDelete.ok).toBe(true);
+    if (!engineDelete.ok) {
+      throw new Error("Expected engine integration delete to succeed");
+    }
+
+    const rpcDelete = await sendRequest(runtime.config().socketPath, {
+      id: "integration-delete-parity",
+      method: "integration.delete",
+      params: {
+        id: rpcBinding.id,
+      },
+    });
+
+    expect(rpcDelete).toEqual({
+      id: "integration-delete-parity",
+      result: null,
+    });
+  });
+
   it("matches sync status semantics for representative flow", async () => {
     if (!engine || !runtime) {
       throw new Error("Expected test harness to initialize engine and daemon runtime");

--- a/packages/daemon/src/protocol-conformance.test.ts
+++ b/packages/daemon/src/protocol-conformance.test.ts
@@ -167,6 +167,74 @@ describe("daemon protocol conformance suite", () => {
     });
   });
 
+  it("routes integration methods through default runtime adapters", async () => {
+    await withRunningRuntime({}, async (runtime) => {
+      const projectResponse = await sendRequest(runtime.config().socketPath, {
+        id: "project-for-integration",
+        method: "project.create",
+        params: {
+          input: {
+            name: "Conformance Integration",
+          },
+        },
+      });
+
+      const projectId = (projectResponse.result as { id: string }).id;
+
+      const createResponse = await sendRequest(runtime.config().socketPath, {
+        id: "integration-create-conformance",
+        method: "integration.create",
+        params: {
+          input: {
+            provider: "github",
+            projectId,
+            targetKind: "repository",
+            targetRef: "owner/repo",
+          },
+        },
+      });
+
+      expect(createResponse.id).toBe("integration-create-conformance");
+      expect(createResponse.result).toMatchObject({
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+      });
+
+      const integrationId = (createResponse.result as { id: string }).id;
+
+      const listResponse = await sendRequest(runtime.config().socketPath, {
+        id: "integration-list-conformance",
+        method: "integration.list",
+        params: {
+          filter: {
+            projectId,
+          },
+        },
+      });
+
+      expect(listResponse.id).toBe("integration-list-conformance");
+      expect(listResponse.result).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: integrationId, projectId })]),
+      );
+
+      const statusResponse = await sendRequest(runtime.config().socketPath, {
+        id: "integration-status-conformance",
+        method: "integration.status",
+        params: {
+          id: integrationId,
+        },
+      });
+
+      expect(statusResponse.id).toBe("integration-status-conformance");
+      expect(statusResponse.result).toMatchObject({
+        bindingId: integrationId,
+        state: "idle",
+      });
+    });
+  });
+
   it("routes recurring/habit/sync methods through default runtime adapters", async () => {
     await withRunningRuntime({}, async (runtime) => {
       const projectResponse = await sendRequest(runtime.config().socketPath, {

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -33,6 +33,7 @@ export const CORE_DAEMON_NAMESPACE_METHODS = {
   project: ["create", "list", "get", "update", "delete"],
   task: ["create", "list", "get", "update", "delete", "move", "search"],
   label: ["create", "list", "update", "delete"],
+  integration: ["create", "list", "get", "update", "delete", "status"],
   note: ["create", "list", "update", "delete"],
   recurring: [
     "create",

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -85,7 +85,14 @@ describe("createDaemonRuntime", () => {
     });
 
     expect(DAEMON_CAPABILITY_METHODS).toEqual(
-      expect.arrayContaining(["recurring.process", "habit.history", "sync.catalogId", "sync.join"]),
+      expect.arrayContaining([
+        "integration.create",
+        "integration.status",
+        "recurring.process",
+        "habit.history",
+        "sync.catalogId",
+        "sync.join",
+      ]),
     );
 
     await runtime.stop();
@@ -508,6 +515,141 @@ describe("createDaemonRuntime", () => {
 
     expect(deleteLabelResponse).toEqual({
       id: "label-delete-1",
+      result: null,
+    });
+
+    await runtime.stop();
+  });
+
+  it("routes integration namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const primaryProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-integration-primary-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Integration Project",
+        },
+      },
+    });
+
+    const secondaryProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-integration-secondary-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Integration Project 2",
+        },
+      },
+    });
+
+    const primaryProjectId = (primaryProjectResponse.result as { id: string }).id;
+    const secondaryProjectId = (secondaryProjectResponse.result as { id: string }).id;
+
+    const createIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-create-1",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "github",
+          projectId: primaryProjectId,
+          targetKind: "repository",
+          targetRef: "owner/repo",
+        },
+      },
+    });
+
+    const integrationId = (createIntegrationResponse.result as { id: string }).id;
+
+    const listIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-list-1",
+      method: "integration.list",
+      params: {
+        filter: {
+          provider: "github",
+        },
+      },
+    });
+
+    expect(listIntegrationResponse.result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: integrationId, projectId: primaryProjectId }),
+      ]),
+    );
+
+    const getIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-get-1",
+      method: "integration.get",
+      params: {
+        id: integrationId,
+      },
+    });
+
+    expect(getIntegrationResponse.result).toEqual(
+      expect.objectContaining({
+        id: integrationId,
+        provider: "github",
+        projectId: primaryProjectId,
+        targetRef: "owner/repo",
+      }),
+    );
+
+    const updateIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-update-1",
+      method: "integration.update",
+      params: {
+        id: integrationId,
+        input: {
+          projectId: secondaryProjectId,
+          provider: "forgejo",
+          targetKind: "project",
+          targetRef: "team/repo",
+          strategy: "pull",
+          enabled: false,
+        },
+      },
+    });
+
+    expect(updateIntegrationResponse.result).toEqual(
+      expect.objectContaining({
+        id: integrationId,
+        projectId: secondaryProjectId,
+        provider: "forgejo",
+        targetKind: "project",
+        targetRef: "team/repo",
+        strategy: "pull",
+        enabled: false,
+      }),
+    );
+
+    const integrationStatusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-status-1",
+      method: "integration.status",
+      params: {
+        id: integrationId,
+      },
+    });
+
+    expect(integrationStatusResponse.result).toEqual(
+      expect.objectContaining({
+        bindingId: integrationId,
+        state: "idle",
+      }),
+    );
+
+    const deleteIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-delete-1",
+      method: "integration.delete",
+      params: {
+        id: integrationId,
+      },
+    });
+
+    expect(deleteIntegrationResponse).toEqual({
+      id: "integration-delete-1",
       result: null,
     });
 
@@ -1446,7 +1588,7 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
-  it("maps domain and request validation errors for project/task/label/note/recurring/habit/sync methods", async () => {
+  it("maps domain and request validation errors for project/task/label/integration/note/recurring/habit/sync methods", async () => {
     const runtime = createDaemonRuntime({ storagePath: tmpDir });
 
     await runtime.start();
@@ -1589,6 +1731,91 @@ describe("createDaemonRuntime", () => {
       message: "habit.history requires params.days as a positive number",
       details: {
         field: "days",
+      },
+    });
+
+    const integrationProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-project-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Integration Protocol Project",
+        },
+      },
+    });
+
+    const integrationProjectId = (integrationProjectResponse.result as { id: string }).id;
+
+    const integrationBadRequestResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-get-bad-request",
+      method: "integration.get",
+      params: {
+        id: 99,
+      },
+    });
+
+    expect(integrationBadRequestResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "integration.get requires params.id as a non-empty string",
+      details: {
+        field: "id",
+      },
+    });
+
+    const firstIntegrationCreateResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-create-first",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "github",
+          projectId: integrationProjectId,
+          targetKind: "repository",
+          targetRef: "owner/repo",
+        },
+      },
+    });
+
+    expect(firstIntegrationCreateResponse.result).toEqual(
+      expect.objectContaining({
+        provider: "github",
+        projectId: integrationProjectId,
+      }),
+    );
+
+    const integrationValidationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-create-validation",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "forgejo",
+          projectId: integrationProjectId,
+          targetKind: "repository",
+          targetRef: "owner/other",
+        },
+      },
+    });
+
+    expect(integrationValidationResponse.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      details: {
+        field: "projectId",
+      },
+    });
+
+    const integrationNotFoundResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-status-not-found",
+      method: "integration.status",
+      params: {
+        id: "ibind-missing",
+      },
+    });
+
+    expect(integrationNotFoundResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "integration binding not found: ibind-missing",
+      details: {
+        entity: "integration binding",
+        id: "ibind-missing",
       },
     });
 


### PR DESCRIPTION
## Summary

Expose integration binding CRUD and status queries over the daemon protocol so thin clients can manage bindings through the existing daemon-first architecture.

## Task

- #2190

## Changes

- Added an `integration` daemon RPC namespace with create/list/get/update/delete/status methods.
- Wired daemon core RPC adapters to the engine integration namespace.
- Added daemon parity, runtime, and protocol conformance coverage for integration binding behavior.
- Extended daemon validation/error mapping tests to cover integration request shapes and conflict responses.
- Updated `docs/ARCHITECTURE.md` to reflect integration as a core domain.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/daemon/src/runtime.test.ts packages/daemon/src/daemon-engine-parity.test.ts packages/daemon/src/protocol-conformance.test.ts`
- `make check`
- `make pre-pr`

## Docs

- Updated `docs/ARCHITECTURE.md` for the core-domain surface change.

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated or intentionally not needed
- [x] No unrelated changes included
