### PR TITLE
feat: drive sync providers from integration bindings

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -151,17 +151,17 @@ toduai plugin config recurring-worker --set '{"intervalSeconds":30}'
 Per-plugin sync scheduler fields are configured through `plugin config --set`:
 
 ```bash
-toduai plugin config github --set '{"projectId":"proj-123","strategy":"bidirectional","intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}'
+toduai plugin config github --set '{"intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}'
 ```
 
 Supported scheduler fields:
-- `projectId` (string): local project to sync for this plugin.
-- `strategy` (`bidirectional` | `pull` | `push` | `none`): operation mode per cycle.
 - `intervalSeconds` (positive number): steady-state cycle interval.
 - `retryInitialSeconds` (positive number): first retry delay after a failed cycle.
 - `retryMaxSeconds` (positive number): upper bound for exponential backoff.
-- `enabled` (boolean, optional): disables execution when false.
+- `enabled` (boolean, optional): disables the local provider worker when false.
 - `settings` (object, optional): provider-specific settings passed to `initialize(...)`.
+
+Integration binding desired state is not configured through local plugin config. The local plugin config only controls host-local execution settings and credentials.
 
 Retry policy:
 - Failures are logged with plugin name, attempt count, and next retry delay.

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -181,7 +181,7 @@ export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/p
 - Sync plugin scheduler config can be overridden via `TODUAI_DAEMON_PLUGIN_CONFIG` (JSON object keyed by plugin name).
 
 ```bash
-export TODUAI_DAEMON_PLUGIN_CONFIG='{"github":{"projectId":"proj-123","intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60}}'
+export TODUAI_DAEMON_PLUGIN_CONFIG='{"github":{"intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}}'
 ```
 
 - Optional socket override:

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -58,8 +58,8 @@ interface SyncProvider {
   readonly version: string;
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
-  pull(project: Project): Promise<SyncProviderPullResult>;
-  push(tasks: Task[], project: Project): Promise<void>;
+  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
+  push(binding: IntegrationBinding, tasks: Task[], project: Project): Promise<void>;
   mapToTask(external: ExternalTask, project: Project): Task;
   mapFromTask(task: Task, project: Project): ExternalTask;
 }
@@ -69,8 +69,8 @@ Expected lifecycle:
 
 1. Load plugin module.
 2. Validate registration and compatibility.
-3. Call `initialize(...)` once before sync operations.
-4. Call `pull(...)` and `push(...)` according to scheduler/strategy.
+3. Call `initialize(...)` once before binding-driven sync operations.
+4. For each applicable integration binding, call `pull(...)` and `push(...)` according to the binding strategy.
 5. Call `shutdown()` during daemon stop/unload.
 
 ## Load-Time Enforcement
@@ -112,14 +112,14 @@ Runtime behavior:
 
 Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginName>` in config file or `TODUAI_DAEMON_PLUGIN_CONFIG` env var (JSON object). Supported fields:
 
-- `projectId`: target local project ID.
-- `strategy`: `bidirectional`, `pull`, `push`, or `none`.
 - `intervalSeconds`: steady-state cycle interval.
 - `retryInitialSeconds` / `retryMaxSeconds`: retry backoff controls.
-- `enabled`: optional execution toggle.
+- `enabled`: optional execution toggle for the local provider worker.
 - `settings`: provider-specific object passed to `initialize(...)`.
 
-Architecture note: the generic integration direction in `docs/architecture/integrations.md` moves project-to-external integration binding desired state into synced core data. In that model, local provider config remains the place for secrets, credentials, and host-local runtime settings.
+Binding desired state is no longer configured through local plugin config. The daemon host now enumerates shared integration bindings from core state, filters by provider name and `enabled` state, and executes provider work according to each binding's `strategy`, `projectId`, `targetKind`, and `targetRef`.
+
+Architecture note: the generic integration direction in `docs/architecture/integrations.md` moves project-to-external integration binding desired state into synced core data. In that model, local provider config remains the place for secrets, credentials, retry tuning, and other host-local runtime settings.
 
 Retry policy:
 

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -1,4 +1,4 @@
-import { err, ok, type Project, type Result, type SyncStrategy, type Task } from "./types.js";
+import { err, type IntegrationBinding, ok, type Project, type Result, type Task } from "./types.js";
 
 export const SYNC_PROVIDER_API_VERSION = 1 as const;
 
@@ -35,8 +35,6 @@ export interface ExternalComment {
 }
 
 export interface SyncProviderConfig {
-  projectId: string;
-  strategy: SyncStrategy;
   settings: Record<string, unknown>;
 }
 
@@ -50,8 +48,8 @@ export interface SyncProvider {
   readonly version: string;
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
-  pull(project: Project): Promise<SyncProviderPullResult>;
-  push(tasks: Task[], project: Project): Promise<void>;
+  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
+  push(binding: IntegrationBinding, tasks: Task[], project: Project): Promise<void>;
   mapToTask(external: ExternalTask, project: Project): Task;
   mapFromTask(task: Task, project: Project): ExternalTask;
 }

--- a/packages/daemon/src/runtime.test.ts
+++ b/packages/daemon/src/runtime.test.ts
@@ -1335,6 +1335,154 @@ describe("createDaemonRuntime", () => {
     expect(runtime.getWorker("github-sync")?.state).toBe("stopped");
   });
 
+  it("executes sync provider work from integration bindings and persists status for later observers", async () => {
+    const outputPath = path.join(tmpDir, "github-provider-events.ndjson");
+    const pluginPath = writeRecordingSyncPluginModule(tmpDir, "github-recording-plugin.mjs", {
+      providerName: "github",
+      providerVersion: "1.0.0",
+      outputPath,
+    });
+
+    const authorityRuntime = createDaemonRuntime({
+      storagePath: tmpDir,
+      socketPath: path.join(tmpDir, "authority.sock"),
+      syncPluginModulePaths: [pluginPath],
+      syncPluginConfigs: {
+        github: {
+          intervalSeconds: 0.05,
+          settings: {
+            token: "env:GITHUB_TOKEN",
+          },
+        },
+      },
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await authorityRuntime.start();
+
+    const createProjectResponse = await sendRequest(authorityRuntime.config().socketPath, {
+      id: "project-integration-provider-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Provider Project",
+        },
+      },
+    });
+
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
+    await sendRequest(authorityRuntime.config().socketPath, {
+      id: "task-integration-provider-create",
+      method: "task.create",
+      params: {
+        input: {
+          title: "Existing Task",
+          projectId,
+        },
+      },
+    });
+
+    const createIntegrationResponse = await sendRequest(authorityRuntime.config().socketPath, {
+      id: "integration-provider-create",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "github",
+          projectId,
+          targetKind: "repository",
+          targetRef: "owner/repo",
+          strategy: "bidirectional",
+          enabled: true,
+        },
+      },
+    });
+
+    const bindingId = (createIntegrationResponse.result as { id: string }).id;
+
+    await waitForProviderEvent(
+      outputPath,
+      (event) => event.type === "push" && event.bindingId === bindingId,
+    );
+
+    const providerEvents = readProviderEvents(outputPath);
+    expect(providerEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "initialize",
+          settings: {
+            token: "env:GITHUB_TOKEN",
+          },
+        }),
+        expect.objectContaining({
+          type: "pull",
+          bindingId,
+          provider: "github",
+          targetRef: "owner/repo",
+          projectId,
+          strategy: "bidirectional",
+        }),
+        expect.objectContaining({
+          type: "push",
+          bindingId,
+          provider: "github",
+          targetRef: "owner/repo",
+          projectId,
+          strategy: "bidirectional",
+          taskCount: 1,
+        }),
+      ]),
+    );
+
+    const authorityStatusResponse = await sendRequest(authorityRuntime.config().socketPath, {
+      id: "integration-provider-status-authority",
+      method: "integration.status",
+      params: {
+        id: bindingId,
+      },
+    });
+
+    expect(authorityStatusResponse.result).toEqual(
+      expect.objectContaining({
+        bindingId,
+        state: "idle",
+        authorityId: authorityRuntime.config().socketPath,
+        lastAttemptedSyncAt: expect.any(String),
+        lastSuccessfulSyncAt: expect.any(String),
+        lastErrorSummary: null,
+      }),
+    );
+
+    await authorityRuntime.stop();
+
+    const observerRuntime = createDaemonRuntime({
+      storagePath: tmpDir,
+      socketPath: path.join(tmpDir, "observer.sock"),
+    });
+
+    await observerRuntime.start();
+
+    const observerStatusResponse = await sendRequest(observerRuntime.config().socketPath, {
+      id: "integration-provider-status-observer",
+      method: "integration.status",
+      params: {
+        id: bindingId,
+      },
+    });
+
+    expect(observerStatusResponse.result).toEqual(
+      expect.objectContaining({
+        bindingId,
+        state: "idle",
+        authorityId: authorityRuntime.config().socketPath,
+        lastAttemptedSyncAt: expect.any(String),
+        lastSuccessfulSyncAt: expect.any(String),
+      }),
+    );
+
+    await observerRuntime.stop();
+  });
+
   it("loads configured worker plugins and surfaces runtime state via worker.status", async () => {
     const pluginPath = writeValidWorkerPluginModule(tmpDir, "recurring-plugin.mjs", {
       pluginName: "recurring-worker",
@@ -2022,6 +2170,88 @@ function writeValidSyncPluginModule(
   return modulePath;
 }
 
+function writeRecordingSyncPluginModule(
+  directory: string,
+  filename: string,
+  options: {
+    providerName: string;
+    providerVersion: string;
+    outputPath: string;
+  },
+): string {
+  const modulePath = path.join(directory, filename);
+
+  const moduleSource = `import fs from "node:fs";
+
+const outputPath = ${JSON.stringify(options.outputPath)};
+
+function record(event) {
+  fs.appendFileSync(outputPath, JSON.stringify(event) + "\\n", "utf8");
+}
+
+export const syncProvider = {
+  manifest: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    apiVersion: 1,
+  },
+  provider: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    async initialize(config) {
+      record({ type: "initialize", settings: config.settings });
+    },
+    async shutdown() {
+      record({ type: "shutdown" });
+    },
+    async pull(binding, project) {
+      record({
+        type: "pull",
+        bindingId: binding.id,
+        provider: binding.provider,
+        targetRef: binding.targetRef,
+        projectId: project.id,
+        strategy: binding.strategy,
+      });
+      return { tasks: [] };
+    },
+    async push(binding, tasks, project) {
+      record({
+        type: "push",
+        bindingId: binding.id,
+        provider: binding.provider,
+        targetRef: binding.targetRef,
+        projectId: project.id,
+        strategy: binding.strategy,
+        taskCount: tasks.length,
+      });
+    },
+    mapToTask() {
+      return {
+        id: "task-1",
+        title: "Example",
+        status: "active",
+        priority: "medium",
+        projectId: "project-1",
+        labels: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      };
+    },
+    mapFromTask() {
+      return {
+        externalId: "ext-1",
+        title: "Example",
+      };
+    },
+  },
+};`;
+
+  fs.writeFileSync(modulePath, moduleSource, "utf8");
+
+  return modulePath;
+}
+
 function writeValidWorkerPluginModule(
   directory: string,
   filename: string,
@@ -2117,6 +2347,38 @@ function writeRecurringAutomationWorkerPluginModule(
   fs.writeFileSync(modulePath, moduleSource, "utf8");
 
   return modulePath;
+}
+
+function readProviderEvents(outputPath: string): Array<Record<string, unknown>> {
+  if (!fs.existsSync(outputPath)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(outputPath, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function waitForProviderEvent(
+  outputPath: string,
+  predicate: (event: Record<string, unknown>) => boolean,
+  timeoutMs = 2_000,
+): Promise<Record<string, unknown>> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const event = readProviderEvents(outputPath).find(predicate);
+    if (event) {
+      return event;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for provider event in ${outputPath}`);
 }
 
 function writeInvalidSyncPluginModule(directory: string, filename: string): string {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -689,6 +689,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
             pluginName: loadedPlugin.manifest.name,
             pluginVersion: loadedPlugin.manifest.version,
             modulePath: loadedPlugin.modulePath,
+            authorityId: resolvedConfig.socketPath,
             provider: loadedPlugin.provider,
             config: pluginConfigResolution.config,
             logger: runtimeLogger,

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1,6 +1,9 @@
 import {
+  createIntegrationBindingId,
   createProjectId,
   createTaskId,
+  type IntegrationBinding,
+  type IntegrationBindingStatus,
   ok,
   type Project,
   type SyncProvider,
@@ -25,77 +28,114 @@ describe("sync-worker-runtime", () => {
     vi.restoreAllMocks();
   });
 
-  it("executes pull/push cycles on configured interval", async () => {
+  it("executes cycles for enabled matching integration bindings and updates status", async () => {
     const provider = createProvider();
     const project = createProject();
     const task = createTask(project.id);
+    const binding = createBinding(project.id, {
+      id: "ibind-1",
+      provider: "github",
+      strategy: "bidirectional",
+      enabled: true,
+    });
+    const otherProviderBinding = createBinding(project.id, {
+      id: "ibind-2",
+      provider: "forgejo",
+      strategy: "bidirectional",
+      enabled: true,
+    });
+    const disabledBinding = createBinding(project.id, {
+      id: "ibind-3",
+      provider: "github",
+      strategy: "bidirectional",
+      enabled: false,
+    });
+    const todu = createTodu(project, [task], [binding, otherProviderBinding, disabledBinding]);
 
     const runtime = createSyncPluginWorkerRuntime({
       pluginName: "github",
       pluginVersion: "1.0.0",
       modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
       provider,
       config: {
         enabled: true,
-        projectId: project.id,
-        strategy: "bidirectional",
         intervalMs: 1_000,
         retryInitialMs: 100,
         retryMaxMs: 800,
         settings: {},
       },
       logger: createLogger(),
-      getTodu: () => createTodu(project, [task]),
+      getTodu: () => todu.instance,
     });
 
     const handle = runtime.start();
 
     await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.integration.list).toHaveBeenCalledWith({
+      provider: "github",
+      enabled: true,
+    });
     expect(provider.initialize).toHaveBeenCalledTimes(1);
+    expect(provider.initialize).toHaveBeenCalledWith({
+      settings: {},
+    });
     expect(provider.pull).toHaveBeenCalledTimes(1);
+    expect(provider.pull).toHaveBeenCalledWith(binding, project);
     expect(provider.push).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(999);
-    expect(provider.pull).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(provider.pull).toHaveBeenCalledTimes(2);
-    expect(provider.push).toHaveBeenCalledTimes(2);
+    expect(provider.push).toHaveBeenCalledWith(binding, [task], project);
+    expect(todu.integration.updateStatus).toHaveBeenCalledTimes(2);
+    expect(todu.integration.updateStatus).toHaveBeenNthCalledWith(1, binding.id, {
+      authorityId: "daemon://authority-1",
+      state: "running",
+      lastAttemptedSyncAt: expect.any(String),
+      lastSuccessfulSyncAt: undefined,
+      lastErrorSummary: null,
+    });
+    expect(todu.integration.updateStatus).toHaveBeenNthCalledWith(2, binding.id, {
+      authorityId: "daemon://authority-1",
+      state: "idle",
+      lastAttemptedSyncAt: expect.any(String),
+      lastSuccessfulSyncAt: expect.any(String),
+      lastErrorSummary: null,
+    });
 
     handle.stop();
     await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(provider.pull).toHaveBeenCalledTimes(2);
-    expect(provider.push).toHaveBeenCalledTimes(2);
     expect(provider.shutdown).toHaveBeenCalledTimes(1);
   });
 
-  it("retries failed cycles with exponential backoff", async () => {
+  it("retries failed cycles with exponential backoff and writes error status", async () => {
     const provider = createProvider({
       pull: vi
         .fn<SyncProvider["pull"]>()
         .mockRejectedValueOnce(new Error("network down"))
         .mockRejectedValueOnce(new Error("network down"))
-        .mockResolvedValue(undefined),
+        .mockResolvedValue({ tasks: [] }),
     });
     const project = createProject();
+    const binding = createBinding(project.id, {
+      strategy: "pull",
+    });
+    const todu = createTodu(project, [], [binding]);
 
     const runtime = createSyncPluginWorkerRuntime({
       pluginName: "github",
       pluginVersion: "1.0.0",
       modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
       provider,
       config: {
         enabled: true,
-        projectId: project.id,
-        strategy: "pull",
         intervalMs: 1_000,
         retryInitialMs: 100,
         retryMaxMs: 400,
         settings: {},
       },
       logger: createLogger(),
-      getTodu: () => createTodu(project, []),
+      getTodu: () => todu.instance,
     });
 
     const handle = runtime.start();
@@ -115,12 +155,11 @@ describe("sync-worker-runtime", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(provider.pull).toHaveBeenCalledTimes(3);
 
-    await vi.advanceTimersByTimeAsync(999);
-    expect(provider.pull).toHaveBeenCalledTimes(3);
+    const statusTransitions = todu.integration.updateStatus.mock.calls
+      .map((call) => call[1]?.state)
+      .filter((value) => value !== undefined);
 
-    await vi.advanceTimersByTimeAsync(1);
-    expect(provider.pull).toHaveBeenCalledTimes(4);
-
+    expect(statusTransitions).toEqual(["running", "error", "running", "error", "running", "idle"]);
     expect(provider.initialize).toHaveBeenCalledTimes(1);
 
     handle.stop();
@@ -131,26 +170,30 @@ describe("sync-worker-runtime", () => {
     const provider = createProvider({
       pull: vi.fn<SyncProvider["pull"]>().mockImplementation(async () => {
         await deferred.promise;
+        return { tasks: [] };
       }),
     });
     const project = createProject();
+    const binding = createBinding(project.id, {
+      strategy: "pull",
+    });
+    const todu = createTodu(project, [], [binding]);
 
     const runtime = createSyncPluginWorkerRuntime({
       pluginName: "github",
       pluginVersion: "1.0.0",
       modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
       provider,
       config: {
         enabled: true,
-        projectId: project.id,
-        strategy: "pull",
         intervalMs: 1_000,
         retryInitialMs: 100,
         retryMaxMs: 400,
         settings: {},
       },
       logger: createLogger(),
-      getTodu: () => createTodu(project, []),
+      getTodu: () => todu.instance,
     });
 
     const handle = runtime.start();
@@ -173,11 +216,12 @@ describe("sync-worker-runtime", () => {
     expect(provider.pull).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves config defaults and clamps retry max", () => {
+  it("resolves config defaults and ignores deprecated projectId and strategy settings", () => {
     const resolved = resolveSyncPluginExecutionConfig("github", {
       retryInitialSeconds: 12,
       retryMaxSeconds: 5,
-      strategy: "invalid",
+      strategy: "pull",
+      projectId: "proj-1",
       enabled: "yes",
       intervalSeconds: -1,
       settings: "oops",
@@ -185,14 +229,21 @@ describe("sync-worker-runtime", () => {
 
     expect(resolved.config).toEqual({
       enabled: true,
-      projectId: undefined,
-      strategy: "bidirectional",
       intervalMs: 300_000,
       retryInitialMs: 12_000,
       retryMaxMs: 12_000,
       settings: {},
     });
-    expect(resolved.warnings.length).toBeGreaterThan(0);
+    expect(resolved.warnings).toEqual(
+      expect.arrayContaining([
+        "sync plugin config warning (github): enabled must be boolean; using true",
+        "sync plugin config warning (github): intervalSeconds must be a positive number; using 300",
+        "sync plugin config warning (github): retryMaxSeconds is less than retryInitialSeconds; using retryInitialSeconds value",
+        "sync plugin config warning (github): projectId is ignored; shared integration bindings define project linkage",
+        "sync plugin config warning (github): strategy is ignored; shared integration bindings define sync strategy",
+        "sync plugin config warning (github): settings must be an object; using empty settings",
+      ]),
+    );
     expect(computeRetryDelayMs(0, resolved.config)).toBe(12_000);
     expect(computeRetryDelayMs(3, resolved.config)).toBe(12_000);
   });
@@ -201,12 +252,12 @@ describe("sync-worker-runtime", () => {
 function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
   return {
     initialize: vi.fn<SyncProvider["initialize"]>().mockResolvedValue(undefined),
-    pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue(undefined),
+    pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({ tasks: [] }),
     push: vi.fn<SyncProvider["push"]>().mockResolvedValue(undefined),
     shutdown: vi.fn<SyncProvider["shutdown"]>().mockResolvedValue(undefined),
     mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
-      id: createTaskId(String(item.id)),
-      title: String(item.id),
+      id: createTaskId(String(item.externalId)),
+      title: item.title,
       status: "todo",
       priority: "medium",
       projectId: createProject().id,
@@ -215,9 +266,11 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
       updatedAt: new Date(0).toISOString(),
     })),
     mapFromTask: vi.fn<SyncProvider["mapFromTask"]>().mockImplementation((task) => ({
-      id: task.id,
+      externalId: task.id,
       title: task.title,
     })),
+    name: "github",
+    version: "1.0.0",
     ...overrides,
   };
 }
@@ -251,15 +304,113 @@ function createTask(projectId: Project["id"]): Task {
   };
 }
 
-function createTodu(project: Project, tasks: Task[]): Todu {
+function createBinding(
+  projectId: Project["id"],
+  overrides: Partial<IntegrationBinding> = {},
+): IntegrationBinding {
+  const now = new Date(0).toISOString();
+
   return {
-    project: {
-      get: vi.fn().mockResolvedValue(ok(project)),
+    id: createIntegrationBindingId(overrides.id ?? "ibind-1"),
+    provider: overrides.provider ?? "github",
+    projectId,
+    targetKind: overrides.targetKind ?? "repository",
+    targetRef: overrides.targetRef ?? "owner/repo",
+    strategy: overrides.strategy ?? "bidirectional",
+    enabled: overrides.enabled ?? true,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function createTodu(
+  project: Project,
+  tasks: Task[],
+  bindings: IntegrationBinding[],
+): {
+  instance: Todu;
+  integration: {
+    list: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+  };
+} {
+  const statuses = new Map<string, IntegrationBindingStatus>();
+  const integrationList = vi.fn(async (filter?: { provider?: string; enabled?: boolean }) => {
+    let filtered = bindings;
+
+    if (filter?.provider !== undefined) {
+      filtered = filtered.filter((binding) => binding.provider === filter.provider);
+    }
+    if (filter?.enabled !== undefined) {
+      filtered = filtered.filter((binding) => binding.enabled === filter.enabled);
+    }
+
+    return ok(filtered);
+  });
+
+  const updateStatus = vi.fn(
+    async (
+      id: string,
+      input: {
+        state?: IntegrationBindingStatus["state"];
+        authorityId?: string | null;
+        lastAttemptedSyncAt?: string | null;
+        lastSuccessfulSyncAt?: string | null;
+        lastErrorSummary?: string | null;
+      },
+    ) => {
+      const previous =
+        statuses.get(id) ??
+        ({
+          bindingId: createIntegrationBindingId(id),
+          state: "idle",
+          authorityId: null,
+          lastAttemptedSyncAt: null,
+          lastSuccessfulSyncAt: null,
+          lastErrorSummary: null,
+          updatedAt: new Date(0).toISOString(),
+        } satisfies IntegrationBindingStatus);
+
+      const next: IntegrationBindingStatus = {
+        bindingId: previous.bindingId,
+        state: input.state ?? previous.state,
+        authorityId: input.authorityId ?? previous.authorityId,
+        lastAttemptedSyncAt:
+          input.lastAttemptedSyncAt !== undefined
+            ? input.lastAttemptedSyncAt
+            : previous.lastAttemptedSyncAt,
+        lastSuccessfulSyncAt:
+          input.lastSuccessfulSyncAt !== undefined
+            ? input.lastSuccessfulSyncAt
+            : previous.lastSuccessfulSyncAt,
+        lastErrorSummary:
+          input.lastErrorSummary !== undefined ? input.lastErrorSummary : previous.lastErrorSummary,
+        updatedAt: new Date(0).toISOString(),
+      };
+
+      statuses.set(id, next);
+      return ok(next);
     },
-    task: {
-      list: vi.fn().mockResolvedValue(ok(tasks)),
+  );
+
+  return {
+    instance: {
+      project: {
+        get: vi.fn().mockResolvedValue(ok(project)),
+      },
+      task: {
+        list: vi.fn().mockResolvedValue(ok(tasks)),
+      },
+      integration: {
+        list: integrationList,
+        updateStatus,
+      },
+    } as unknown as Todu,
+    integration: {
+      list: integrationList,
+      updateStatus,
     },
-  } as unknown as Todu;
+  };
 }
 
 function createLogger(): DaemonLogger {

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -1,8 +1,7 @@
 import {
   createProjectId,
-  isSyncStrategy,
+  type IntegrationBinding,
   type SyncProvider,
-  type SyncStrategy,
   type ToduError,
 } from "@todu/core";
 import type { Todu } from "@todu/engine";
@@ -15,8 +14,6 @@ const DEFAULT_RETRY_MAX_SECONDS = 60;
 
 export interface SyncPluginExecutionConfig {
   enabled: boolean;
-  projectId?: string;
-  strategy: SyncStrategy;
   intervalMs: number;
   retryInitialMs: number;
   retryMaxMs: number;
@@ -32,6 +29,7 @@ export interface CreateSyncPluginWorkerRuntimeOptions {
   pluginName: string;
   pluginVersion: string;
   modulePath: string;
+  authorityId: string;
   provider: SyncProvider;
   config: SyncPluginExecutionConfig;
   logger: DaemonLogger;
@@ -50,9 +48,6 @@ export function resolveSyncPluginExecutionConfig(
   const warnings: string[] = [];
 
   const enabled = parseBoolean(rawConfig?.enabled, true, warnings, "enabled", pluginName);
-  const projectId = parseOptionalString(rawConfig?.projectId);
-  const strategy = parseStrategy(rawConfig?.strategy, warnings, pluginName);
-
   const intervalMs = parseSecondsAsMs(
     rawConfig?.intervalSeconds,
     DEFAULT_SYNC_INTERVAL_SECONDS,
@@ -82,13 +77,25 @@ export function resolveSyncPluginExecutionConfig(
     retryMaxMs = retryInitialMs;
   }
 
+  const projectId = parseOptionalString(rawConfig?.projectId);
+  if (projectId) {
+    warnings.push(
+      `sync plugin config warning (${pluginName}): projectId is ignored; shared integration bindings define project linkage`,
+    );
+  }
+
+  const strategy = parseOptionalString(rawConfig?.strategy);
+  if (strategy) {
+    warnings.push(
+      `sync plugin config warning (${pluginName}): strategy is ignored; shared integration bindings define sync strategy`,
+    );
+  }
+
   const settings = parseSettings(rawConfig?.settings, warnings, pluginName);
 
   return {
     config: {
       enabled,
-      projectId,
-      strategy,
       intervalMs,
       retryInitialMs,
       retryMaxMs,
@@ -120,7 +127,6 @@ export function createSyncPluginWorkerRuntime(
       let initialized = false;
       let pendingShutdown = false;
       let retryAttempt = 0;
-      let missingProjectWarningLogged = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
       const scheduleNext = (delayMs: number): void => {
@@ -152,6 +158,93 @@ export function createSyncPluginWorkerRuntime(
         }
       };
 
+      const ensureInitialized = async (): Promise<void> => {
+        if (initialized) {
+          return;
+        }
+
+        await options.provider.initialize({
+          settings: config.settings,
+        });
+        initialized = true;
+      };
+
+      const updateBindingStatus = async (
+        activeTodu: Todu,
+        binding: IntegrationBinding,
+        input: {
+          state?: "running" | "idle" | "blocked" | "error";
+          lastAttemptedSyncAt?: string | null;
+          lastSuccessfulSyncAt?: string | null;
+          lastErrorSummary?: string | null;
+        },
+      ): Promise<void> => {
+        const result = await activeTodu.integration.updateStatus(binding.id, {
+          authorityId: options.authorityId,
+          state: input.state,
+          lastAttemptedSyncAt: input.lastAttemptedSyncAt,
+          lastSuccessfulSyncAt: input.lastSuccessfulSyncAt,
+          lastErrorSummary: input.lastErrorSummary,
+        });
+
+        if (!result.ok) {
+          runtimeLogger.warn("sync plugin failed to update integration binding status", {
+            pluginName: options.pluginName,
+            pluginVersion: options.pluginVersion,
+            modulePath: options.modulePath,
+            bindingId: binding.id,
+            error: formatToduError(result.error),
+          });
+        }
+      };
+
+      const runBindingCycle = async (
+        activeTodu: Todu,
+        binding: IntegrationBinding,
+        startedAt: string,
+      ): Promise<void> => {
+        if (binding.strategy === "none") {
+          await updateBindingStatus(activeTodu, binding, {
+            state: "idle",
+            lastErrorSummary: null,
+          });
+          return;
+        }
+
+        await updateBindingStatus(activeTodu, binding, {
+          state: "running",
+          lastAttemptedSyncAt: startedAt,
+          lastErrorSummary: null,
+        });
+
+        const projectResult = await activeTodu.project.get(createProjectId(binding.projectId));
+        if (!projectResult.ok) {
+          throw new Error(`project load failed: ${formatToduError(projectResult.error)}`);
+        }
+
+        await ensureInitialized();
+
+        if (binding.strategy === "pull" || binding.strategy === "bidirectional") {
+          await options.provider.pull(binding, projectResult.value);
+        }
+
+        if (binding.strategy === "push" || binding.strategy === "bidirectional") {
+          const tasksResult = await activeTodu.task.list({ projectId: projectResult.value.id });
+          if (!tasksResult.ok) {
+            throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+          }
+
+          await options.provider.push(binding, tasksResult.value, projectResult.value);
+        }
+
+        await updateBindingStatus(activeTodu, binding, {
+          state: "idle",
+          lastAttemptedSyncAt: startedAt,
+          lastSuccessfulSyncAt: new Date(now()).toISOString(),
+          lastErrorSummary: null,
+        });
+      };
+
       const runCycle = async (): Promise<void> => {
         if (stopped || running) {
           return;
@@ -159,30 +252,10 @@ export function createSyncPluginWorkerRuntime(
 
         running = true;
         const startedAtMs = now();
+        const startedAt = new Date(startedAtMs).toISOString();
 
         try {
           if (!config.enabled) {
-            retryAttempt = 0;
-            scheduleNext(config.intervalMs);
-            return;
-          }
-
-          if (config.strategy === "none") {
-            retryAttempt = 0;
-            scheduleNext(config.intervalMs);
-            return;
-          }
-
-          if (!config.projectId) {
-            if (!missingProjectWarningLogged) {
-              runtimeLogger.warn("sync plugin projectId is not configured; skipping sync cycle", {
-                pluginName: options.pluginName,
-                pluginVersion: options.pluginVersion,
-                modulePath: options.modulePath,
-              });
-              missingProjectWarningLogged = true;
-            }
-
             retryAttempt = 0;
             scheduleNext(config.intervalMs);
             return;
@@ -193,33 +266,27 @@ export function createSyncPluginWorkerRuntime(
             throw new Error("daemon data host unavailable");
           }
 
-          missingProjectWarningLogged = false;
-
-          if (!initialized) {
-            await options.provider.initialize({
-              projectId: config.projectId,
-              strategy: config.strategy,
-              settings: config.settings,
-            });
-            initialized = true;
+          const bindingsResult = await activeTodu.integration.list({
+            provider: options.pluginName,
+            enabled: true,
+          });
+          if (!bindingsResult.ok) {
+            throw new Error(
+              `integration binding list failed: ${formatToduError(bindingsResult.error)}`,
+            );
           }
 
-          const projectResult = await activeTodu.project.get(createProjectId(config.projectId));
-          if (!projectResult.ok) {
-            throw new Error(`project load failed: ${formatToduError(projectResult.error)}`);
-          }
-
-          if (config.strategy === "pull" || config.strategy === "bidirectional") {
-            await options.provider.pull(projectResult.value);
-          }
-
-          if (config.strategy === "push" || config.strategy === "bidirectional") {
-            const tasksResult = await activeTodu.task.list({ projectId: projectResult.value.id });
-            if (!tasksResult.ok) {
-              throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+          for (const binding of bindingsResult.value) {
+            try {
+              await runBindingCycle(activeTodu, binding, startedAt);
+            } catch (error) {
+              await updateBindingStatus(activeTodu, binding, {
+                state: "error",
+                lastAttemptedSyncAt: startedAt,
+                lastErrorSummary: summarizeError(error),
+              });
+              throw error;
             }
-
-            await options.provider.push(tasksResult.value, projectResult.value);
           }
 
           retryAttempt = 0;
@@ -227,8 +294,7 @@ export function createSyncPluginWorkerRuntime(
             pluginName: options.pluginName,
             pluginVersion: options.pluginVersion,
             modulePath: options.modulePath,
-            strategy: config.strategy,
-            projectId: config.projectId,
+            bindingCount: bindingsResult.value.length,
             durationMs: Math.max(0, Math.round(now() - startedAtMs)),
           });
 
@@ -241,11 +307,9 @@ export function createSyncPluginWorkerRuntime(
             pluginName: options.pluginName,
             pluginVersion: options.pluginVersion,
             modulePath: options.modulePath,
-            strategy: config.strategy,
-            projectId: config.projectId ?? null,
             attempt: retryAttempt,
             nextRetryMs: delayMs,
-            error: error instanceof Error ? error.message : String(error),
+            error: summarizeError(error),
           });
 
           scheduleNext(delayMs);
@@ -297,6 +361,14 @@ function formatToduError(error: ToduError): string {
   }
 }
 
+function summarizeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
 function parseSettings(
   value: unknown,
   warnings: string[],
@@ -314,23 +386,6 @@ function parseSettings(
     `sync plugin config warning (${pluginName}): settings must be an object; using empty settings`,
   );
   return {};
-}
-
-function parseStrategy(value: unknown, warnings: string[], pluginName: string): SyncStrategy {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    return "bidirectional";
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (isSyncStrategy(normalized)) {
-    return normalized;
-  }
-
-  warnings.push(
-    `sync plugin config warning (${pluginName}): strategy must be one of bidirectional/pull/push/none; using bidirectional`,
-  );
-
-  return "bidirectional";
 }
 
 function parseBoolean(


### PR DESCRIPTION
## Summary

Rework daemon-side sync provider orchestration to enumerate shared integration bindings, execute provider work per binding, and write synced binding status updates instead of relying on plugin-local project and strategy configuration.

## Task

- #2192

## Changes

- Updated the sync provider runtime contract so provider pull/push work receives integration binding context.
- Reworked daemon sync plugin runtime to list enabled integration bindings by provider, execute work per binding, and write per-binding status updates.
- Added daemon runtime coverage for binding-driven execution and persisted status visibility from a later observer runtime.
- Updated sync worker runtime tests for binding selection, retries, and deprecated local config handling.
- Updated plugin/operator docs to reflect that project linkage and strategy now come from shared integration bindings while credentials and runtime settings remain local.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/core/src/sync-provider.test.ts packages/daemon/src/sync-worker-runtime.test.ts packages/daemon/src/runtime.test.ts`
- `make check`
- `make pre-pr`

## Docs

- Updated `docs/plugin-sync-provider-api.md`
- Updated `docs/cli-daemon-usage.md`
- Updated `docs/daemon-service-operations.md`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated or intentionally not needed
- [x] No unrelated changes included
