### PR TITLE
fix: apply pushed task links

### DIFF
--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -107,12 +107,21 @@ interface SyncProviderPushCommentLink {
   raw?: unknown;
 }
 
+interface SyncProviderPushTaskLink {
+  localTaskId: TaskId;
+  externalId: string;
+  sourceUrl?: string;
+}
+
 interface SyncProviderPushResult {
   commentLinks: SyncProviderPushCommentLink[];
+  taskLinks: SyncProviderPushTaskLink[];
 }
 ```
 
-The runtime applies each returned link idempotently by attaching the canonical `sync:externalId:<externalCommentId>` tag to the referenced local note. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error.
+The runtime applies returned `taskLinks` first, writing back task linkage for pushed local tasks so later pull cycles deduplicate by `externalId`. Returning the same task link again is a no-op. Returning a conflicting task link for a task that is already linked to a different external item is treated as a runtime error.
+
+The runtime then applies each returned comment link idempotently by attaching the canonical `sync:externalId:<externalCommentId>` tag to the referenced local note. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error.
 
 ### Pull path
 

--- a/packages/core/src/sync-provider.test.ts
+++ b/packages/core/src/sync-provider.test.ts
@@ -153,6 +153,7 @@ function createValidRegistration(): SyncProviderRegistration {
       async push() {
         return {
           commentLinks: [],
+          taskLinks: [],
         };
       },
       mapToTask() {

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -6,6 +6,7 @@ import {
   type Project,
   type Result,
   type Task,
+  type TaskId,
   type TaskPushPayload,
 } from "./types.js";
 
@@ -63,8 +64,15 @@ export interface SyncProviderPushCommentLink {
   raw?: unknown;
 }
 
+export interface SyncProviderPushTaskLink {
+  localTaskId: TaskId;
+  externalId: string;
+  sourceUrl?: string;
+}
+
 export interface SyncProviderPushResult {
   commentLinks: SyncProviderPushCommentLink[];
+  taskLinks: SyncProviderPushTaskLink[];
 }
 
 export interface SyncProvider {

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -298,6 +298,228 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
+  it("push applies returned task links to existing local tasks", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "push" });
+    const provider = createProvider({
+      push: vi.fn<SyncProvider["push"]>().mockResolvedValue({
+        commentLinks: [],
+        taskLinks: [
+          {
+            localTaskId: task.id,
+            externalId: "gh-101",
+            sourceUrl: "https://example.com/issues/101",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.update).toHaveBeenCalledTimes(1);
+    expect(todu.task.update).toHaveBeenCalledWith(task.id, {
+      externalId: "gh-101",
+      sourceUrl: "https://example.com/issues/101",
+    });
+
+    handle.stop();
+  });
+
+  it("push applies returned task links idempotently across cycles", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "push" });
+    const provider = createProvider({
+      push: vi.fn<SyncProvider["push"]>().mockResolvedValue({
+        commentLinks: [],
+        taskLinks: [
+          {
+            localTaskId: task.id,
+            externalId: "gh-101",
+            sourceUrl: "https://example.com/issues/101",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(provider.push).toHaveBeenCalledTimes(2);
+    expect(todu.task.update).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+
+  it("push task links prevent duplicate task import on later pull cycles", async () => {
+    const project = createProject();
+    const task = createTask(project.id);
+    const binding = createBinding(project.id, { strategy: "bidirectional" });
+    const provider = createProvider({
+      pull: vi
+        .fn<SyncProvider["pull"]>()
+        .mockResolvedValueOnce({ tasks: [], comments: [] })
+        .mockResolvedValue({
+          tasks: [
+            {
+              externalId: "gh-101",
+              title: task.title,
+              updatedAt: new Date(0).toISOString(),
+            },
+          ],
+          comments: [],
+        }),
+      push: vi
+        .fn<SyncProvider["push"]>()
+        .mockResolvedValueOnce({
+          commentLinks: [],
+          taskLinks: [
+            {
+              localTaskId: task.id,
+              externalId: "gh-101",
+              sourceUrl: "https://example.com/issues/101",
+            },
+          ],
+        })
+        .mockResolvedValue({ commentLinks: [], taskLinks: [] }),
+      mapToTask: vi
+        .fn<SyncProvider["mapToTask"]>()
+        .mockImplementation((external, activeProject) => ({
+          id: task.id,
+          title: external.title,
+          status: "active",
+          priority: "medium",
+          projectId: activeProject.id,
+          labels: [],
+          assignees: [],
+          externalId: external.externalId,
+          sourceUrl: external.sourceUrl,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        })),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(todu.task.create).not.toHaveBeenCalled();
+    expect(todu.task.update).toHaveBeenCalledTimes(1);
+    expect(todu.task.update).toHaveBeenCalledWith(task.id, {
+      externalId: "gh-101",
+      sourceUrl: "https://example.com/issues/101",
+    });
+
+    handle.stop();
+  });
+
+  it("push task links fail on conflicting existing linkage", async () => {
+    const project = createProject();
+    const task = {
+      ...createTask(project.id),
+      externalId: "gh-existing",
+    };
+    const binding = createBinding(project.id, { strategy: "push" });
+    const provider = createProvider({
+      push: vi.fn<SyncProvider["push"]>().mockResolvedValue({
+        commentLinks: [],
+        taskLinks: [
+          {
+            localTaskId: task.id,
+            externalId: "gh-other",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const statusTransitions = todu.integration.updateStatus.mock.calls
+      .map((call) => call[1]?.state)
+      .filter((value) => value !== undefined);
+
+    expect(statusTransitions).toEqual(["running", "error"]);
+    expect(todu.task.update).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
+
   it("push applies returned comment links to existing local notes", async () => {
     const project = createProject();
     const task = createTask(project.id);
@@ -317,6 +539,7 @@ describe("sync-worker-runtime", () => {
             externalTaskId: task.id,
           },
         ],
+        taskLinks: [],
       }),
     });
     const todu = createTodu(project, [task], [binding], { notes: [localNote] });
@@ -367,6 +590,7 @@ describe("sync-worker-runtime", () => {
             externalTaskId: task.id,
           },
         ],
+        taskLinks: [],
       }),
     });
     const todu = createTodu(project, [task], [binding], { notes: [localNote] });
@@ -433,8 +657,9 @@ describe("sync-worker-runtime", () => {
               externalTaskId: task.id,
             },
           ],
+          taskLinks: [],
         })
-        .mockResolvedValue({ commentLinks: [] }),
+        .mockResolvedValue({ commentLinks: [], taskLinks: [] }),
     });
     const todu = createTodu(project, [task], [binding], { notes: [localNote] });
 
@@ -503,8 +728,9 @@ describe("sync-worker-runtime", () => {
               externalTaskId: task.id,
             },
           ],
+          taskLinks: [],
         })
-        .mockResolvedValue({ commentLinks: [] }),
+        .mockResolvedValue({ commentLinks: [], taskLinks: [] }),
     });
     const todu = createTodu(project, [task], [binding], { notes: [localNote] });
 
@@ -953,7 +1179,7 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
   return {
     initialize: vi.fn<SyncProvider["initialize"]>().mockResolvedValue(undefined),
     pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({ tasks: [] }),
-    push: vi.fn<SyncProvider["push"]>().mockResolvedValue({ commentLinks: [] }),
+    push: vi.fn<SyncProvider["push"]>().mockResolvedValue({ commentLinks: [], taskLinks: [] }),
     shutdown: vi.fn<SyncProvider["shutdown"]>().mockResolvedValue(undefined),
     mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
       id: createTaskId(String(item.externalId)),

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -7,6 +7,7 @@ import {
   type Project,
   type SyncProvider,
   type SyncProviderPushCommentLink,
+  type SyncProviderPushTaskLink,
   type Task,
   type TaskPushPayload,
   type ToduError,
@@ -276,10 +277,15 @@ export function createSyncPluginWorkerRuntime(
             pushPayloads,
             projectResult.value,
           );
-          if (!pushResult || !Array.isArray(pushResult.commentLinks)) {
-            throw new Error("sync provider push must return { commentLinks: [] }");
+          if (
+            !pushResult ||
+            !Array.isArray(pushResult.commentLinks) ||
+            !Array.isArray(pushResult.taskLinks)
+          ) {
+            throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
           }
 
+          await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
           await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
         }
 
@@ -407,6 +413,48 @@ function getSyncExternalIdFromNote(note: Note): string | null {
   }
 
   return externalIdTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length);
+}
+
+async function applyPushTaskLinks(todu: Todu, links: SyncProviderPushTaskLink[]): Promise<void> {
+  for (const link of links) {
+    const taskResult = await todu.task.get(link.localTaskId);
+    if (!taskResult.ok) {
+      throw new Error(
+        `push task link references missing local task: task=${link.localTaskId} error=${formatToduError(taskResult.error)}`,
+      );
+    }
+
+    const task = taskResult.value;
+    if (task.externalId && task.externalId !== link.externalId) {
+      throw new Error(
+        `push task link conflicts with existing task linkage: task=${link.localTaskId} existing=${task.externalId} next=${link.externalId}`,
+      );
+    }
+
+    const updateInput: {
+      externalId?: string;
+      sourceUrl?: string;
+    } = {};
+
+    if (!task.externalId) {
+      updateInput.externalId = link.externalId;
+    }
+
+    if (link.sourceUrl !== undefined && task.sourceUrl !== link.sourceUrl) {
+      updateInput.sourceUrl = link.sourceUrl;
+    }
+
+    if (updateInput.externalId === undefined && updateInput.sourceUrl === undefined) {
+      continue;
+    }
+
+    const updateResult = await todu.task.update(task.id, updateInput);
+    if (!updateResult.ok) {
+      throw new Error(
+        `push task link update failed: task=${link.localTaskId} externalId=${link.externalId} error=${formatToduError(updateResult.error)}`,
+      );
+    }
+  }
 }
 
 function getPulledTaskTimestamp(task: ExternalTask): string | null {


### PR DESCRIPTION
## Summary

Persist task mappings returned from sync-provider push results so later pull cycles deduplicate local tasks by external ID instead of re-importing them as duplicates.

## Task

- #2245
- Closes #317

## Changes

- add `taskLinks` to `SyncProviderPushResult`
- apply returned task links in the daemon before comment links
- write back `externalId` and `sourceUrl` onto local tasks
- fail clearly when a provider returns a conflicting task mapping
- add unit coverage for task-link application, idempotence, conflict handling, and duplicate-prevention behavior
- update sync-provider API docs for the push result contract

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] `./scripts/pre-pr.sh` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
- [x] No integration tests run locally (per task constraints)
