### PR TITLE
feat: add sync-provider comment contract and runtime support

### DIFF
--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -59,11 +59,13 @@ interface SyncProvider {
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
   pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(binding: IntegrationBinding, tasks: TaskWithDetail[], project: Project): Promise<void>;
+  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<void>;
   mapToTask(external: ExternalTask, project: Project): Task;
-  mapFromTask(task: TaskWithDetail, project: Project): ExternalTask;
+  mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
 }
 ```
+
+`TaskPushPayload` extends `TaskWithDetail` with `comments: Note[]`, providing each task's description and attached comments during push.
 
 Expected lifecycle:
 
@@ -72,6 +74,38 @@ Expected lifecycle:
 3. Call `initialize(...)` once before binding-driven sync operations.
 4. For each applicable integration binding, call `pull(...)` and `push(...)` according to the binding strategy.
 5. Call `shutdown()` during daemon stop/unload.
+
+## Comment Sync Contract
+
+The sync-provider runtime supports comment/note mirroring through pull and push paths.
+
+### Push path
+
+Each `TaskPushPayload` in `push(...)` includes a `comments: Note[]` array containing the task's attached notes (entity type `task`). Providers can use these to detect local comment creates, edits, and deletes by comparing with external state.
+
+### Pull path
+
+`SyncProviderPullResult.comments` accepts `ExternalComment[]`. The runtime reconciles pulled comments with local notes using a snapshot model:
+
+- Comments with an `externalId` not present locally are created as new notes with a `sync:externalId:<value>` tag.
+- Comments matching an existing local note (by external ID tag) are updated if the external `updatedAt` is newer than the local `createdAt` (last-write-wins).
+- Local synced notes whose external IDs are absent from the pull result are deleted.
+
+### ExternalComment
+
+```ts
+interface ExternalComment {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: string;
+  createdAt: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+```
+
+The `externalTaskId` must match a todu task ID for the comment to be applied. The `createdAt` timestamp is required; `updatedAt` is used for conflict resolution when present (falls back to `createdAt`).
 
 ## Load-Time Enforcement
 

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -5,7 +5,7 @@ import {
   type Project,
   type Result,
   type Task,
-  type TaskWithDetail,
+  type TaskPushPayload,
 } from "./types.js";
 
 export const SYNC_PROVIDER_API_VERSION = 1 as const;
@@ -58,9 +58,9 @@ export interface SyncProvider {
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
   pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(binding: IntegrationBinding, tasks: TaskWithDetail[], project: Project): Promise<void>;
+  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<void>;
   mapToTask(external: ExternalTask, project: Project): Task;
-  mapFromTask(task: TaskWithDetail, project: Project): ExternalTask;
+  mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
 }
 
 export interface SyncProviderRegistration {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -198,6 +198,11 @@ export interface TaskWithDetail extends Task {
   description?: string;
 }
 
+/** Task with description and comments, used as sync-provider push input */
+export interface TaskPushPayload extends TaskWithDetail {
+  comments: Note[];
+}
+
 // ============================================================================
 // Label entity — stored in catalog document
 // ============================================================================

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1,9 +1,12 @@
 import {
   createIntegrationBindingId,
+  createNoteId,
   createProjectId,
   createTaskId,
+  type ExternalComment,
   type IntegrationBinding,
   type IntegrationBindingStatus,
+  type Note,
   ok,
   type Project,
   type SyncProvider,
@@ -86,7 +89,7 @@ describe("sync-worker-runtime", () => {
     expect(provider.push).toHaveBeenCalledTimes(1);
     expect(provider.push).toHaveBeenCalledWith(
       binding,
-      [{ ...task, description: undefined }],
+      [{ ...task, description: undefined, comments: [] }],
       project,
     );
     expect(todu.integration.updateStatus).toHaveBeenCalledTimes(2);
@@ -251,6 +254,268 @@ describe("sync-worker-runtime", () => {
     expect(computeRetryDelayMs(0, resolved.config)).toBe(12_000);
     expect(computeRetryDelayMs(3, resolved.config)).toBe(12_000);
   });
+
+  it("push includes task comments from note.list in each TaskPushPayload", async () => {
+    const provider = createProvider();
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "push" });
+    const taskNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "a comment",
+      tags: ["sync:externalId:ext-c1"],
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [taskNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(provider.push).toHaveBeenCalledTimes(1);
+    const pushArgs = provider.push.mock.calls[0];
+    const pushedTasks = pushArgs[1];
+    expect(pushedTasks).toHaveLength(1);
+    expect(pushedTasks[0].comments).toEqual([taskNote]);
+
+    handle.stop();
+  });
+
+  it("pull creates new comments as notes when externalId is not present locally", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledComments: ExternalComment[] = [
+      {
+        externalId: "gh-comment-1",
+        externalTaskId: task.id,
+        body: "New comment from GitHub",
+        author: "octocat",
+        createdAt: "2026-03-10T10:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: pulledComments,
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.create).toHaveBeenCalledTimes(1);
+    expect(todu.note.create).toHaveBeenCalledWith({
+      content: "New comment from GitHub",
+      author: "octocat",
+      entityType: "task",
+      entityId: task.id,
+      tags: ["sync:externalId:gh-comment-1"],
+    });
+
+    handle.stop();
+  });
+
+  it("pull updates existing comments when external updatedAt is newer", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const existingNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "old content",
+      tags: ["sync:externalId:gh-comment-1"],
+      createdAt: "2026-03-09T10:00:00Z",
+    });
+    const pulledComments: ExternalComment[] = [
+      {
+        externalId: "gh-comment-1",
+        externalTaskId: task.id,
+        body: "Updated content from GitHub",
+        author: "octocat",
+        createdAt: "2026-03-09T10:00:00Z",
+        updatedAt: "2026-03-10T15:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: pulledComments,
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [existingNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.create).not.toHaveBeenCalled();
+    expect(todu.note.update).toHaveBeenCalledTimes(1);
+    expect(todu.note.update).toHaveBeenCalledWith(existingNote.id, {
+      content: "Updated content from GitHub",
+    });
+
+    handle.stop();
+  });
+
+  it("pull deletes local synced notes absent from pull result", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const orphanedNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "will be deleted",
+      tags: ["sync:externalId:gh-comment-deleted"],
+    });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-other",
+            externalTaskId: task.id,
+            body: "still exists",
+            createdAt: "2026-03-10T10:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [orphanedNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.delete).toHaveBeenCalledTimes(1);
+    expect(todu.note.delete).toHaveBeenCalledWith(orphanedNote.id);
+    // The new comment should be created
+    expect(todu.note.create).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+
+  it("pull skips update when local note is newer than external comment", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const existingNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "locally edited content",
+      tags: ["sync:externalId:gh-comment-1"],
+      createdAt: "2026-03-10T20:00:00Z",
+    });
+    const pulledComments: ExternalComment[] = [
+      {
+        externalId: "gh-comment-1",
+        externalTaskId: task.id,
+        body: "Older external content",
+        author: "octocat",
+        createdAt: "2026-03-09T10:00:00Z",
+        updatedAt: "2026-03-10T12:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: pulledComments,
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [existingNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.update).not.toHaveBeenCalled();
+    expect(todu.note.create).not.toHaveBeenCalled();
+    expect(todu.note.delete).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
 });
 
 function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
@@ -328,17 +593,43 @@ function createBinding(
   };
 }
 
+function createNote(overrides: Partial<Note> & { content: string }): Note {
+  const now = new Date(0).toISOString();
+
+  return {
+    id: createNoteId(overrides.id ?? `note-${Math.random().toString(36).slice(2, 8)}`),
+    content: overrides.content,
+    author: overrides.author ?? "user",
+    entityType: overrides.entityType,
+    entityId: overrides.entityId,
+    tags: overrides.tags ?? [],
+    createdAt: overrides.createdAt ?? now,
+  };
+}
+
+interface CreateToduOptions {
+  notes?: Note[];
+}
+
 function createTodu(
   project: Project,
   tasks: Task[],
   bindings: IntegrationBinding[],
+  options: CreateToduOptions = {},
 ): {
   instance: Todu;
   integration: {
     list: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
   };
+  note: {
+    list: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
 } {
+  const notes: Note[] = [...(options.notes ?? [])];
   const statuses = new Map<string, IntegrationBindingStatus>();
   const integrationList = vi.fn(async (filter?: { provider?: string; enabled?: boolean }) => {
     let filtered = bindings;
@@ -404,6 +695,60 @@ function createTodu(
     return ok({ ...task, description: undefined });
   });
 
+  let noteIdCounter = 1;
+  const noteList = vi.fn(
+    async (filter?: { entityType?: string; entityId?: string; tag?: string }) => {
+      let filtered = notes;
+      if (filter?.entityType) {
+        filtered = filtered.filter((n) => n.entityType === filter.entityType);
+      }
+      if (filter?.entityId) {
+        filtered = filtered.filter((n) => n.entityId === filter.entityId);
+      }
+      if (filter?.tag) {
+        const tag = filter.tag;
+        filtered = filtered.filter((n) => n.tags.includes(tag));
+      }
+      return ok(filtered);
+    },
+  );
+
+  const noteCreate = vi.fn(
+    async (input: {
+      content: string;
+      author?: string;
+      entityType?: string;
+      entityId?: string;
+      tags?: string[];
+    }) => {
+      const note: Note = {
+        id: createNoteId(`note-${String(noteIdCounter++).padStart(3, "0")}`),
+        content: input.content,
+        author: input.author ?? "user",
+        entityType: input.entityType as Note["entityType"],
+        entityId: input.entityId,
+        tags: input.tags ?? [],
+        createdAt: new Date(0).toISOString(),
+      };
+      notes.push(note);
+      return ok(note);
+    },
+  );
+
+  const noteUpdate = vi.fn(async (id: string, input: { content?: string; tags?: string[] }) => {
+    const note = notes.find((n) => n.id === id);
+    if (!note) return ok(undefined);
+    if (input.content !== undefined) note.content = input.content;
+    if (input.tags !== undefined) note.tags = input.tags;
+    return ok(note);
+  });
+
+  const noteDelete = vi.fn(async (id: string) => {
+    const index = notes.findIndex((n) => n.id === id);
+    if (index !== -1) notes.splice(index, 1);
+    return ok(undefined);
+  });
+
   return {
     instance: {
       project: {
@@ -417,10 +762,22 @@ function createTodu(
         list: integrationList,
         updateStatus,
       },
+      note: {
+        list: noteList,
+        create: noteCreate,
+        update: noteUpdate,
+        delete: noteDelete,
+      },
     } as unknown as Todu,
     integration: {
       list: integrationList,
       updateStatus,
+    },
+    note: {
+      list: noteList,
+      create: noteCreate,
+      update: noteUpdate,
+      delete: noteDelete,
     },
   };
 }

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -1,8 +1,10 @@
 import {
   createProjectId,
+  type ExternalComment,
   type IntegrationBinding,
+  type Note,
   type SyncProvider,
-  type TaskWithDetail,
+  type TaskPushPayload,
   type ToduError,
 } from "@todu/core";
 import type { Todu } from "@todu/engine";
@@ -226,7 +228,11 @@ export function createSyncPluginWorkerRuntime(
         await ensureInitialized();
 
         if (binding.strategy === "pull" || binding.strategy === "bidirectional") {
-          await options.provider.pull(binding, projectResult.value);
+          const pullResult = await options.provider.pull(binding, projectResult.value);
+
+          if (pullResult.comments && pullResult.comments.length > 0) {
+            await applyPulledComments(activeTodu, pullResult.comments);
+          }
         }
 
         if (binding.strategy === "push" || binding.strategy === "bidirectional") {
@@ -235,17 +241,23 @@ export function createSyncPluginWorkerRuntime(
             throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
           }
 
-          const tasksWithDetails: TaskWithDetail[] = [];
+          const pushPayloads: TaskPushPayload[] = [];
           for (const task of tasksResult.value) {
             const detailResult = await activeTodu.task.get(task.id);
-            if (detailResult.ok) {
-              tasksWithDetails.push(detailResult.value);
-            } else {
-              tasksWithDetails.push({ ...task, description: undefined });
-            }
+            const taskDetail = detailResult.ok
+              ? detailResult.value
+              : { ...task, description: undefined };
+
+            const commentsResult = await activeTodu.note.list({
+              entityType: "task",
+              entityId: task.id,
+            });
+            const comments: Note[] = commentsResult.ok ? commentsResult.value : [];
+
+            pushPayloads.push({ ...taskDetail, comments });
           }
 
-          await options.provider.push(binding, tasksWithDetails, projectResult.value);
+          await options.provider.push(binding, pushPayloads, projectResult.value);
         }
 
         await updateBindingStatus(activeTodu, binding, {
@@ -359,6 +371,99 @@ export function createSyncPluginWorkerRuntime(
       };
     },
   };
+}
+
+/**
+ * Apply comments pulled from an external provider to local todu notes.
+ *
+ * Uses a snapshot-based reconciliation model:
+ * - Comments with an `externalId` matching an existing note's content tag are updated (last-write-wins by updatedAt).
+ * - Comments without a local match are created as new notes.
+ * - Local notes with external ID tags that are absent from the pull result are deleted.
+ *
+ * External IDs are tracked via a `sync:externalId:<value>` tag on each note.
+ */
+async function applyPulledComments(
+  todu: Todu,
+  comments: ExternalComment[],
+): Promise<{ created: number; updated: number; deleted: number }> {
+  const stats = { created: 0, updated: 0, deleted: 0 };
+
+  // Group pulled comments by task
+  const commentsByTask = new Map<string, ExternalComment[]>();
+  for (const comment of comments) {
+    const taskId = comment.externalTaskId;
+    const existing = commentsByTask.get(taskId);
+    if (existing) {
+      existing.push(comment);
+    } else {
+      commentsByTask.set(taskId, [comment]);
+    }
+  }
+
+  // Collect all task IDs that have at least one pulled comment
+  const affectedTaskIds = new Set(commentsByTask.keys());
+
+  // For each affected task, reconcile local notes with pulled comments
+  for (const taskId of affectedTaskIds) {
+    const pulledComments = commentsByTask.get(taskId) ?? [];
+    const localNotesResult = await todu.note.list({
+      entityType: "task",
+      entityId: taskId,
+    });
+    const localNotes: Note[] = localNotesResult.ok ? localNotesResult.value : [];
+
+    // Build index of local notes by external ID tag
+    const localByExternalId = new Map<string, Note>();
+    for (const note of localNotes) {
+      const externalIdTag = note.tags.find((t) => t.startsWith("sync:externalId:"));
+      if (externalIdTag) {
+        const externalId = externalIdTag.slice("sync:externalId:".length);
+        localByExternalId.set(externalId, note);
+      }
+    }
+
+    // Build set of pulled external IDs for delete detection
+    const pulledExternalIds = new Set(pulledComments.map((c) => c.externalId));
+
+    // Create or update pulled comments
+    for (const pulled of pulledComments) {
+      const localNote = localByExternalId.get(pulled.externalId);
+
+      if (!localNote) {
+        // Create new note
+        await todu.note.create({
+          content: pulled.body,
+          author: pulled.author ?? "external",
+          entityType: "task",
+          entityId: taskId,
+          tags: [`sync:externalId:${pulled.externalId}`],
+        });
+        stats.created++;
+      } else {
+        // Update if external is newer (last-write-wins by updatedAt)
+        const externalUpdatedAt = pulled.updatedAt ?? pulled.createdAt;
+        const localCreatedAt = localNote.createdAt;
+
+        if (externalUpdatedAt > localCreatedAt) {
+          await todu.note.update(localNote.id, {
+            content: pulled.body,
+          });
+          stats.updated++;
+        }
+      }
+    }
+
+    // Delete local synced notes whose external IDs are absent from pull result
+    for (const [externalId, note] of localByExternalId) {
+      if (!pulledExternalIds.has(externalId)) {
+        await todu.note.delete(note.id);
+        stats.deleted++;
+      }
+    }
+  }
+
+  return stats;
 }
 
 function formatToduError(error: ToduError): string {


### PR DESCRIPTION
## Summary

Adds comment/note sync capability to the sync-provider runtime, enabling plugins to mirror task comments with create, edit, and delete flows.

## Changes

### Core types (`@todu/core`)
- Add `TaskPushPayload` interface extending `TaskWithDetail` with `comments: Note[]`
- Update `SyncProvider.push()` to accept `TaskPushPayload[]` instead of `TaskWithDetail[]`
- Update `SyncProvider.mapFromTask()` to accept `TaskPushPayload` instead of `TaskWithDetail`

### Sync worker runtime (`@todu/daemon`)
- **Push path**: Loads task notes (`entityType: 'task'`) for each task and includes them in push payloads
- **Pull path**: Consumes `SyncProviderPullResult.comments` with snapshot-based reconciliation:
  - Creates new notes for comments with unrecognized external IDs
  - Updates existing notes when external `updatedAt` is newer (last-write-wins)
  - Deletes local synced notes whose external IDs are absent from the pull result
  - Tracks external IDs via `sync:externalId:<value>` tags on notes

### Tests
- Push includes task comments in each `TaskPushPayload`
- Pull creates new comments as notes
- Pull updates existing comments when external is newer
- Pull deletes local synced notes absent from pull result
- Pull skips update when local note is newer than external comment

### Docs
- Updated `docs/plugin-sync-provider-api.md` with comment sync contract details

Task: #2235