### PR TITLE
fix: apply pulled sync-provider tasks

### DIFF
--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -75,6 +75,17 @@ Expected lifecycle:
 4. For each applicable integration binding, call `pull(...)` and `push(...)` according to the binding strategy.
 5. Call `shutdown()` during daemon stop/unload.
 
+## Task Pull Contract
+
+`SyncProviderPullResult.tasks` accepts `ExternalTask[]`. The runtime reconciles pulled tasks within the binding's project by `externalId`:
+
+- Each pulled item is mapped through `mapToTask(external, project)`.
+- When no local task with the same `externalId` exists, the runtime creates a new task in the bound project.
+- When a matching local task exists, the runtime updates it only if the external item is newer by `updatedAt` (falling back to `createdAt` when `updatedAt` is absent).
+- Task deletions are not inferred from pull results in the current implementation.
+
+The runtime persists the pulled task's core fields, including mapped status, priority, labels, assignees, `externalId`, and `sourceUrl`. Task descriptions come from `ExternalTask.description`.
+
 ## Comment Sync Contract
 
 The sync-provider runtime supports comment/note mirroring through pull and push paths.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -287,12 +287,15 @@ export interface UpdateIntegrationBindingStatusInput {
 export interface CreateTaskInput {
   title: string;
   projectId: ProjectId;
+  status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
   labels?: string[];
   assignees?: string[];
   dueDate?: string;
   scheduledDate?: string;
+  externalId?: string;
+  sourceUrl?: string;
 }
 
 export interface UpdateTaskInput {
@@ -304,6 +307,8 @@ export interface UpdateTaskInput {
   assignees?: string[];
   dueDate?: string;
   scheduledDate?: string;
+  externalId?: string;
+  sourceUrl?: string;
 }
 
 export interface TaskFilter {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -443,6 +443,18 @@ describe("validateCreateTaskInput", () => {
     ).toBeNull();
   });
 
+  it("accepts valid sync linkage fields in create", () => {
+    expect(
+      validateCreateTaskInput({
+        title: "Test",
+        projectId,
+        status: "waiting",
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+      }),
+    ).toBeNull();
+  });
+
   it("rejects empty assignee string in create", () => {
     const error = validateCreateTaskInput({ title: "Test", projectId, assignees: [""] });
     expect(error?.field).toBe("assignees");
@@ -478,6 +490,15 @@ describe("validateCreateTaskInput", () => {
       description: "a".repeat(MAX_DESCRIPTION_LENGTH + 1),
     });
     expect(error?.field).toBe("description");
+  });
+
+  it("rejects blank externalId", () => {
+    const error = validateCreateTaskInput({
+      title: "Test",
+      projectId,
+      externalId: "   ",
+    });
+    expect(error?.field).toBe("externalId");
   });
 });
 
@@ -522,9 +543,23 @@ describe("validateUpdateTaskInput", () => {
     expect(validateUpdateTaskInput({ assignees: ["alice", "bob"] })).toBeNull();
   });
 
+  it("accepts valid sync linkage updates", () => {
+    expect(
+      validateUpdateTaskInput({
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+      }),
+    ).toBeNull();
+  });
+
   it("rejects empty assignee string in update", () => {
     const error = validateUpdateTaskInput({ assignees: [""] });
     expect(error?.field).toBe("assignees");
+  });
+
+  it("rejects blank sourceUrl update", () => {
+    const error = validateUpdateTaskInput({ sourceUrl: "   " });
+    expect(error?.field).toBe("sourceUrl");
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -315,6 +315,17 @@ export function validateTaskTitle(title: string): ValidationError | null {
   return null;
 }
 
+function validateTaskLinkField(
+  field: "externalId" | "sourceUrl",
+  value: string,
+): ValidationError | null {
+  if (value.trim().length === 0) {
+    return validationError(field, `${field} is required`);
+  }
+
+  return null;
+}
+
 export function validateISODate(field: string, value: string): ValidationError | null {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -330,6 +341,10 @@ export function validateCreateTaskInput(input: CreateTaskInput): ValidationError
   if (input.description !== undefined) {
     const descError = validateDescription(input.description);
     if (descError) return descError;
+  }
+
+  if (input.status !== undefined && !isTaskStatus(input.status)) {
+    return validationError("status", `Invalid status: ${input.status}`);
   }
 
   if (input.priority !== undefined && !isTaskPriority(input.priority)) {
@@ -351,6 +366,16 @@ export function validateCreateTaskInput(input: CreateTaskInput): ValidationError
     if (dateError) return dateError;
   }
 
+  if (input.externalId !== undefined) {
+    const externalIdError = validateTaskLinkField("externalId", input.externalId);
+    if (externalIdError) return externalIdError;
+  }
+
+  if (input.sourceUrl !== undefined) {
+    const sourceUrlError = validateTaskLinkField("sourceUrl", input.sourceUrl);
+    if (sourceUrlError) return sourceUrlError;
+  }
+
   return null;
 }
 
@@ -366,7 +391,9 @@ export function validateUpdateTaskInput(
     input.labels === undefined &&
     input.assignees === undefined &&
     input.dueDate === undefined &&
-    input.scheduledDate === undefined
+    input.scheduledDate === undefined &&
+    input.externalId === undefined &&
+    input.sourceUrl === undefined
   ) {
     return validationError("input", "At least one field must be provided");
   }
@@ -410,6 +437,16 @@ export function validateUpdateTaskInput(
   if (input.scheduledDate !== undefined) {
     const dateError = validateISODate("scheduledDate", input.scheduledDate);
     if (dateError) return dateError;
+  }
+
+  if (input.externalId !== undefined) {
+    const externalIdError = validateTaskLinkField("externalId", input.externalId);
+    if (externalIdError) return externalIdError;
+  }
+
+  if (input.sourceUrl !== undefined) {
+    const sourceUrlError = validateTaskLinkField("sourceUrl", input.sourceUrl);
+    if (sourceUrlError) return sourceUrlError;
   }
 
   return null;

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   createProjectId,
   createTaskId,
   type ExternalComment,
+  type ExternalTask,
   type IntegrationBinding,
   type IntegrationBindingStatus,
   type Note,
@@ -533,6 +534,200 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
+  it("pull creates new tasks from pulled external tasks", async () => {
+    const project = createProject();
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledTasks: ExternalTask[] = [
+      {
+        externalId: "gh-101",
+        title: "Pulled bug",
+        description: "Imported from GitHub",
+        sourceUrl: "https://example.com/issues/101",
+        updatedAt: "2026-03-10T15:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: pulledTasks,
+      }),
+      mapToTask: vi
+        .fn<SyncProvider["mapToTask"]>()
+        .mockImplementation((external, activeProject) => ({
+          id: createTaskId(`task-${external.externalId}`),
+          title: external.title,
+          status: "waiting",
+          priority: "high",
+          projectId: activeProject.id,
+          labels: ["bug"],
+          assignees: ["octocat"],
+          sourceUrl: external.sourceUrl,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        })),
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(provider.mapToTask).toHaveBeenCalledTimes(1);
+    expect(provider.mapToTask).toHaveBeenCalledWith(pulledTasks[0], project);
+    expect(todu.task.create).toHaveBeenCalledTimes(1);
+    expect(todu.task.create).toHaveBeenCalledWith({
+      title: "Pulled bug",
+      projectId: project.id,
+      status: "waiting",
+      priority: "high",
+      description: "Imported from GitHub",
+      labels: ["bug"],
+      assignees: ["octocat"],
+      externalId: "gh-101",
+      sourceUrl: "https://example.com/issues/101",
+    });
+
+    handle.stop();
+  });
+
+  it("pull updates existing tasks when external updatedAt is newer", async () => {
+    const project = createProject();
+    const existingTask = {
+      ...createTask(project.id),
+      externalId: "gh-101",
+      updatedAt: "2026-03-09T10:00:00Z",
+    };
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledTasks: ExternalTask[] = [
+      {
+        externalId: "gh-101",
+        title: "Updated pulled bug",
+        description: "Updated from GitHub",
+        sourceUrl: "https://example.com/issues/101",
+        updatedAt: "2026-03-10T15:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: pulledTasks,
+      }),
+      mapToTask: vi
+        .fn<SyncProvider["mapToTask"]>()
+        .mockImplementation((external, activeProject) => ({
+          id: existingTask.id,
+          title: external.title,
+          status: "inprogress",
+          priority: "high",
+          projectId: activeProject.id,
+          labels: ["bug", "synced"],
+          assignees: ["octocat"],
+          sourceUrl: external.sourceUrl,
+          createdAt: existingTask.createdAt,
+          updatedAt: external.updatedAt ?? existingTask.updatedAt,
+        })),
+    });
+    const todu = createTodu(project, [existingTask], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.update).toHaveBeenCalledTimes(1);
+    expect(todu.task.update).toHaveBeenCalledWith(existingTask.id, {
+      title: "Updated pulled bug",
+      status: "inprogress",
+      priority: "high",
+      description: "Updated from GitHub",
+      labels: ["bug", "synced"],
+      assignees: ["octocat"],
+      externalId: "gh-101",
+      sourceUrl: "https://example.com/issues/101",
+    });
+
+    handle.stop();
+  });
+
+  it("pull skips existing task updates when local task is newer", async () => {
+    const project = createProject();
+    const existingTask = {
+      ...createTask(project.id),
+      externalId: "gh-101",
+      updatedAt: "2026-03-10T20:00:00Z",
+    };
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledTasks: ExternalTask[] = [
+      {
+        externalId: "gh-101",
+        title: "Older pulled bug",
+        description: "Older external state",
+        updatedAt: "2026-03-10T12:00:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: pulledTasks,
+      }),
+    });
+    const todu = createTodu(project, [existingTask], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(provider.mapToTask).toHaveBeenCalledTimes(1);
+    expect(todu.task.update).not.toHaveBeenCalled();
+    expect(todu.task.create).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
+
   it("pull creates new comments as notes when externalId is not present locally", async () => {
     const project = createProject();
     const task = createTask(project.id);
@@ -763,7 +958,7 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
     mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
       id: createTaskId(String(item.externalId)),
       title: item.title,
-      status: "todo",
+      status: "active",
       priority: "medium",
       projectId: createProject().id,
       labels: [],
@@ -800,7 +995,7 @@ function createTask(projectId: Project["id"]): Task {
   return {
     id: createTaskId("task-1"),
     title: "Task",
-    status: "todo",
+    status: "active",
     priority: "medium",
     projectId,
     labels: [],
@@ -849,7 +1044,7 @@ interface CreateToduOptions {
 
 function createTodu(
   project: Project,
-  tasks: Task[],
+  initialTasks: Task[],
   bindings: IntegrationBinding[],
   options: CreateToduOptions = {},
 ): {
@@ -858,6 +1053,12 @@ function createTodu(
     list: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
   };
+  task: {
+    list: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
   note: {
     list: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
@@ -865,6 +1066,7 @@ function createTodu(
     delete: ReturnType<typeof vi.fn>;
   };
 } {
+  const tasks: Task[] = [...initialTasks];
   const notes: Note[] = [...(options.notes ?? [])];
   const statuses = new Map<string, IntegrationBindingStatus>();
   const integrationList = vi.fn(async (filter?: { provider?: string; enabled?: boolean }) => {
@@ -925,11 +1127,79 @@ function createTodu(
     },
   );
 
+  const taskList = vi.fn().mockImplementation(async (filter?: { projectId?: string }) => {
+    if (!filter?.projectId) {
+      return ok([...tasks]);
+    }
+
+    return ok(tasks.filter((task) => task.projectId === filter.projectId));
+  });
+
   const taskGet = vi.fn().mockImplementation(async (id: string) => {
     const task = tasks.find((t) => t.id === id);
     if (!task) return ok({ id, description: undefined });
     return ok({ ...task, description: undefined });
   });
+
+  const taskCreate = vi
+    .fn()
+    .mockImplementation(
+      async (input: {
+        title: string;
+        projectId: string;
+        status?: Task["status"];
+        priority?: Task["priority"];
+        description?: string;
+        labels?: string[];
+        assignees?: string[];
+        externalId?: string;
+        sourceUrl?: string;
+      }) => {
+        const createdTask: Task = {
+          id: createTaskId(`task-created-${tasks.length + 1}`),
+          title: input.title,
+          status: input.status ?? "active",
+          priority: input.priority ?? "medium",
+          projectId: input.projectId as Project["id"],
+          labels: input.labels ?? [],
+          assignees: input.assignees ?? [],
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        };
+        if (input.externalId !== undefined) createdTask.externalId = input.externalId;
+        if (input.sourceUrl !== undefined) createdTask.sourceUrl = input.sourceUrl;
+        tasks.push(createdTask);
+        return ok({ ...createdTask, description: input.description });
+      },
+    );
+
+  const taskUpdate = vi.fn().mockImplementation(
+    async (
+      id: string,
+      input: {
+        title?: string;
+        status?: Task["status"];
+        priority?: Task["priority"];
+        description?: string;
+        labels?: string[];
+        assignees?: string[];
+        externalId?: string;
+        sourceUrl?: string;
+      },
+    ) => {
+      const task = tasks.find((candidate) => candidate.id === id);
+      if (!task) return ok(undefined);
+      if (input.title !== undefined) task.title = input.title;
+      if (input.status !== undefined) task.status = input.status;
+      if (input.priority !== undefined) task.priority = input.priority;
+      if (input.labels !== undefined) task.labels = [...input.labels];
+      if (input.assignees !== undefined) task.assignees = [...input.assignees];
+      if (input.externalId !== undefined) task.externalId = input.externalId;
+      if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl;
+      task.updatedAt = new Date(0).toISOString();
+      return ok({ ...task, description: input.description });
+    },
+  );
 
   let noteIdCounter = 1;
   const noteList = vi.fn(
@@ -991,8 +1261,10 @@ function createTodu(
         get: vi.fn().mockResolvedValue(ok(project)),
       },
       task: {
-        list: vi.fn().mockResolvedValue(ok(tasks)),
+        list: taskList,
         get: taskGet,
+        create: taskCreate,
+        update: taskUpdate,
       },
       integration: {
         list: integrationList,
@@ -1008,6 +1280,12 @@ function createTodu(
     integration: {
       list: integrationList,
       updateStatus,
+    },
+    task: {
+      list: taskList,
+      get: taskGet,
+      create: taskCreate,
+      update: taskUpdate,
     },
     note: {
       list: noteList,

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -1,10 +1,13 @@
 import {
   createProjectId,
   type ExternalComment,
+  type ExternalTask,
   type IntegrationBinding,
   type Note,
+  type Project,
   type SyncProvider,
   type SyncProviderPushCommentLink,
+  type Task,
   type TaskPushPayload,
   type ToduError,
 } from "@todu/core";
@@ -232,6 +235,15 @@ export function createSyncPluginWorkerRuntime(
         if (binding.strategy === "pull" || binding.strategy === "bidirectional") {
           const pullResult = await options.provider.pull(binding, projectResult.value);
 
+          if (pullResult.tasks.length > 0) {
+            await applyPulledTasks(
+              activeTodu,
+              options.provider,
+              projectResult.value,
+              pullResult.tasks,
+            );
+          }
+
           if (pullResult.comments && pullResult.comments.length > 0) {
             await applyPulledComments(activeTodu, pullResult.comments);
           }
@@ -395,6 +407,161 @@ function getSyncExternalIdFromNote(note: Note): string | null {
   }
 
   return externalIdTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length);
+}
+
+function getPulledTaskTimestamp(task: ExternalTask): string | null {
+  return task.updatedAt ?? task.createdAt ?? null;
+}
+
+function buildPulledTaskCreateInput(
+  mappedTask: Task,
+  project: Project,
+  externalTask: ExternalTask,
+): {
+  title: string;
+  projectId: Project["id"];
+  status: Task["status"];
+  priority: Task["priority"];
+  description?: string;
+  labels: string[];
+  assignees: string[];
+  externalId: string;
+  sourceUrl?: string;
+} {
+  const input: {
+    title: string;
+    projectId: Project["id"];
+    status: Task["status"];
+    priority: Task["priority"];
+    description?: string;
+    labels: string[];
+    assignees: string[];
+    externalId: string;
+    sourceUrl?: string;
+  } = {
+    title: mappedTask.title,
+    projectId: project.id,
+    status: mappedTask.status,
+    priority: mappedTask.priority,
+    labels: mappedTask.labels,
+    assignees: mappedTask.assignees,
+    externalId: mappedTask.externalId ?? externalTask.externalId,
+  };
+
+  if (externalTask.description !== undefined) {
+    input.description = externalTask.description;
+  }
+
+  const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
+  if (sourceUrl !== undefined) {
+    input.sourceUrl = sourceUrl;
+  }
+
+  return input;
+}
+
+function buildPulledTaskUpdateInput(
+  mappedTask: Task,
+  externalTask: ExternalTask,
+): {
+  title: string;
+  status: Task["status"];
+  priority: Task["priority"];
+  description?: string;
+  labels: string[];
+  assignees: string[];
+  externalId: string;
+  sourceUrl?: string;
+} {
+  const input: {
+    title: string;
+    status: Task["status"];
+    priority: Task["priority"];
+    description?: string;
+    labels: string[];
+    assignees: string[];
+    externalId: string;
+    sourceUrl?: string;
+  } = {
+    title: mappedTask.title,
+    status: mappedTask.status,
+    priority: mappedTask.priority,
+    labels: mappedTask.labels,
+    assignees: mappedTask.assignees,
+    externalId: mappedTask.externalId ?? externalTask.externalId,
+  };
+
+  if (externalTask.description !== undefined) {
+    input.description = externalTask.description;
+  }
+
+  const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
+  if (sourceUrl !== undefined) {
+    input.sourceUrl = sourceUrl;
+  }
+
+  return input;
+}
+
+async function applyPulledTasks(
+  todu: Todu,
+  provider: SyncProvider,
+  project: Project,
+  tasks: ExternalTask[],
+): Promise<{ created: number; updated: number; skipped: number }> {
+  const stats = { created: 0, updated: 0, skipped: 0 };
+  const tasksResult = await todu.task.list({ projectId: project.id });
+  if (!tasksResult.ok) {
+    throw new Error(`pulled task list failed: ${formatToduError(tasksResult.error)}`);
+  }
+
+  const localByExternalId = new Map<string, Task>();
+  for (const task of tasksResult.value) {
+    if (task.externalId) {
+      localByExternalId.set(task.externalId, task);
+    }
+  }
+
+  for (const externalTask of tasks) {
+    const mappedTask = provider.mapToTask(externalTask, project);
+    const existingTask = localByExternalId.get(externalTask.externalId);
+    const externalUpdatedAt = getPulledTaskTimestamp(externalTask);
+
+    if (!existingTask) {
+      const createResult = await todu.task.create(
+        buildPulledTaskCreateInput(mappedTask, project, externalTask),
+      );
+      if (!createResult.ok) {
+        throw new Error(
+          `pulled task create failed: externalId=${externalTask.externalId} error=${formatToduError(createResult.error)}`,
+        );
+      }
+
+      localByExternalId.set(externalTask.externalId, createResult.value);
+      stats.created += 1;
+      continue;
+    }
+
+    if (externalUpdatedAt && externalUpdatedAt <= existingTask.updatedAt) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    const updateResult = await todu.task.update(
+      existingTask.id,
+      buildPulledTaskUpdateInput(mappedTask, externalTask),
+    );
+    if (!updateResult.ok) {
+      throw new Error(
+        `pulled task update failed: task=${existingTask.id} externalId=${externalTask.externalId} error=${formatToduError(updateResult.error)}`,
+      );
+    }
+
+    localByExternalId.set(externalTask.externalId, updateResult.value);
+    stats.updated += 1;
+  }
+
+  return stats;
 }
 
 async function applyPushCommentLinks(

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -75,6 +75,22 @@ describe("task namespace", () => {
       expect(result.value.scheduledDate).toBe("2026-03-30");
     });
 
+    it("creates a task with sync linkage fields", async () => {
+      const result = await todu.task.create({
+        title: "Synced Task",
+        projectId,
+        status: "waiting",
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.status).toBe("waiting");
+      expect(result.value.externalId).toBe("gh-101");
+      expect(result.value.sourceUrl).toBe("https://example.com/issues/101");
+    });
+
     it("trims whitespace from title", async () => {
       const result = await todu.task.create({ title: "  Trimmed  ", projectId });
       expect(result.ok).toBe(true);
@@ -348,6 +364,17 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.assignees).toEqual(["alice", "bob"]);
+    });
+
+    it("updates sync linkage fields", async () => {
+      const result = await todu.task.update(taskId, {
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.externalId).toBe("gh-101");
+      expect(result.value.sourceUrl).toBe("https://example.com/issues/101");
     });
 
     it("replaces assignees entirely on update", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -132,7 +132,7 @@ export function createTaskNamespace(
       const task: Task = {
         id,
         title: input.title.trim(),
-        status: "active",
+        status: input.status ?? "active",
         priority: input.priority ?? "medium",
         projectId: input.projectId,
         labels: input.labels ?? [],
@@ -143,6 +143,8 @@ export function createTaskNamespace(
       // Automerge doesn't allow undefined — only set optional fields if present
       if (input.dueDate !== undefined) task.dueDate = input.dueDate;
       if (input.scheduledDate !== undefined) task.scheduledDate = input.scheduledDate;
+      if (input.externalId !== undefined) task.externalId = input.externalId.trim();
+      if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
       if (templateId !== undefined) task.templateId = templateId;
 
       // Add to task list document
@@ -300,6 +302,8 @@ export function createTaskNamespace(
         }
         if (input.dueDate !== undefined) task.dueDate = input.dueDate;
         if (input.scheduledDate !== undefined) task.scheduledDate = input.scheduledDate;
+        if (input.externalId !== undefined) task.externalId = input.externalId.trim();
+        if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
         task.updatedAt = now;
       });
 


### PR DESCRIPTION
## Summary

Process `pullResult.tasks` in the daemon sync worker so pulled external tasks are mapped and persisted instead of silently discarded.

## Task

- #2242
- Closes #315

## Changes

- add pulled-task reconciliation in `packages/daemon/src/sync-worker-runtime.ts`
- map pulled external tasks with `provider.mapToTask(...)`
- create missing local tasks and update existing tasks when the external task is newer
- extend task create/update inputs to persist sync linkage fields (`status`, `externalId`, `sourceUrl`)
- add unit coverage for pulled-task reconciliation and validation
- document pulled task behavior in the sync provider API guide

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
