### PR TITLE
Fix legacy task list crashes when arrays are missing

### DIFF
--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -1,11 +1,51 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ProjectId, TaskId } from "@todu/core";
+import { Repo } from "@automerge/automerge-repo";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
 import { createProjectId, createTaskId } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
+
+async function removeTaskArrays(
+  storagePath: string,
+  projectId: ProjectId,
+  taskId: TaskId,
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    const taskListDocId = catalogHandle.doc()?.taskListDocIds[projectId];
+    if (!taskListDocId) {
+      throw new Error(`task list not found for project ${projectId}`);
+    }
+
+    const taskListHandle = await repo.find<TaskListDocument>(taskListDocId);
+    await taskListHandle.whenReady();
+    taskListHandle.change((doc) => {
+      const legacyTask = doc.tasks.find((task) => task.id === taskId) as
+        | (Task & { labels?: string[]; assignees?: string[] })
+        | undefined;
+      if (!legacyTask) {
+        throw new Error(`task not found: ${taskId}`);
+      }
+
+      delete legacyTask.labels;
+      delete legacyTask.assignees;
+    });
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
 
 describe("task namespace", () => {
   let tmpDir: string;
@@ -132,6 +172,26 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value).toHaveLength(2);
+    });
+
+    it("lists legacy tasks missing labels and assignees", async () => {
+      const created = await todu.task.create({ title: "Legacy task", projectId });
+      if (!created.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await removeTaskArrays(tmpDir, projectId, created.value.id);
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.task.list();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].title).toBe("Legacy task");
+      expect(result.value[0].labels).toEqual([]);
+      expect(result.value[0].assignees).toEqual([]);
     });
 
     it("filters by status", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -53,6 +53,40 @@ export function createTaskNamespace(
   catalog: DocHandle<CatalogDocument>,
   repo: Repo,
 ): InternalTaskNamespace {
+  function migrateTaskListDoc(handle: DocHandle<TaskListDocument>): void {
+    const doc = handle.doc();
+    if (!doc) return;
+
+    const tasks = doc.tasks ?? [];
+    const needsMigration =
+      doc.detailDocIds === undefined ||
+      doc.detailDocIds === null ||
+      tasks.some((task) => task.labels === undefined || task.labels === null) ||
+      tasks.some((task) => task.assignees === undefined || task.assignees === null);
+
+    if (!needsMigration) return;
+
+    handle.change((d) => {
+      if (d.detailDocIds === undefined || d.detailDocIds === null) {
+        d.detailDocIds = {};
+      }
+      for (const task of d.tasks) {
+        if (task.labels === undefined || task.labels === null) {
+          task.labels = [];
+        }
+        if (task.assignees === undefined || task.assignees === null) {
+          task.assignees = [];
+        }
+      }
+    });
+  }
+
+  async function loadTaskListDoc(docId: string): Promise<DocHandle<TaskListDocument>> {
+    const handle = await repo.find<TaskListDocument>(docId as DocumentId);
+    migrateTaskListDoc(handle);
+    return handle;
+  }
+
   /**
    * Get or create the TaskListDocument for a project.
    * Stores the document ID in catalog.taskListDocIds.
@@ -64,7 +98,7 @@ export function createTaskNamespace(
     const existingDocId = catalogDoc?.taskListDocIds[projectId];
 
     if (existingDocId) {
-      return await repo.find<TaskListDocument>(existingDocId as DocumentId);
+      return await loadTaskListDoc(existingDocId);
     }
 
     // Create new task list document
@@ -98,7 +132,7 @@ export function createTaskNamespace(
     if (!catalogDoc) return { found: false };
 
     for (const docId of Object.values(catalogDoc.taskListDocIds)) {
-      const handle = await repo.find<TaskListDocument>(docId as DocumentId);
+      const handle = await loadTaskListDoc(docId);
       const doc = handle.doc();
       if (!doc) continue;
 
@@ -183,7 +217,7 @@ export function createTaskNamespace(
         : Object.values(catalogDoc.taskListDocIds);
 
       for (const docId of docIds) {
-        const handle = await repo.find<TaskListDocument>(docId as DocumentId);
+        const handle = await loadTaskListDoc(docId);
         const doc = handle.doc();
         if (!doc) continue;
 
@@ -435,7 +469,7 @@ export function createTaskNamespace(
       const matches: Task[] = [];
 
       for (const docId of Object.values(catalogDoc.taskListDocIds)) {
-        const handle = await repo.find<TaskListDocument>(docId as DocumentId);
+        const handle = await loadTaskListDoc(docId);
         const doc = handle.doc();
         if (!doc) continue;
 
@@ -461,8 +495,8 @@ function cloneTask(t: Task): Task {
     status: t.status,
     priority: t.priority,
     projectId: t.projectId,
-    labels: [...t.labels],
-    assignees: [...t.assignees],
+    labels: [...(t.labels ?? [])],
+    assignees: [...(t.assignees ?? [])],
     dueDate: t.dueDate,
     scheduledDate: t.scheduledDate,
     externalId: t.externalId,


### PR DESCRIPTION
## Summary

Prevent task reads from crashing on legacy task list documents that are missing `labels` or `assignees` arrays.

## Task

- #2269

## Changes

- migrate legacy task list documents on load to backfill missing array fields
- route all task-list document reads through the migration helper
- make task cloning defensive when legacy arrays are missing
- add regression coverage for legacy task documents

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/engine/src/tasks.integration.test.ts`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included