### PR TITLE
feat: remove legacy project sync control path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,7 +226,7 @@ Baseline worker lifecycle states are:
 - Daemon plugin module paths resolve from `TODUAI_DAEMON_PLUGIN_PATHS` first, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.
-- Planned external integration architecture uses a small synced core integration binding model consumed by sync provider plugins, while provider runtime internals remain local to the authority daemon host. See `docs/architecture/integrations.md`.
+- External sync uses a small synced core integration binding model consumed by sync provider plugins, and integration bindings are the sole core control plane for that work. Provider runtime internals remain local to the authority daemon host. See `docs/architecture/integrations.md`.
 - Author-facing contract details are documented in `docs/worker-plugin-api.md` and `docs/plugin-sync-provider-api.md`.
 - Product/plugin boundary policy is documented in `docs/adr/0001-plugin-boundaries-and-data-ownership.md`, `docs/architecture/plugins.md`, and `docs/architecture/integrations.md`.
 

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -298,6 +298,7 @@ As a result:
 - no compatibility layer is required for legacy project/system external sync assumptions
 - implementation may discard existing sample data if needed
 - implementation may introduce a new root catalog/document layout if that is the simplest path to the new model
+- core project surfaces should not expose project-level external sync control fields after the cutover
 
 New external sync work should be designed only against the integration binding model and related per-integration-binding status documents.
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -188,6 +188,7 @@ toduai integration status <binding-id>
 
 Behavior notes:
 - Integration bindings are the generic shared control plane for external integrations.
+- Project commands no longer expose project-level external sync settings; use `toduai integration ...` to manage external sync intent.
 - Provider-specific credential setup stays out of `integration add|update|remove` and remains local to the authority daemon host.
 - `integration list` supports filtering by `--provider`, `--project`, `--enabled`, and `--disabled`.
 - `integration status` shows runtime status for one binding or all bindings.

--- a/docs/plans/phase-10-external-integrations.md
+++ b/docs/plans/phase-10-external-integrations.md
@@ -93,6 +93,7 @@ See also:
 
 7. **Core cleanup: remove conflicting external sync control paths**
    - Remove or neutralize project-level external sync behavior that conflicts with integration bindings.
+   - Remove legacy project-surface sync metadata that suggests projects own external sync control.
    - Ensure integration binding becomes the single external sync control plane.
 
 ## Dependencies

--- a/integration-tests/cli-project/create.md
+++ b/integration-tests/cli-project/create.md
@@ -20,18 +20,17 @@ toduai project create --name "My App"
 
 **Expected:**
 
-```
+```text
 Project created:
 ID:          proj-XXXXXXXX
 Name:        My App
 Status:      active
 Priority:    medium
-Sync:        none
 Created:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Updated:     YYYY-MM-DDTHH:MM:SS.MMMZ
 ```
 
-Defaults: status=active, priority=medium, sync=none.
+Defaults: status=active, priority=medium.
 
 ## 2. Create with All Options (CLI)
 
@@ -41,13 +40,12 @@ toduai project create --name "Backend API" --priority high --description "REST A
 
 **Expected:**
 
-```
+```text
 Project created:
 ID:          proj-XXXXXXXX
 Name:        Backend API
 Status:      active
 Priority:    high
-Sync:        none
 Created:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Updated:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Description: REST API service
@@ -59,7 +57,7 @@ Description: REST API service
 toduai --format json project create --name "Frontend"
 ```
 
-**Expected:** JSON with id, name, status, priority, syncStrategy, createdAt, updatedAt.
+**Expected:** JSON with id, name, status, priority, createdAt, and updatedAt.
 
 ```json
 {
@@ -67,7 +65,6 @@ toduai --format json project create --name "Frontend"
   "name": "Frontend",
   "status": "active",
   "priority": "medium",
-  "syncStrategy": "none",
   "createdAt": "YYYY-MM-DDTHH:MM:SS.MMMZ",
   "updatedAt": "YYYY-MM-DDTHH:MM:SS.MMMZ"
 }
@@ -153,7 +150,7 @@ toduai project show "Electron Project" --no-color
 
 **Expected:**
 
-```
+```text
 ID:          proj-XXXXXXXX
 Name:        Electron Project
 Status:      active

--- a/integration-tests/cli-project/show.md
+++ b/integration-tests/cli-project/show.md
@@ -22,12 +22,11 @@ toduai project show "My App"
 
 **Expected:**
 
-```
+```text
 ID:          proj-XXXXXXXX
 Name:        My App
 Status:      active
 Priority:    high
-Sync:        none
 Created:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Updated:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Description: Main application
@@ -48,7 +47,7 @@ toduai project show "$PROJECT_ID"
 toduai --format json project show "My App"
 ```
 
-**Expected:** JSON object with all project fields.
+**Expected:** JSON object with `id`, `name`, `status`, `priority`, `description`, `createdAt`, and `updatedAt`.
 
 ## 4. Verify Electron Detail View
 

--- a/integration-tests/cli-project/update.md
+++ b/integration-tests/cli-project/update.md
@@ -22,13 +22,12 @@ toduai project update "My App" --name "My Application"
 
 **Expected:**
 
-```
+```text
 Project updated:
 ID:          proj-XXXXXXXX
 Name:        My Application
 Status:      active
 Priority:    medium
-Sync:        none
 Created:     YYYY-MM-DDTHH:MM:SS.MMMZ
 Updated:     YYYY-MM-DDTHH:MM:SS.MMMZ
 ```
@@ -156,7 +155,7 @@ toduai project show "Renamed In Electron" --no-color
 
 **Expected:**
 
-```
+```text
 ID:          proj-XXXXXXXX
 Name:        Renamed In Electron
 Status:      done

--- a/packages/cli/src/commands/project.test.ts
+++ b/packages/cli/src/commands/project.test.ts
@@ -60,6 +60,9 @@ describe("project CLI commands", () => {
     const created = JSON.parse(createJson);
     expect(created.name).toBe("JSON Project");
     expect(created.id).toMatch(/^proj-/);
+    expect(created).not.toHaveProperty("syncStrategy");
+    expect(created).not.toHaveProperty("systemId");
+    expect(created).not.toHaveProperty("externalId");
 
     // List
     const listOutput = run("project list");
@@ -75,6 +78,7 @@ describe("project CLI commands", () => {
     const showOutput = run(`project show ${created.id}`);
     expect(showOutput).toContain("JSON Project");
     expect(showOutput).toContain(created.id);
+    expect(showOutput).not.toContain("Sync:");
 
     // Show by name
     const showByName = run('project show "Test Project"');

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -26,7 +26,6 @@ function projectDetail(p: Project): string {
     `Name:        ${p.name}`,
     `Status:      ${p.status}`,
     `Priority:    ${p.priority}`,
-    `Sync:        ${p.syncStrategy}`,
     `Created:     ${p.createdAt}`,
     `Updated:     ${p.updatedAt}`,
   ];

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -21,7 +21,7 @@ import type {
 /**
  * Catalog document (one per todu instance).
  * Contains all small/bounded data: projects, labels, habits, settings,
- * recurring templates, and external system registrations.
+ * recurring templates, and shared integration binding metadata.
  */
 export interface CatalogDocument {
   /** Schema version for migration support */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -136,9 +136,6 @@ export interface Project {
   description?: string;
   status: ProjectStatus;
   priority: TaskPriority;
-  externalId?: string;
-  systemId?: string;
-  syncStrategy: SyncStrategy;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/daemon/src/daemon-engine-parity.test.ts
+++ b/packages/daemon/src/daemon-engine-parity.test.ts
@@ -69,9 +69,11 @@ describe("daemon vs engine parity", () => {
         description: engineCreate.value.description,
         priority: engineCreate.value.priority,
         status: engineCreate.value.status,
-        syncStrategy: engineCreate.value.syncStrategy,
       }),
     );
+    expect(rpcCreate.result).not.toHaveProperty("syncStrategy");
+    expect(rpcCreate.result).not.toHaveProperty("systemId");
+    expect(rpcCreate.result).not.toHaveProperty("externalId");
 
     const engineList = await engine.project.list();
     expect(engineList.ok).toBe(true);

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -283,7 +283,6 @@ function createProject(): Project {
     name: "Project",
     status: "active",
     priority: "medium",
-    syncStrategy: "none",
     createdAt: now,
     updatedAt: now,
   };

--- a/packages/engine/src/projects.test.ts
+++ b/packages/engine/src/projects.test.ts
@@ -32,7 +32,9 @@ describe("project namespace", () => {
       expect(result.value.name).toBe("My Project");
       expect(result.value.status).toBe("active");
       expect(result.value.priority).toBe("medium");
-      expect(result.value.syncStrategy).toBe("none");
+      expect(result.value).not.toHaveProperty("syncStrategy");
+      expect(result.value).not.toHaveProperty("systemId");
+      expect(result.value).not.toHaveProperty("externalId");
       expect(result.value.id).toMatch(/^proj-/);
       expect(result.value.createdAt).toBeTruthy();
       expect(result.value.updatedAt).toBeTruthy();

--- a/packages/engine/src/projects.ts
+++ b/packages/engine/src/projects.ts
@@ -35,7 +35,6 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
         name: input.name.trim(),
         status: "active",
         priority: input.priority ?? "medium",
-        syncStrategy: "none",
         createdAt: now,
         updatedAt: now,
       };
@@ -135,9 +134,6 @@ function cloneProject(p: Project): Project {
     description: p.description,
     status: p.status,
     priority: p.priority,
-    externalId: p.externalId,
-    systemId: p.systemId,
-    syncStrategy: p.syncStrategy,
     createdAt: p.createdAt,
     updatedAt: p.updatedAt,
   };


### PR DESCRIPTION
## Summary

Remove legacy project-level external sync metadata from the shared project surface so integration bindings remain the only core control plane for external sync.

## Task

- #2193

## Changes

- Removed legacy project sync fields from the core `Project` model and engine project creation/cloning.
- Removed the project CLI detail output that implied projects still owned sync configuration.
- Added coverage confirming project create/show surfaces no longer expose legacy sync metadata over engine, daemon, and CLI paths.
- Updated architecture and operator docs to describe the integration-binding-only cutover.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npm run test -- packages/engine/src/projects.test.ts packages/daemon/src/daemon-engine-parity.test.ts packages/daemon/src/sync-worker-runtime.test.ts packages/cli/src/commands/project.test.ts`
- `make check`
- `make pre-pr`

## Docs

- Updated `docs/ARCHITECTURE.md`
- Updated `docs/architecture/integrations.md`
- Updated `docs/cli-daemon-usage.md`
- Updated `docs/plans/phase-10-external-integrations.md`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [x] Documentation updated or intentionally not needed
- [x] No unrelated changes included
