### PR TITLE
Make habits project-scoped

### DIFF
--- a/packages/cli/src/commands/habit.integration.test.ts
+++ b/packages/cli/src/commands/habit.integration.test.ts
@@ -44,31 +44,40 @@ describe("habit CLI commands", { timeout: 30000 }, () => {
   }
 
   it("habit create → list → show → check → streak → uncheck → history → update → pause → resume → delete flow", () => {
+    const project = JSON.parse(run('project create --name "Habits" --format json'));
+
     // Create
     const createOutput = run(
-      'habit create --title "Meditate" --schedule "FREQ=DAILY" --timezone UTC --start-date 2026-02-01 --format json',
+      `habit create --title "Meditate" --project ${project.id} --schedule "FREQ=DAILY" --timezone UTC --start-date 2026-02-01 --format json`,
     );
     const created = JSON.parse(createOutput);
     expect(created.id).toMatch(/^hab-/);
     expect(created.title).toBe("Meditate");
+    expect(created.projectId).toBe(project.id);
     expect(created.schedule).toBe("FREQ=DAILY");
     expect(created.paused).toBe(false);
 
     // List
     const listOutput = run("habit list");
     expect(listOutput).toContain("Meditate");
+    expect(listOutput).toContain("Habits");
     expect(listOutput).toContain("Daily");
 
     const listJson = JSON.parse(run("habit list --format json"));
     expect(listJson).toHaveLength(1);
 
+    const projectListJson = JSON.parse(run(`habit list --project ${project.id} --format json`));
+    expect(projectListJson).toHaveLength(1);
+
     // Show
     const showOutput = run(`habit show ${created.id}`);
     expect(showOutput).toContain("Meditate");
+    expect(showOutput).toContain("Project:     Habits");
     expect(showOutput).toContain("FREQ=DAILY");
 
     // Show JSON includes streak
     const showJson = JSON.parse(run(`habit show ${created.id} --format json`));
+    expect(showJson.projectId).toBe(project.id);
     expect(showJson.streak).toBeDefined();
     expect(showJson.streak.current).toBe(0);
 

--- a/packages/cli/src/commands/habit.ts
+++ b/packages/cli/src/commands/habit.ts
@@ -7,25 +7,28 @@ import { formatJSON, formatTable } from "../format.js";
 const HABIT_COLUMNS = [
   { key: "id", label: "ID" },
   { key: "title", label: "Title" },
+  { key: "project", label: "Project" },
   { key: "schedule", label: "Schedule" },
   { key: "nextDue", label: "Next Due" },
   { key: "status", label: "Status" },
 ];
 
-function habitToRow(h: Habit): Record<string, string> {
+function habitToRow(h: Habit, projectName?: string): Record<string, string> {
   return {
     id: h.id,
     title: h.title,
+    project: projectName ?? h.projectId,
     schedule: describeSchedule(h.schedule),
     nextDue: h.nextDue,
     status: h.paused ? "paused" : "active",
   };
 }
 
-function habitDetail(h: Habit): string {
+function habitDetail(h: Habit, projectName?: string): string {
   const lines = [
     `ID:          ${h.id}`,
     `Title:       ${h.title}`,
+    `Project:     ${projectName ?? h.projectId}`,
     `Schedule:    ${h.schedule}`,
     `             (${describeSchedule(h.schedule)})`,
     `Timezone:    ${h.timezone}`,
@@ -70,6 +73,46 @@ async function resolveHabit(
   return { ok: false, message: `Habit not found: ${ref}` };
 }
 
+async function getProjectName(invokeDaemon: CliDaemonInvoker, projectId: string): Promise<string> {
+  const result = await invokeDaemon<Array<{ id: string; name: string }>>("project.list", {});
+  if (!result.ok) {
+    return projectId;
+  }
+
+  const project = result.value.find((p) => p.id === projectId);
+  return project?.name ?? projectId;
+}
+
+async function resolveProjectId(
+  invokeDaemon: CliDaemonInvoker,
+  ref: string,
+): Promise<{ ok: true; value: string } | { ok: false; message: string }> {
+  const byId = await invokeDaemon<{ id: string }>("project.get", { id: ref });
+  if (byId.ok) {
+    return { ok: true, value: byId.value.id };
+  }
+
+  if (byId.error.code !== "NOT_FOUND") {
+    return { ok: false, message: formatDaemonCommandError(byId.error) };
+  }
+
+  const result = await invokeDaemon<Array<{ id: string; name: string }>>("project.list", {});
+  if (!result.ok) {
+    return { ok: false, message: formatDaemonCommandError(result.error) };
+  }
+
+  const byName = result.value.filter((p) => p.name.toLowerCase() === ref.toLowerCase());
+  if (byName.length === 1) {
+    return { ok: true, value: byName[0].id };
+  }
+
+  if (byName.length > 1) {
+    return { ok: false, message: `Multiple projects match "${ref}". Use the project ID.` };
+  }
+
+  return { ok: false, message: `Project not found: ${ref}` };
+}
+
 export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const habit = program.command("habit").description("Manage habits");
 
@@ -77,15 +120,24 @@ export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonI
     .command("create")
     .description("Create a habit")
     .requiredOption("--title <title>", "habit title")
+    .requiredOption("--project <project>", "project name or ID")
     .requiredOption("--schedule <rrule>", "RRULE recurrence pattern")
     .requiredOption("--timezone <tz>", "IANA timezone")
     .requiredOption("--start-date <date>", "start date (YYYY-MM-DD)")
     .option("--end-date <date>", "end date (YYYY-MM-DD)")
     .option("--description <text>", "habit description")
     .action(async (opts) => {
+      const projectRes = await resolveProjectId(invokeDaemon, opts.project);
+      if (!projectRes.ok) {
+        console.error(projectRes.message);
+        process.exitCode = 1;
+        return;
+      }
+
       const result = await invokeDaemon<Habit>("habit.create", {
         input: {
           title: opts.title,
+          projectId: projectRes.value,
           schedule: opts.schedule,
           timezone: opts.timezone,
           startDate: opts.startDate,
@@ -104,8 +156,9 @@ export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonI
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const projectName = await getProjectName(invokeDaemon, result.value.projectId);
         console.log(`Created habit: ${result.value.id}`);
-        console.log(habitDetail(result.value));
+        console.log(habitDetail(result.value, projectName));
       }
     });
 
@@ -114,10 +167,23 @@ export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonI
     .description("List habits")
     .option("--active", "show only active habits")
     .option("--paused", "show only paused habits")
+    .option("--project <project>", "filter by project")
     .action(async (opts) => {
+      let projectId: string | undefined;
+      if (opts.project) {
+        const projectRes = await resolveProjectId(invokeDaemon, opts.project);
+        if (!projectRes.ok) {
+          console.error(projectRes.message);
+          process.exitCode = 1;
+          return;
+        }
+        projectId = projectRes.value;
+      }
+
       const filter: Record<string, unknown> = {};
       if (opts.active) filter.paused = false;
       if (opts.paused) filter.paused = true;
+      if (projectId) filter.projectId = projectId;
 
       const result = await invokeDaemon<Habit[]>("habit.list", { filter });
       if (!result.ok) {
@@ -132,9 +198,17 @@ export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
+      const projects = await invokeDaemon<Array<{ id: string; name: string }>>("project.list", {});
+      const projectNames: Record<string, string> = {};
+      if (projects.ok) {
+        for (const project of projects.value) {
+          projectNames[project.id] = project.name;
+        }
+      }
+
       const rows: Record<string, string>[] = [];
       for (const h of result.value) {
-        const row = habitToRow(h);
+        const row = habitToRow(h, projectNames[h.projectId]);
         const streak = await invokeDaemon<HabitStreak>("habit.streak", { id: h.id });
         if (streak.ok) {
           row.streak = streak.value.current > 0 ? `🔥 ${streak.value.current}` : "0";
@@ -174,7 +248,8 @@ export function registerHabitCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
-      console.log(habitDetail(resolved.value));
+      const projectName = await getProjectName(invokeDaemon, resolved.value.projectId);
+      console.log(habitDetail(resolved.value, projectName));
 
       const streak = await invokeDaemon<HabitStreak>("habit.streak", {
         id: resolved.value.id,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -455,6 +455,7 @@ export interface Habit {
   id: HabitId;
   title: string;
   description?: string;
+  projectId: ProjectId;
   schedule: string;
   timezone: string;
   startDate: string;
@@ -471,6 +472,7 @@ export interface Habit {
 
 export interface CreateHabitInput {
   title: string;
+  projectId: ProjectId;
   schedule: string;
   timezone: string;
   startDate: string;
@@ -488,6 +490,7 @@ export interface UpdateHabitInput {
 
 export interface HabitFilter {
   paused?: boolean;
+  projectId?: ProjectId;
   search?: string;
   checkedToday?: boolean;
 }

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -9,6 +9,7 @@ import {
   MAX_PROJECT_NAME_LENGTH,
   MAX_TASK_TITLE_LENGTH,
   validateAssignees,
+  validateCreateHabitInput,
   validateCreateIntegrationBindingInput,
   validateCreateLabelInput,
   validateCreateNoteInput,
@@ -24,6 +25,7 @@ import {
   validateNoteContent,
   validateProjectName,
   validateTaskTitle,
+  validateUpdateHabitInput,
   validateUpdateIntegrationBindingInput,
   validateUpdateIntegrationBindingStatusInput,
   validateUpdateLabelInput,
@@ -639,6 +641,45 @@ describe("validateUpdateRecurringInput", () => {
   it("rejects invalid recurring missPolicy updates", () => {
     const error = validateUpdateRecurringInput({ missPolicy: "skip" as "accumulate" });
     expect(error?.field).toBe("missPolicy");
+  });
+});
+
+describe("validateCreateHabitInput", () => {
+  const projectId = createProjectId("proj-habit");
+
+  it("accepts valid input", () => {
+    expect(
+      validateCreateHabitInput({
+        title: "Meditate",
+        projectId,
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-03-01",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects missing projectId", () => {
+    const error = validateCreateHabitInput({
+      title: "Meditate",
+      projectId: "" as never,
+      schedule: "FREQ=DAILY",
+      timezone: "UTC",
+      startDate: "2026-03-01",
+    });
+
+    expect(error?.field).toBe("projectId");
+  });
+});
+
+describe("validateUpdateHabitInput", () => {
+  it("accepts valid title-only updates", () => {
+    expect(validateUpdateHabitInput({ title: "Meditate daily" })).toBeNull();
+  });
+
+  it("rejects empty input", () => {
+    const error = validateUpdateHabitInput({});
+    expect(error?.field).toBe("input");
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -668,6 +668,10 @@ export function validateCreateHabitInput(input: CreateHabitInput): ValidationErr
   const titleError = validateHabitTitle(input.title);
   if (titleError) return titleError;
 
+  if (!input.projectId) {
+    return validationError("projectId", "Project ID is required");
+  }
+
   const ruleError = validateRRule(input.schedule);
   if (ruleError) return ruleError;
 

--- a/packages/daemon/src/protocol-conformance.integration.test.ts
+++ b/packages/daemon/src/protocol-conformance.integration.test.ts
@@ -275,6 +275,7 @@ describe("daemon protocol conformance suite", () => {
         params: {
           input: {
             title: "Stretch",
+            projectId,
             schedule: "FREQ=DAILY",
             timezone: "America/Chicago",
             startDate: "2026-02-01",
@@ -285,6 +286,7 @@ describe("daemon protocol conformance suite", () => {
       expect(habitResponse.id).toBe("habit-create-conformance");
       expect(habitResponse.result).toMatchObject({
         title: "Stretch",
+        projectId,
       });
 
       const syncStatus = await sendRequest(runtime.config().socketPath, {

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -816,12 +816,24 @@ describe("createDaemonRuntime", () => {
 
     await runtime.start();
 
+    const createProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-project-create-1",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Habits",
+        },
+      },
+    });
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
     const createHabitResponse = await sendRequest(runtime.config().socketPath, {
       id: "habit-create-1",
       method: "habit.create",
       params: {
         input: {
           title: "Meditate",
+          projectId,
           schedule: "FREQ=DAILY",
           timezone: "America/Chicago",
           startDate: "2026-02-01",
@@ -1845,12 +1857,24 @@ describe("createDaemonRuntime", () => {
       },
     });
 
+    const habitProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "habit-project-validation-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Habit Validation",
+        },
+      },
+    });
+    const habitProjectId = (habitProjectResponse.result as { id: string }).id;
+
     const habitValidationResponse = await sendRequest(runtime.config().socketPath, {
       id: "habit-create-validation",
       method: "habit.create",
       params: {
         input: {
           title: "Bad Habit",
+          projectId: habitProjectId,
           schedule: "FREQ=HOURLY",
           timezone: "UTC",
           startDate: "2026-02-01",

--- a/packages/electron/src/main/agent.ts
+++ b/packages/electron/src/main/agent.ts
@@ -148,7 +148,7 @@ ${JSON.stringify({ id: p.id, name: p.name, status: p.status, priority: p.priorit
       if (!result.ok) return undefined;
       const h = result.value;
       return `\`\`\`json
-${JSON.stringify({ id: h.id, title: h.title, paused: h.paused, schedule: h.schedule, description: h.description }, null, 2)}
+${JSON.stringify({ id: h.id, title: h.title, paused: h.paused, schedule: h.schedule, projectId: h.projectId, description: h.description }, null, 2)}
 \`\`\``;
     }
     case "recurring": {

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -191,6 +191,7 @@ const ListHabitsParams = Type.Object({
   paused: Type.Optional(
     Type.Boolean({ description: "Filter by paused state (true = paused, false = active)" }),
   ),
+  projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
   checkedToday: Type.Optional(
     Type.Boolean({
       description:
@@ -399,7 +400,7 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     {
       name: "list_habits",
       description:
-        "List habits with optional filtering by paused state or title search. Use filter parameters so the UI updates to show matching habits.",
+        "List habits with optional filtering by paused state, project, or title search. Use filter parameters so the UI updates to show matching habits.",
       label: "List Habits",
       parameters: ListHabitsParams,
       execute: async (_toolCallId, params) => {

--- a/packages/electron/src/renderer/views/CreateHabitDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateHabitDialog.tsx
@@ -1,17 +1,21 @@
+import type { ProjectId } from "@todu/core/browser";
 import { type ReactNode, useState } from "react";
 import { SchedulePresetPicker } from "../components/SchedulePresetPicker.js";
-import { useCreateHabit } from "../hooks/useTodu.js";
+import { useCreateHabit, useProjects } from "../hooks/useTodu.js";
 
 export function CreateHabitDialog({ onClose }: { onClose: () => void }): ReactNode {
+  const { data: projects } = useProjects();
   const createHabit = useCreateHabit();
 
   const [title, setTitle] = useState("");
+  const [projectId, setProjectId] = useState("");
   const [schedule, setSchedule] = useState("FREQ=DAILY");
   const [description, setDescription] = useState("");
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
   const [endDate, setEndDate] = useState("");
   const [error, setError] = useState("");
 
+  const effectiveProjectId = projectId || projects?.[0]?.id || "";
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   const handleSubmit = () => {
@@ -23,10 +27,15 @@ export function CreateHabitDialog({ onClose }: { onClose: () => void }): ReactNo
       setError("Schedule is required");
       return;
     }
+    if (!effectiveProjectId) {
+      setError("Select a project");
+      return;
+    }
     setError("");
     createHabit.mutate(
       {
         title: title.trim(),
+        projectId: effectiveProjectId as ProjectId,
         schedule,
         timezone,
         startDate,
@@ -69,6 +78,24 @@ export function CreateHabitDialog({ onClose }: { onClose: () => void }): ReactNo
             placeholder="Habit name"
             autoFocus
           />
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="habit-project">
+            Project *
+          </label>
+          <select
+            id="habit-project"
+            className="input"
+            value={effectiveProjectId}
+            onChange={(e) => setProjectId(e.target.value)}
+          >
+            {projects?.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="form-field">

--- a/packages/electron/src/renderer/views/HabitDetail.tsx
+++ b/packages/electron/src/renderer/views/HabitDetail.tsx
@@ -12,6 +12,7 @@ import {
   useHabitHistory,
   useHabitStreak,
   usePauseHabit,
+  useProjects,
   useResumeHabit,
   useUncheckHabit,
   useUpdateHabit,
@@ -146,6 +147,7 @@ export function HabitDetail({
   onBack: () => void;
 }): ReactNode {
   const { data: habit, isLoading, isError, error } = useHabitDetail(habitId);
+  const { data: projects } = useProjects();
   const updateHabit = useUpdateHabit();
   const deleteHabit = useDeleteHabit();
   const pauseHabit = usePauseHabit();
@@ -190,6 +192,8 @@ export function HabitDetail({
       </div>
     );
   }
+
+  const projectName = projects?.find((project) => project.id === habit.projectId)?.name ?? "—";
 
   const handleTitleSave = () => {
     setEditingTitle(false);
@@ -314,6 +318,10 @@ export function HabitDetail({
       </div>
 
       <div className="detail-meta-row">
+        <div className="detail-meta-cell">
+          <span className="detail-meta-label">Project</span>
+          <span>{projectName}</span>
+        </div>
         <div className="detail-meta-cell">
           <span className="detail-meta-label">Start</span>
           <span>{habit.startDate}</span>

--- a/packages/electron/src/renderer/views/HabitList.tsx
+++ b/packages/electron/src/renderer/views/HabitList.tsx
@@ -1,6 +1,12 @@
 import type { HabitFilter, HabitId } from "@todu/core/browser";
-import { type ReactNode, useEffect, useRef, useState } from "react";
-import { useCheckHabit, useHabitList, useHabitStreak, useUncheckHabit } from "../hooks/useTodu.js";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCheckHabit,
+  useHabitList,
+  useHabitStreak,
+  useProjects,
+  useUncheckHabit,
+} from "../hooks/useTodu.js";
 import { describeSchedule } from "../lib/describe-schedule.js";
 
 // ============================================================================
@@ -61,6 +67,7 @@ export function HabitList({
   externalFilter?: HabitFilter | null;
 }): ReactNode {
   const [filterStatus, setFilterStatus] = useState<"all" | "active" | "paused">("all");
+  const [filterProject, setFilterProject] = useState("");
   const [filterChecked, setFilterChecked] = useState<"all" | "done" | "pending">("all");
   const [searchText, setSearchText] = useState("");
   const appliedExternalRef = useRef<HabitFilter | null | undefined>(undefined);
@@ -72,6 +79,7 @@ export function HabitList({
       if (externalFilter.paused === true) setFilterStatus("paused");
       else if (externalFilter.paused === false) setFilterStatus("active");
       else setFilterStatus("all");
+      setFilterProject((externalFilter.projectId as string) ?? "");
       if (externalFilter.checkedToday === true) setFilterChecked("done");
       else if (externalFilter.checkedToday === false) setFilterChecked("pending");
       else setFilterChecked("all");
@@ -82,12 +90,21 @@ export function HabitList({
   const filter: HabitFilter = {
     ...(filterStatus === "active" ? { paused: false } : {}),
     ...(filterStatus === "paused" ? { paused: true } : {}),
+    ...(filterProject ? { projectId: filterProject as HabitFilter["projectId"] } : {}),
     ...(filterChecked === "done" ? { checkedToday: true } : {}),
     ...(filterChecked === "pending" ? { checkedToday: false } : {}),
     ...(searchText ? { search: searchText } : {}),
   };
 
   const { data: habits, isLoading, isError, error } = useHabitList(filter);
+  const { data: projects } = useProjects();
+  const projectMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const project of projects ?? []) {
+      map.set(project.id, project.name);
+    }
+    return map;
+  }, [projects]);
 
   if (isLoading) {
     return (
@@ -143,6 +160,18 @@ export function HabitList({
           </select>
           <select
             className="filter-select"
+            value={filterProject}
+            onChange={(e) => setFilterProject(e.target.value)}
+          >
+            <option value="">All projects</option>
+            {projects?.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+          <select
+            className="filter-select"
             value={filterChecked}
             onChange={(e) => setFilterChecked(e.target.value as "all" | "done" | "pending")}
           >
@@ -162,6 +191,7 @@ export function HabitList({
           <thead>
             <tr>
               <th>Title</th>
+              <th>Project</th>
               <th>Schedule</th>
               <th>Streak</th>
               <th>Today</th>
@@ -180,6 +210,7 @@ export function HabitList({
                 }}
               >
                 <td className="cell-name">{habit.title}</td>
+                <td className="cell-project">{projectMap.get(habit.projectId) ?? "—"}</td>
                 <td className="cell-schedule">{describeSchedule(habit.schedule)}</td>
                 <td>
                   <StreakCell habitId={habit.id} />

--- a/packages/engine/src/change-observer.integration.test.ts
+++ b/packages/engine/src/change-observer.integration.test.ts
@@ -86,9 +86,13 @@ describe("change notifications", () => {
   });
 
   it("habit check-in triggers onChange (separate HabitLogDocument)", async () => {
+    const projectResult = await todu.project.create({ name: "habit project" });
+    if (!projectResult.ok) throw new Error("project create failed");
+
     const today = new Date().toISOString().slice(0, 10);
     const habitResult = await todu.habit.create({
       title: "exercise",
+      projectId: projectResult.value.id,
       schedule: "FREQ=DAILY",
       timezone: "America/Chicago",
       startDate: today,

--- a/packages/engine/src/habits.integration.test.ts
+++ b/packages/engine/src/habits.integration.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { HabitId } from "@todu/core";
+import type { HabitId, ProjectId } from "@todu/core";
+import { createProjectId } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTodu } from "./index.js";
 import { clearProcessors } from "./scheduling.js";
@@ -10,11 +11,15 @@ import type { Todu } from "./todu.js";
 describe("habits", () => {
   let todu: Todu;
   let tmpDir: string;
+  let projectId: ProjectId;
 
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-habits-"));
     clearProcessors();
     todu = await createTodu({ storagePath: tmpDir });
+    const project = await todu.project.create({ name: "Habits Project" });
+    if (!project.ok) throw new Error("project create failed");
+    projectId = project.value.id;
   });
 
   afterEach(async () => {
@@ -26,6 +31,7 @@ describe("habits", () => {
   describe("CRUD", () => {
     it("creates a habit", async () => {
       const result = await todu.habit.create({
+        projectId,
         title: "Meditate",
         schedule: "FREQ=DAILY",
         timezone: "America/Chicago",
@@ -45,6 +51,7 @@ describe("habits", () => {
 
     it("creates a habit with optional fields", async () => {
       const result = await todu.habit.create({
+        projectId,
         title: "Exercise",
         schedule: "FREQ=WEEKLY;BYDAY=MO,WE,FR",
         timezone: "UTC",
@@ -62,6 +69,7 @@ describe("habits", () => {
 
     it("rejects invalid RRULE", async () => {
       const result = await todu.habit.create({
+        projectId,
         title: "Bad rule",
         schedule: "FREQ=HOURLY",
         timezone: "UTC",
@@ -73,6 +81,7 @@ describe("habits", () => {
 
     it("rejects invalid timezone", async () => {
       const result = await todu.habit.create({
+        projectId,
         title: "Bad tz",
         schedule: "FREQ=DAILY",
         timezone: "Fake/Zone",
@@ -84,6 +93,7 @@ describe("habits", () => {
 
     it("rejects endDate before startDate", async () => {
       const result = await todu.habit.create({
+        projectId,
         title: "Bad dates",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -96,12 +106,14 @@ describe("habits", () => {
 
     it("lists habits", async () => {
       await todu.habit.create({
+        projectId,
         title: "A",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
         startDate: "2026-02-01",
       });
       await todu.habit.create({
+        projectId,
         title: "B",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -113,14 +125,70 @@ describe("habits", () => {
       if (result.ok) expect(result.value).toHaveLength(2);
     });
 
+    it("stores the habit projectId", async () => {
+      const result = await todu.habit.create({
+        projectId,
+        title: "Project habit",
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-02-01",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.projectId).toBe(projectId);
+    });
+
+    it("rejects nonexistent projectId", async () => {
+      const result = await todu.habit.create({
+        projectId: createProjectId("proj-missing"),
+        title: "Missing project",
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-02-01",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+    });
+
+    it("filters by projectId", async () => {
+      const otherProject = await todu.project.create({ name: "Other Habits Project" });
+      if (!otherProject.ok) throw new Error("project create failed");
+
+      await todu.habit.create({
+        projectId,
+        title: "Primary project habit",
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-02-01",
+      });
+      await todu.habit.create({
+        projectId: otherProject.value.id,
+        title: "Other project habit",
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2026-02-01",
+      });
+
+      const result = await todu.habit.list({ projectId });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].title).toBe("Primary project habit");
+    });
+
     it("filters by paused status", async () => {
       const _createA = await todu.habit.create({
+        projectId,
         title: "Active",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
         startDate: "2026-02-01",
       });
       const createB = await todu.habit.create({
+        projectId,
         title: "Paused",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -138,12 +206,14 @@ describe("habits", () => {
 
     it("filters by checkedToday", async () => {
       const createA = await todu.habit.create({
+        projectId,
         title: "Checked Habit",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
         startDate: "2026-02-01",
       });
       await todu.habit.create({
+        projectId,
         title: "Unchecked Habit",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -168,12 +238,14 @@ describe("habits", () => {
 
     it("filters by search", async () => {
       await todu.habit.create({
+        projectId,
         title: "Morning Meditation",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
         startDate: "2026-02-01",
       });
       await todu.habit.create({
+        projectId,
         title: "Evening Jog",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -190,6 +262,7 @@ describe("habits", () => {
 
     it("gets a habit by ID", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Get me",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -211,6 +284,7 @@ describe("habits", () => {
 
     it("updates a habit", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Original",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -233,6 +307,7 @@ describe("habits", () => {
 
     it("deletes a habit", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Delete me",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -251,6 +326,7 @@ describe("habits", () => {
 
     it("pauses and resumes", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Pausable",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -272,6 +348,7 @@ describe("habits", () => {
   describe("check/uncheck", () => {
     it("checks in for today", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -290,6 +367,7 @@ describe("habits", () => {
 
     it("check is idempotent", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -309,6 +387,7 @@ describe("habits", () => {
 
     it("uncheck removes today's entry", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -329,6 +408,7 @@ describe("habits", () => {
 
     it("uncheck is idempotent", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -345,6 +425,7 @@ describe("habits", () => {
   describe("streak", () => {
     it("returns zero streak with no check-ins", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -365,6 +446,7 @@ describe("habits", () => {
 
     it("counts today's check-in in streak", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -388,6 +470,7 @@ describe("habits", () => {
   describe("history", () => {
     it("returns history with today", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -410,6 +493,7 @@ describe("habits", () => {
 
     it("shows incomplete days as not completed", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Daily",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -432,6 +516,7 @@ describe("habits", () => {
     it("only includes scheduled dates", async () => {
       // Weekday-only habit
       const create = await todu.habit.create({
+        projectId,
         title: "Weekday",
         schedule: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
         timezone: "UTC",
@@ -453,6 +538,7 @@ describe("habits", () => {
   describe("processTemplates", () => {
     it("paused habits are not processed", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Paused",
         schedule: "FREQ=DAILY",
         timezone: "UTC",
@@ -476,6 +562,7 @@ describe("habits", () => {
   describe("HabitLogDocument lifecycle", () => {
     it("log is created on habit creation and cleaned up on deletion", async () => {
       const create = await todu.habit.create({
+        projectId,
         title: "Lifecycle",
         schedule: "FREQ=DAILY",
         timezone: "UTC",

--- a/packages/engine/src/habits.ts
+++ b/packages/engine/src/habits.ts
@@ -14,6 +14,7 @@ import {
   type HabitStreak,
   notFound,
   ok,
+  type ProjectId,
   type Result,
   type UpdateHabitInput,
   validateCreateHabitInput,
@@ -73,10 +74,16 @@ export function createHabitNamespace(
     return handle;
   }
 
+  function projectExists(projectId: ProjectId): boolean {
+    const doc = catalog.doc();
+    return doc?.projects.some((project) => project.id === projectId) ?? false;
+  }
+
   return {
     async create(input: CreateHabitInput): Promise<Result<Habit>> {
       const validationErr = validateCreateHabitInput(input);
       if (validationErr) return err(validationErr);
+      if (!projectExists(input.projectId)) return err(notFound("project", input.projectId));
 
       const id = generateHabitId();
       const now = new Date().toISOString();
@@ -96,6 +103,7 @@ export function createHabitNamespace(
         id,
         title: input.title.trim(),
         description: input.description,
+        projectId: input.projectId,
         schedule: input.schedule,
         timezone: input.timezone,
         startDate: input.startDate,
@@ -129,6 +137,9 @@ export function createHabitNamespace(
 
       if (filter?.paused !== undefined) {
         habits = habits.filter((h) => h.paused === filter.paused);
+      }
+      if (filter?.projectId !== undefined) {
+        habits = habits.filter((h) => h.projectId === filter.projectId);
       }
       if (filter?.search) {
         const lowerQuery = filter.search.toLowerCase();


### PR DESCRIPTION
## Summary

Require habits to belong to projects across the core model, engine, CLI, daemon, and Electron UI.

## Task

- #2293

## Changes

- add `projectId` to the habit model and require it on habit creation
- validate referenced projects in the engine and support habit filtering by project
- update CLI habit create/list/show flows to resolve and display projects
- update Electron habit create/list/detail views and agent/tool surfaces for project-scoped habits
- add validation, engine, daemon, and CLI regression coverage for the new contract

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/core/src/validation.test.ts packages/engine/src/habits.integration.test.ts packages/engine/src/change-observer.integration.test.ts packages/cli/src/commands/habit.integration.test.ts packages/daemon/src/protocol-conformance.integration.test.ts`
- `npx vitest run --config vitest.all.config.ts packages/daemon/src/runtime.integration.test.ts -t "routes habit and sync namespace methods through runtime adapters"`
- `npm run --workspace=packages/electron build`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included