### PR TITLE
Support importing past-dated journal entries

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -243,6 +243,32 @@ toduai --format json recurring show <template-id>
 
 Text output includes a `Miss Policy` field/column. JSON output includes `missPolicy`, and older templates without a stored field are displayed as `accumulate` for backward compatibility.
 
+## Import backdated journal entries via CLI
+
+Use `toduai note add` with `--created-at` to import historical journal entries without editing the datastore directly.
+
+Create a backdated journal entry from an existing note:
+
+```bash
+toduai note add "Imported journal entry" \
+  --created-at 2021-04-17T14:30:00Z \
+  --tag imported \
+  --tag journal
+```
+
+For scripted imports, emit one command per entry with the original timestamp:
+
+```bash
+toduai note add "Started new role today" --created-at 2019-06-03T09:00:00Z
+toduai note add "Moved apartments" --created-at 2020-08-29T18:45:00Z
+```
+
+Behavior notes:
+- `--created-at` accepts an ISO-8601 date or datetime string.
+- Stored journal timestamps are normalized to ISO datetime form.
+- Standalone journal notes are bucketed by the provided historical month, not by import time.
+- Invalid `--created-at` input fails with a validation error.
+
 ## Validate connectivity
 
 ```bash

--- a/packages/cli/src/commands/label-note.integration.test.ts
+++ b/packages/cli/src/commands/label-note.integration.test.ts
@@ -137,6 +137,25 @@ describe("label + note CLI commands", () => {
       expect(JSON.parse(afterDelete)).toHaveLength(2);
     });
 
+    it("creates a backdated journal entry with --created-at", () => {
+      const createdJson = run(
+        '--format json note add "Imported entry" --created-at "2021-04-17T14:30:00Z"',
+      );
+      const created = JSON.parse(createdJson);
+      expect(created.createdAt).toBe("2021-04-17T14:30:00.000Z");
+
+      const listJson = run("--format json note list");
+      const notes = JSON.parse(listJson);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].createdAt).toBe("2021-04-17T14:30:00.000Z");
+    });
+
+    it("fails clearly for invalid --created-at", () => {
+      const output = run('note add "Imported entry" --created-at "not-a-date"', true);
+      expect(output).toContain("Invalid date");
+      expect(output).toContain("not-a-date");
+    });
+
     it("shows 'No notes.' when empty", () => {
       const output = run("note list");
       expect(output).toBe("No notes.");

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -73,6 +73,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--project <ref>", "attach to a project")
     .option("--tag <tags...>", "tags")
     .option("--author <author>", "author (default: user)")
+    .option("--created-at <iso>", "ISO timestamp for importing/backdating a journal entry")
     .action(async (content, opts) => {
       let entityType: NoteEntityType | undefined;
       let entityId: string | undefined;
@@ -99,6 +100,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
           entityId,
           tags: opts.tag,
           author: opts.author,
+          createdAt: opts.createdAt,
         },
       });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -350,6 +350,7 @@ export interface CreateNoteInput {
   entityType?: NoteEntityType;
   entityId?: string;
   tags?: string[];
+  createdAt?: string;
 }
 
 export interface UpdateNoteInput {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -813,6 +813,23 @@ describe("validateCreateNoteInput", () => {
     expect(validateCreateNoteInput({ content: "Thought", tags: ["idea", "design"] })).toBeNull();
   });
 
+  it("accepts note with createdAt", () => {
+    expect(
+      validateCreateNoteInput({
+        content: "Imported journal entry",
+        createdAt: "2021-04-17T14:30:00Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects invalid createdAt", () => {
+    const error = validateCreateNoteInput({
+      content: "Imported journal entry",
+      createdAt: "not-a-date",
+    });
+    expect(error?.field).toBe("createdAt");
+  });
+
   it("rejects empty content", () => {
     const error = validateCreateNoteInput({ content: "" });
     expect(error?.field).toBe("content");

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -531,6 +531,11 @@ export function validateCreateNoteInput(input: CreateNoteInput): ValidationError
     return validationError("entityType", `Invalid entity type: ${input.entityType}`);
   }
 
+  if (input.createdAt !== undefined) {
+    const createdAtError = validateISODate("createdAt", input.createdAt);
+    if (createdAtError) return createdAtError;
+  }
+
   // If entityType is set, entityId must also be set (and vice versa)
   if (input.entityType !== undefined && !input.entityId) {
     return validationError("entityId", "Entity ID is required when entity type is specified");

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -115,6 +115,27 @@ describe("note namespace", () => {
       expect(result.value.author).toBe("agent");
     });
 
+    it("creates a journal note with an explicit historical timestamp", async () => {
+      const result = await todu.note.create({
+        content: "Imported from old journal",
+        createdAt: "2021-04-17T14:30:00Z",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.createdAt).toBe("2021-04-17T14:30:00.000Z");
+    });
+
+    it("rejects invalid createdAt input", async () => {
+      const result = await todu.note.create({
+        content: "Imported from old journal",
+        createdAt: "not-a-date",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("validation");
+      expect(result.error.field).toBe("createdAt");
+    });
+
     it("rejects empty content", async () => {
       const result = await todu.note.create({ content: "" });
       expect(result.ok).toBe(false);
@@ -342,7 +363,10 @@ describe("note namespace", () => {
       const task = await todu.task.create({ title: "Task for notes", projectId });
       if (!task.ok) throw new Error("create failed");
 
-      const journalNote = await todu.note.create({ content: "Journal" });
+      const journalNote = await todu.note.create({
+        content: "Journal",
+        createdAt: "2021-04-17T14:30:00Z",
+      });
       const taskNote = await todu.note.create({
         content: "Task attached",
         entityType: "task",
@@ -365,6 +389,7 @@ describe("note namespace", () => {
       );
       expect(catalogDoc.noteBucketByNoteId[journalNote.value.id]).toBe(journalBucket);
       expect(catalogDoc.noteBucketByNoteId[taskNote.value.id]).toBe(taskBucket);
+      expect(journalBucket).toBe("journal:2021-04");
     });
 
     it("migrates legacy notesDocId data into partition buckets", async () => {

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -281,7 +281,9 @@ export function createNoteNamespace(
         }
       }
 
-      const now = new Date().toISOString();
+      const createdAt = input.createdAt
+        ? new Date(input.createdAt).toISOString()
+        : new Date().toISOString();
       const id = createNoteId(`note-${crypto.randomUUID().slice(0, 8)}`);
 
       const note: Note = {
@@ -289,7 +291,7 @@ export function createNoteNamespace(
         content: input.content.trim(),
         author: input.author ?? "user",
         tags: input.tags ?? [],
-        createdAt: now,
+        createdAt,
       };
       if (input.entityType !== undefined) note.entityType = input.entityType;
       if (input.entityId !== undefined) note.entityId = input.entityId;


### PR DESCRIPTION
## Summary

Add a supported CLI workflow for importing backdated journal entries by allowing note creation to accept an explicit historical timestamp.

## Task

- #2282

## Changes

- extend note creation input with optional `createdAt`
- validate note `createdAt` input and normalize stored timestamps
- add `toduai note add --created-at <iso>` for historical journal imports
- ensure journal notes bucket by the provided historical month instead of import time
- document the supported CLI import workflow
- add validation, engine, and CLI regression coverage

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/core/src/validation.test.ts packages/engine/src/notes.integration.test.ts packages/cli/src/commands/label-note.integration.test.ts`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated
- [x] No unrelated changes included