### PR TITLE
Show Electron app version in Settings

### DIFF
--- a/packages/electron/src/main/settings.ts
+++ b/packages/electron/src/main/settings.ts
@@ -210,6 +210,10 @@ export function registerSettingsIpc(): void {
   ipcMain.handle("todu:settings:providers", () => {
     return listProviders();
   });
+
+  ipcMain.handle("todu:settings:version", () => {
+    return app.getVersion();
+  });
 }
 
 export function unregisterSettingsIpc(): void {
@@ -219,4 +223,5 @@ export function unregisterSettingsIpc(): void {
   ipcMain.removeHandler("todu:settings:remove-api-key");
   ipcMain.removeHandler("todu:settings:stored-providers");
   ipcMain.removeHandler("todu:settings:providers");
+  ipcMain.removeHandler("todu:settings:version");
 }

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -105,6 +105,7 @@ const api = {
       ipcRenderer.invoke("todu:settings:remove-api-key", provider),
     storedProviders: () => ipcRenderer.invoke("todu:settings:stored-providers"),
     providers: () => ipcRenderer.invoke("todu:settings:providers"),
+    version: () => ipcRenderer.invoke("todu:settings:version"),
   },
 
   // ── Sync ─────────────────────────────────────────────────────────

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -147,6 +147,7 @@ export interface ToduSettingsApi {
   removeApiKey(provider: string): Promise<void>;
   storedProviders(): Promise<Record<string, boolean>>;
   providers(): Promise<ProviderInfo[]>;
+  version(): Promise<string>;
 }
 
 export type RemoteSyncState = "disconnected" | "connected" | "syncing";

--- a/packages/electron/src/renderer/views/SettingsView.test.tsx
+++ b/packages/electron/src/renderer/views/SettingsView.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsView } from "./SettingsView.js";
+
+describe("SettingsView app version", () => {
+  const settingsGet = vi.fn();
+  const settingsStoredProviders = vi.fn();
+  const settingsProviders = vi.fn();
+  const settingsVersion = vi.fn();
+  const oauthStatus = vi.fn();
+  const syncStatus = vi.fn();
+  const syncCatalogId = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    settingsGet.mockResolvedValue({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+    });
+    settingsStoredProviders.mockResolvedValue({});
+    settingsProviders.mockResolvedValue([
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        models: [{ id: "claude-sonnet-4-20250514", label: "Claude Sonnet 4" }],
+      },
+    ]);
+    settingsVersion.mockResolvedValue("0.7.7");
+    oauthStatus.mockResolvedValue([]);
+    syncStatus.mockResolvedValue({
+      local: { mode: "local" },
+      remote: { state: "disconnected" },
+    });
+    syncCatalogId.mockResolvedValue("");
+
+    Object.defineProperty(window, "todu", {
+      configurable: true,
+      value: {
+        settings: {
+          get: settingsGet,
+          save: vi.fn().mockResolvedValue(undefined),
+          setApiKey: vi.fn().mockResolvedValue(undefined),
+          removeApiKey: vi.fn().mockResolvedValue(undefined),
+          storedProviders: settingsStoredProviders,
+          providers: settingsProviders,
+          version: settingsVersion,
+        },
+        agent: {
+          setModel: vi.fn().mockResolvedValue(undefined),
+        },
+        oauth: {
+          status: oauthStatus,
+          login: vi.fn().mockResolvedValue(undefined),
+          promptResponse: vi.fn().mockResolvedValue(undefined),
+          cancel: vi.fn().mockResolvedValue(undefined),
+          disconnect: vi.fn().mockResolvedValue(undefined),
+        },
+        sync: {
+          status: syncStatus,
+          getCatalogId: syncCatalogId,
+          joinCheck: vi.fn().mockResolvedValue(undefined),
+          join: vi.fn().mockResolvedValue(undefined),
+          start: vi.fn().mockResolvedValue(undefined),
+          stop: vi.fn().mockResolvedValue(undefined),
+        },
+        on: vi.fn(() => () => {}),
+      } as unknown as Window["todu"],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the app version in the settings view", async () => {
+    render(<SettingsView themePreference="system" onThemeChange={() => {}} />);
+
+    expect(await screen.findByText("App")).toBeDefined();
+    expect(await screen.findByText("v0.7.7")).toBeDefined();
+    expect(settingsVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an unavailable fallback when version lookup fails", async () => {
+    settingsVersion.mockRejectedValueOnce(new Error("version unavailable"));
+
+    render(<SettingsView themePreference="system" onThemeChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unavailable")).toBeDefined();
+    });
+  });
+});

--- a/packages/electron/src/renderer/views/SettingsView.tsx
+++ b/packages/electron/src/renderer/views/SettingsView.tsx
@@ -25,6 +25,7 @@ export function SettingsView({
   const [storedKeys, setStoredKeys] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
 
   // API key input state — one per provider
   const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
@@ -78,6 +79,17 @@ export function SettingsView({
       })
       .catch(() => {
         // Sync data unavailable — the Sync section simply won't render
+      });
+  }, []);
+
+  // Load app version separately so a metadata lookup failure does not
+  // affect the rest of the settings page.
+  useEffect(() => {
+    window.todu.settings
+      .version()
+      .then(setAppVersion)
+      .catch(() => {
+        // Version unavailable — show fallback text in the App section
       });
   }, []);
 
@@ -625,6 +637,24 @@ export function SettingsView({
             </div>
           </div>
         ))}
+      </div>
+
+      {/* ── App ─────────────────────────────────────────────────────── */}
+      <div className="settings-section">
+        <h3 className="section-title">App</h3>
+        <div className="settings-key-row">
+          <div className="settings-key-header">
+            <span className="settings-key-label">Version</span>
+            <span
+              className={`settings-key-status ${appVersion ? "settings-key-stored" : "settings-key-missing"}`}
+            >
+              {appVersion ? `v${appVersion}` : "Unavailable"}
+            </span>
+          </div>
+          <p className="settings-hint">
+            Use this version when checking release notes or reporting app issues.
+          </p>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Show the current Electron app version in the Settings view so users can verify which build is running without leaving the app.

## Task

- #2295

## Changes

- expose the Electron app version from main process metadata via the settings IPC surface
- add an App section in Settings that displays the current version
- add a renderer test covering the visible version and fallback behavior

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/electron/src/main/settings.test.ts packages/electron/src/renderer/views/SettingsView.test.tsx`
- `npm run --workspace=packages/electron build`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included