### PR TITLE
fix: avoid recurring DST startup hangs

### DIFF
--- a/packages/engine/src/schedule.test.ts
+++ b/packages/engine/src/schedule.test.ts
@@ -64,6 +64,21 @@ describe("nextOccurrence", () => {
     expect(next).toBe("2026-02-07");
   });
 
+  it("advances past DST transitions without returning the same local date", () => {
+    const next = nextOccurrence("FREQ=DAILY", "2026-03-03", "America/Chicago", "2026-03-09");
+    expect(next).toBe("2026-03-10");
+  });
+
+  it("advances weekly schedules past DST transitions without returning the same local date", () => {
+    const next = nextOccurrence(
+      "FREQ=WEEKLY;BYDAY=MO",
+      "2026-03-02",
+      "America/Chicago",
+      "2026-03-09",
+    );
+    expect(next).toBe("2026-03-16");
+  });
+
   it("skips weekends for weekday rule", () => {
     // FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR — every weekday
     // Feb 6, 2026 is Friday. Next weekday is Monday Feb 9.
@@ -177,6 +192,10 @@ describe("isScheduledDate", () => {
 
   it("returns false for invalid RRULE", () => {
     expect(isScheduledDate("INVALID", "2026-01-01", "UTC", "2026-02-06")).toBe(false);
+  });
+
+  it("recognizes scheduled dates after DST transitions", () => {
+    expect(isScheduledDate("FREQ=DAILY", "2026-03-03", "America/Chicago", "2026-03-10")).toBe(true);
   });
 
   it("handles interval correctly", () => {

--- a/packages/engine/src/schedule.ts
+++ b/packages/engine/src/schedule.ts
@@ -88,18 +88,29 @@ export function nextOccurrence(
   const parsed = parseRule(rule, startDate, timezone);
   if (parsed.error) return null;
 
-  const after = dateStringToUTC(afterDate, timezone);
-  const next = parsed.rrule.after(after);
+  let cursor = dateStringToUTC(afterDate, timezone);
 
-  if (!next) return null;
+  for (let attempts = 0; attempts < 32; attempts += 1) {
+    const next = parsed.rrule.after(cursor);
 
-  // Convert back to date string in the template's timezone
-  const dateStr = utcToDateString(next, timezone);
+    if (!next) return null;
 
-  // Check against end date
-  if (endDate && dateStr > endDate) return null;
+    // Convert back to date string in the template's timezone.
+    // Around DST transitions, the recurrence library can advance to a later
+    // instant that still formats to the same local calendar date.
+    const dateStr = utcToDateString(next, timezone);
+    if (dateStr <= afterDate) {
+      cursor = next;
+      continue;
+    }
 
-  return dateStr;
+    // Check against end date
+    if (endDate && dateStr > endDate) return null;
+
+    return dateStr;
+  }
+
+  return null;
 }
 
 /**
@@ -161,22 +172,13 @@ export function isScheduledDate(
   date: string,
   endDate?: string,
 ): boolean {
-  const parsed = parseRule(rule, startDate, timezone);
-  if (parsed.error) return false;
-
   // Check if date is within bounds
   if (date < startDate) return false;
   if (endDate && date > endDate) return false;
 
-  // Check the day before to see if this date is the next occurrence
+  // Check the day before to see if this date is the next local occurrence.
   const dayBefore = shiftDate(date, -1);
-  const after = dateStringToUTC(dayBefore, timezone);
-  const next = parsed.rrule.after(after);
-
-  if (!next) return false;
-
-  const nextStr = utcToDateString(next, timezone);
-  return nextStr === date;
+  return nextOccurrence(rule, startDate, timezone, dayBefore, endDate) === date;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fix the recurring-worker startup hang caused by DST-transition recurrence calculations returning the same local date instead of making forward progress.

## Task

- #2267

## Changes

- make `nextOccurrence(...)` skip same-day recurrence results that can appear across DST transitions in timezone-based schedules
- route `isScheduledDate(...)` through `nextOccurrence(...)` so date validation uses the same corrected local-date progression logic
- add regression tests covering daily and weekly America/Chicago DST-transition cases plus scheduled-date validation after DST

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] `make pre-pr` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included

## Manual verification

- reproduced the startup hang locally by starting a daemon runtime against a copy of existing local data with `packages/recurring-worker/dist/index.js` configured
- verified the runtime previously hung after `plugin loaded`
- verified after the fix that the worker starts and `daemon runtime started` is logged successfully
