### PR TITLE
feat: add push result comment link updates for sync-provider notes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,7 +222,7 @@ Baseline worker lifecycle states are:
 - Generic worker plugins use `WorkerPluginRegistration` from `@todu/core` and export `workerPlugin`.
 - Sync provider plugins use `SyncProviderRegistration` from `@todu/core` and export `syncProvider`.
 - Plugin load paths validate registrations at load time before worker registration.
-- Compatibility baseline for sync providers is API-version based (current provider API version: `1`).
+- Compatibility baseline for sync providers is API-version based (current provider API version: `2`).
 - Daemon plugin module paths resolve from `TODUAI_DAEMON_PLUGIN_PATHS` first, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -27,7 +27,7 @@ Use local provider configuration for secrets and host-local runtime settings, no
 
 Compatibility is API-version based.
 
-- Host-supported provider API version: `SYNC_PROVIDER_API_VERSION` (currently `1`).
+- Host-supported provider API version: `SYNC_PROVIDER_API_VERSION` (currently `2`).
 - Every provider manifest must declare `apiVersion`.
 - Providers are loadable only when `manifest.apiVersion` matches the host-supported API version.
 - Version mismatches must fail at load time.
@@ -59,7 +59,7 @@ interface SyncProvider {
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
   pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<void>;
+  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<SyncProviderPushResult>;
   mapToTask(external: ExternalTask, project: Project): Task;
   mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
 }
@@ -82,6 +82,26 @@ The sync-provider runtime supports comment/note mirroring through pull and push 
 ### Push path
 
 Each `TaskPushPayload` in `push(...)` includes a `comments: Note[]` array containing the task's attached notes (entity type `task`). Providers can use these to detect local comment creates, edits, and deletes by comparing with external state.
+
+`push(...)` must return a `SyncProviderPushResult`:
+
+```ts
+interface SyncProviderPushCommentLink {
+  localNoteId: NoteId;
+  externalCommentId: string;
+  externalTaskId: string;
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface SyncProviderPushResult {
+  commentLinks: SyncProviderPushCommentLink[];
+}
+```
+
+The runtime applies each returned link idempotently by attaching the canonical `sync:externalId:<externalCommentId>` tag to the referenced local note. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error.
 
 ### Pull path
 

--- a/packages/core/src/sync-provider.test.ts
+++ b/packages/core/src/sync-provider.test.ts
@@ -150,7 +150,11 @@ function createValidRegistration(): SyncProviderRegistration {
           tasks: [],
         };
       },
-      async push() {},
+      async push() {
+        return {
+          commentLinks: [],
+        };
+      },
       mapToTask() {
         return {
           id: "task-1" as never,

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -1,6 +1,7 @@
 import {
   err,
   type IntegrationBinding,
+  type NoteId,
   ok,
   type Project,
   type Result,
@@ -8,7 +9,7 @@ import {
   type TaskPushPayload,
 } from "./types.js";
 
-export const SYNC_PROVIDER_API_VERSION = 1 as const;
+export const SYNC_PROVIDER_API_VERSION = 2 as const;
 
 export const SYNC_CONFLICT_RESOLUTION_POLICIES = ["last-write-wins"] as const;
 export type SyncConflictResolutionPolicy = (typeof SYNC_CONFLICT_RESOLUTION_POLICIES)[number];
@@ -52,13 +53,31 @@ export interface SyncProviderPullResult {
   comments?: ExternalComment[];
 }
 
+export interface SyncProviderPushCommentLink {
+  localNoteId: NoteId;
+  externalCommentId: string;
+  externalTaskId: string;
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+export interface SyncProviderPushResult {
+  commentLinks: SyncProviderPushCommentLink[];
+}
+
 export interface SyncProvider {
   readonly name: string;
   readonly version: string;
   initialize(config: SyncProviderConfig): Promise<void>;
   shutdown(): Promise<void>;
   pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<void>;
+  push(
+    binding: IntegrationBinding,
+    tasks: TaskPushPayload[],
+    project: Project,
+  ): Promise<SyncProviderPushResult>;
   mapToTask(external: ExternalTask, project: Project): Task;
   mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
 }

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -297,6 +297,242 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
+  it("push applies returned comment links to existing local notes", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "push" });
+    const localNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "local comment",
+      tags: ["local"],
+    });
+    const provider = createProvider({
+      push: vi.fn<SyncProvider["push"]>().mockResolvedValue({
+        commentLinks: [
+          {
+            localNoteId: localNote.id,
+            externalCommentId: "gh-comment-1",
+            externalTaskId: task.id,
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [localNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.update).toHaveBeenCalledTimes(1);
+    expect(todu.note.update).toHaveBeenCalledWith(localNote.id, {
+      tags: ["local", "sync:externalId:gh-comment-1"],
+    });
+
+    handle.stop();
+  });
+
+  it("push applies returned comment links idempotently across cycles", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "push" });
+    const localNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "local comment",
+    });
+    const provider = createProvider({
+      push: vi.fn<SyncProvider["push"]>().mockResolvedValue({
+        commentLinks: [
+          {
+            localNoteId: localNote.id,
+            externalCommentId: "gh-comment-1",
+            externalTaskId: task.id,
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [localNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(provider.push).toHaveBeenCalledTimes(2);
+    expect(todu.note.update).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+
+  it("linked local-origin comments later update remotely through the same local note", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "bidirectional" });
+    const localNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "local comment",
+    });
+    const provider = createProvider({
+      pull: vi
+        .fn<SyncProvider["pull"]>()
+        .mockResolvedValueOnce({ tasks: [], comments: [] })
+        .mockResolvedValue({
+          tasks: [],
+          comments: [
+            {
+              externalId: "gh-comment-1",
+              externalTaskId: task.id,
+              body: "remote edit",
+              createdAt: "2026-03-10T10:00:00Z",
+              updatedAt: "2026-03-10T11:00:00Z",
+            },
+          ],
+        }),
+      push: vi
+        .fn<SyncProvider["push"]>()
+        .mockResolvedValueOnce({
+          commentLinks: [
+            {
+              localNoteId: localNote.id,
+              externalCommentId: "gh-comment-1",
+              externalTaskId: task.id,
+            },
+          ],
+        })
+        .mockResolvedValue({ commentLinks: [] }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [localNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(todu.note.update).toHaveBeenNthCalledWith(1, localNote.id, {
+      tags: ["sync:externalId:gh-comment-1"],
+    });
+    expect(todu.note.update).toHaveBeenNthCalledWith(2, localNote.id, {
+      content: "remote edit",
+    });
+
+    handle.stop();
+  });
+
+  it("linked local-origin comments later delete remotely through the same local note", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "bidirectional" });
+    const localNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "local comment",
+    });
+    const provider = createProvider({
+      pull: vi
+        .fn<SyncProvider["pull"]>()
+        .mockResolvedValueOnce({ tasks: [], comments: [] })
+        .mockResolvedValue({
+          tasks: [],
+          comments: [
+            {
+              externalId: "gh-comment-other",
+              externalTaskId: task.id,
+              body: "other remote comment",
+              createdAt: "2026-03-10T10:00:00Z",
+            },
+          ],
+        }),
+      push: vi
+        .fn<SyncProvider["push"]>()
+        .mockResolvedValueOnce({
+          commentLinks: [
+            {
+              localNoteId: localNote.id,
+              externalCommentId: "gh-comment-1",
+              externalTaskId: task.id,
+            },
+          ],
+        })
+        .mockResolvedValue({ commentLinks: [] }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [localNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(todu.note.delete).toHaveBeenCalledWith(localNote.id);
+
+    handle.stop();
+  });
+
   it("pull creates new comments as notes when externalId is not present locally", async () => {
     const project = createProject();
     const task = createTask(project.id);
@@ -522,7 +758,7 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
   return {
     initialize: vi.fn<SyncProvider["initialize"]>().mockResolvedValue(undefined),
     pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({ tasks: [] }),
-    push: vi.fn<SyncProvider["push"]>().mockResolvedValue(undefined),
+    push: vi.fn<SyncProvider["push"]>().mockResolvedValue({ commentLinks: [] }),
     shutdown: vi.fn<SyncProvider["shutdown"]>().mockResolvedValue(undefined),
     mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
       id: createTaskId(String(item.externalId)),

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -4,6 +4,7 @@ import {
   type IntegrationBinding,
   type Note,
   type SyncProvider,
+  type SyncProviderPushCommentLink,
   type TaskPushPayload,
   type ToduError,
 } from "@todu/core";
@@ -14,6 +15,7 @@ import type { WorkerRuntime } from "./workers.js";
 const DEFAULT_SYNC_INTERVAL_SECONDS = 300;
 const DEFAULT_RETRY_INITIAL_SECONDS = 5;
 const DEFAULT_RETRY_MAX_SECONDS = 60;
+const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 
 export interface SyncPluginExecutionConfig {
   enabled: boolean;
@@ -257,7 +259,16 @@ export function createSyncPluginWorkerRuntime(
             pushPayloads.push({ ...taskDetail, comments });
           }
 
-          await options.provider.push(binding, pushPayloads, projectResult.value);
+          const pushResult = await options.provider.push(
+            binding,
+            pushPayloads,
+            projectResult.value,
+          );
+          if (!pushResult || !Array.isArray(pushResult.commentLinks)) {
+            throw new Error("sync provider push must return { commentLinks: [] }");
+          }
+
+          await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
         }
 
         await updateBindingStatus(activeTodu, binding, {
@@ -373,6 +384,54 @@ export function createSyncPluginWorkerRuntime(
   };
 }
 
+function createSyncExternalIdTag(externalId: string): string {
+  return `${SYNC_EXTERNAL_ID_TAG_PREFIX}${externalId}`;
+}
+
+function getSyncExternalIdFromNote(note: Note): string | null {
+  const externalIdTag = note.tags.find((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
+  if (!externalIdTag) {
+    return null;
+  }
+
+  return externalIdTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length);
+}
+
+async function applyPushCommentLinks(
+  todu: Todu,
+  links: SyncProviderPushCommentLink[],
+): Promise<void> {
+  for (const link of links) {
+    const notesResult = await todu.note.list({
+      entityType: "task",
+      entityId: link.externalTaskId,
+    });
+    const notes = notesResult.ok ? notesResult.value : [];
+    const note = notes.find((candidate) => candidate.id === link.localNoteId);
+
+    if (!note) {
+      throw new Error(
+        `push comment link references missing task note: note=${link.localNoteId} task=${link.externalTaskId}`,
+      );
+    }
+
+    const existingExternalId = getSyncExternalIdFromNote(note);
+    if (existingExternalId === link.externalCommentId) {
+      continue;
+    }
+
+    if (existingExternalId && existingExternalId !== link.externalCommentId) {
+      throw new Error(
+        `push comment link conflicts with existing note linkage: note=${link.localNoteId} existing=${existingExternalId} next=${link.externalCommentId}`,
+      );
+    }
+
+    await todu.note.update(note.id, {
+      tags: [...note.tags, createSyncExternalIdTag(link.externalCommentId)],
+    });
+  }
+}
+
 /**
  * Apply comments pulled from an external provider to local todu notes.
  *
@@ -416,9 +475,8 @@ async function applyPulledComments(
     // Build index of local notes by external ID tag
     const localByExternalId = new Map<string, Note>();
     for (const note of localNotes) {
-      const externalIdTag = note.tags.find((t) => t.startsWith("sync:externalId:"));
-      if (externalIdTag) {
-        const externalId = externalIdTag.slice("sync:externalId:".length);
+      const externalId = getSyncExternalIdFromNote(note);
+      if (externalId) {
         localByExternalId.set(externalId, note);
       }
     }
@@ -437,7 +495,7 @@ async function applyPulledComments(
           author: pulled.author ?? "external",
           entityType: "task",
           entityId: taskId,
-          tags: [`sync:externalId:${pulled.externalId}`],
+          tags: [createSyncExternalIdTag(pulled.externalId)],
         });
         stats.created++;
       } else {


### PR DESCRIPTION
## Summary

Adds push-result comment link updates so locally-created task notes can be linked to remotely-created comments and then participate in the existing pull-side reconciliation flow.

## Changes

### Core sync-provider contract
- Bump `SYNC_PROVIDER_API_VERSION` to `2`
- Add `SyncProviderPushCommentLink` and `SyncProviderPushResult`
- Change `SyncProvider.push()` to return `Promise<SyncProviderPushResult>`

### Runtime behavior
- Apply push-returned comment links to local task notes idempotently
- Attach canonical `sync:externalId:<externalCommentId>` tags to linked notes
- Reject conflicting relinks for already-linked notes
- Reuse the existing pull-side snapshot reconciliation for later remote edits/deletes

### Tests
- Push applies returned comment links to existing local notes
- Push link application is idempotent across cycles
- Linked local-origin comments later update remotely through the same local note
- Linked local-origin comments later delete remotely through the same local note

### Docs
- Update `docs/plugin-sync-provider-api.md` with push result contract
- Update `docs/ARCHITECTURE.md` provider API version reference

Task: #2237
