### PR TITLE
fix: preserve direct daemon logs

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -26,6 +26,8 @@ Wrapper behavior:
 - **Delegates** to system service managers when configured (`systemd --user` on Linux, `launchd` on macOS).
 - Falls back to **direct managed mode** when no service registration exists.
 - Direct mode tracks a managed PID at `<data_dir>/daemon.pid` and refuses to stop unmanaged daemon processes.
+- Direct mode appends stdout/stderr logs to `<data_dir>/daemon.out.log` and `<data_dir>/daemon.err.log`.
+- On `daemon start`/`daemon restart`, oversized direct log files are rotated to `.1` and `.2` before the new process starts.
 
 Foreground daemon run (manual/interactive) is still available:
 

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -34,6 +34,9 @@ Direct managed fallback mode:
 
 - starts daemon as a detached local process
 - writes managed PID to `<data_dir>/daemon.pid`
+- appends stdout logs to `<data_dir>/daemon.out.log`
+- appends stderr logs to `<data_dir>/daemon.err.log`
+- rotates oversized direct log files on `start`/`restart`, keeping `.1` and `.2` archives
 - stops only managed direct-mode daemon processes
 - refuses to stop unmanaged daemon processes (safe fallback behavior)
 
@@ -204,3 +207,4 @@ If you set a socket override for the daemon service, CLI invocations must use th
 
 - Run `toduai --format json daemon status` and inspect `reason`/`transport.path`.
 - Check service logs (`journalctl --user -u toduai-daemon -f` or `tail -f` macOS logs).
+- In direct lifecycle mode, inspect `<data_dir>/daemon.out.log` and `<data_dir>/daemon.err.log`.

--- a/packages/cli/src/commands/daemon.integration.test.ts
+++ b/packages/cli/src/commands/daemon.integration.test.ts
@@ -136,13 +136,18 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     expect(afterStop.running).toBe(false);
   });
 
-  it("daemon start/stop/restart commands manage daemon in direct mode", () => {
+  it("daemon start/stop/restart commands manage daemon in direct mode", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-lifecycle-test-"));
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
 
     const start = runCli(["daemon", "start"]);
     expect(start.status).toBe(0);
     expect(start.stdout).toContain("Daemon start: started managed daemon process");
+
+    const stdoutLogPath = path.join(tmpDir, "daemon.out.log");
+    const stderrLogPath = path.join(tmpDir, "daemon.err.log");
+    await waitForFileContains(stdoutLogPath, '"message":"daemon process started"', 5000);
+    expect(fs.existsSync(stderrLogPath)).toBe(true);
 
     const statusAfterStart = runCli(["--format", "json", "daemon", "status"]);
     expect(statusAfterStart.status).toBe(0);
@@ -163,6 +168,24 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     const statusAfterStop = runCli(["--format", "json", "daemon", "status"]);
     expect(statusAfterStop.status).toBe(0);
     expect(JSON.parse(statusAfterStop.stdout).running).toBe(false);
+  });
+
+  it("daemon start rotates oversized direct log files on startup", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-log-rotation-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+
+    const stdoutLogPath = path.join(tmpDir, "daemon.out.log");
+    const stderrLogPath = path.join(tmpDir, "daemon.err.log");
+    createLargeLogFile(stdoutLogPath, "old-stdout-log");
+    createLargeLogFile(stderrLogPath, "old-stderr-log");
+
+    const start = runCli(["daemon", "start"]);
+    expect(start.status).toBe(0);
+
+    await waitForFileContains(stdoutLogPath, '"message":"daemon process started"', 5000);
+    expect(fs.readFileSync(`${stdoutLogPath}.1`, "utf8")).toContain("old-stdout-log");
+    expect(fs.readFileSync(`${stderrLogPath}.1`, "utf8")).toContain("old-stderr-log");
+    expect(fs.readFileSync(stdoutLogPath, "utf8")).not.toContain("old-stdout-log");
   });
 
   it("daemon stop fails when daemon is unmanaged in direct mode", async () => {
@@ -262,6 +285,34 @@ async function waitForSocket(socketPath: string, processHandle: ChildProcess, ti
   }
 
   throw new Error(`Timed out waiting for daemon socket: ${socketPath}`);
+}
+
+function createLargeLogFile(filePath: string, marker: string): void {
+  const targetSizeBytes = 11 * 1024 * 1024;
+  const chunk = `${marker}\n`;
+  const repeated = chunk.repeat(Math.ceil(targetSizeBytes / chunk.length));
+  fs.writeFileSync(filePath, repeated, "utf8");
+}
+
+async function waitForFileContains(
+  filePath: string,
+  expected: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      const contents = fs.readFileSync(filePath, "utf8");
+      if (contents.includes(expected)) {
+        return;
+      }
+    }
+
+    await sleep(50);
+  }
+
+  throw new Error(`Timed out waiting for log output in ${filePath}`);
 }
 
 async function waitForProcessExit(processHandle: ChildProcess, timeoutMs: number): Promise<void> {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -71,6 +71,10 @@ interface DaemonCommandContext {
 }
 
 const DIRECT_PID_FILENAME = "daemon.pid";
+const DIRECT_STDOUT_LOG_FILENAME = "daemon.out.log";
+const DIRECT_STDERR_LOG_FILENAME = "daemon.err.log";
+const DIRECT_LOG_ROTATION_MAX_BYTES = 10 * 1024 * 1024;
+const DIRECT_LOG_ROTATION_KEEP_COUNT = 2;
 const SYSTEMD_SERVICE_NAME = "toduai-daemon";
 const SYSTEMD_SERVICE_PATH = ".config/systemd/user/toduai-daemon.service";
 const LAUNCHD_LABEL = "com.todu.daemon";
@@ -460,6 +464,41 @@ function isLaunchdAlreadyStopped(message: string): boolean {
   return message.includes("No such process") || message.includes("Could not find service");
 }
 
+function resolveDirectLogPaths(storagePath: string): { stdout: string; stderr: string } {
+  return {
+    stdout: path.join(storagePath, DIRECT_STDOUT_LOG_FILENAME),
+    stderr: path.join(storagePath, DIRECT_STDERR_LOG_FILENAME),
+  };
+}
+
+function rotateDirectLogFile(filePath: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    return;
+  }
+
+  if (!stat.isFile() || stat.size < DIRECT_LOG_ROTATION_MAX_BYTES) {
+    return;
+  }
+
+  safeUnlink(`${filePath}.${DIRECT_LOG_ROTATION_KEEP_COUNT}`);
+
+  for (let index = DIRECT_LOG_ROTATION_KEEP_COUNT - 1; index >= 1; index -= 1) {
+    const currentArchivePath = `${filePath}.${index}`;
+    const nextArchivePath = `${filePath}.${index + 1}`;
+
+    if (!fs.existsSync(currentArchivePath)) {
+      continue;
+    }
+
+    fs.renameSync(currentArchivePath, nextArchivePath);
+  }
+
+  fs.renameSync(filePath, `${filePath}.1`);
+}
+
 async function executeDirectStart(
   action: DaemonLifecycleAction,
   context: DaemonCommandContext,
@@ -508,16 +547,62 @@ async function executeDirectStart(
 
   fs.mkdirSync(context.storagePath, { recursive: true });
 
-  const daemonProcess = spawn(
-    process.execPath,
-    resolveSelfInvocationArgs(["daemon", INTERNAL_DAEMON_RUN_SUBCOMMAND]),
-    {
-      cwd: process.cwd(),
-      detached: true,
-      stdio: "ignore",
-      env: createDaemonChildEnv(context),
-    },
-  );
+  const directLogPaths = resolveDirectLogPaths(context.storagePath);
+  let stdoutFd: number | null = null;
+  let stderrFd: number | null = null;
+
+  try {
+    rotateDirectLogFile(directLogPaths.stdout);
+    rotateDirectLogFile(directLogPaths.stderr);
+    stdoutFd = fs.openSync(directLogPaths.stdout, "a");
+    stderrFd = fs.openSync(directLogPaths.stderr, "a");
+  } catch (error) {
+    if (stdoutFd !== null) {
+      fs.closeSync(stdoutFd);
+    }
+
+    if (stderrFd !== null) {
+      fs.closeSync(stderrFd);
+    }
+
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "failed to open direct daemon log files",
+      details: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  let daemonProcess: ReturnType<typeof spawn>;
+  try {
+    daemonProcess = spawn(
+      process.execPath,
+      resolveSelfInvocationArgs(["daemon", INTERNAL_DAEMON_RUN_SUBCOMMAND]),
+      {
+        cwd: process.cwd(),
+        detached: true,
+        stdio: ["ignore", stdoutFd, stderrFd],
+        env: createDaemonChildEnv(context),
+      },
+    );
+  } catch (error) {
+    fs.closeSync(stdoutFd);
+    fs.closeSync(stderrFd);
+
+    return {
+      action,
+      ok: false,
+      mode: "direct",
+      delegated: false,
+      message: "failed to spawn daemon process",
+      details: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  fs.closeSync(stdoutFd);
+  fs.closeSync(stderrFd);
 
   const daemonPid = daemonProcess.pid;
   if (!daemonPid) {


### PR DESCRIPTION
## Summary

Preserve direct daemon logs by writing detached direct-mode stdout/stderr to durable files and rotating oversized logs on startup.

## Task

#2272

## Changes

- write direct lifecycle daemon stdout/stderr to `<data_dir>/daemon.out.log` and `<data_dir>/daemon.err.log`
- rotate oversized direct log files on `daemon start`/`daemon restart`, keeping `.1` and `.2` archives
- add integration coverage for direct log persistence and startup-time rotation
- document direct-mode log locations and rotation behavior

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
