### PR TITLE
Preserve imported task timestamps for synced issues

### DIFF
--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -86,6 +86,14 @@ Expected lifecycle:
 
 The runtime persists the pulled task's core fields, including mapped status, priority, labels, assignees, `externalId`, and `sourceUrl`. Task descriptions come from `ExternalTask.description`.
 
+Imported timestamp semantics:
+
+- Newly created local tasks preserve external `createdAt` when provided.
+- Newly created local tasks preserve external `updatedAt` when provided.
+- If only one external task timestamp is provided, the runtime uses that timestamp for both local `createdAt` and `updatedAt` so imported history remains deterministic.
+- For later pull updates of already-linked tasks, local `createdAt` remains unchanged and local `updatedAt` follows the imported external timestamp used for the update decision.
+- Invalid external task timestamps fail the pull safely instead of being written into local task state.
+
 ## Comment Sync Contract
 
 The sync-provider runtime supports comment/note mirroring through pull and push paths.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,6 +296,8 @@ export interface CreateTaskInput {
   scheduledDate?: string;
   externalId?: string;
   sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface UpdateTaskInput {
@@ -309,6 +311,7 @@ export interface UpdateTaskInput {
   scheduledDate?: string;
   externalId?: string;
   sourceUrl?: string;
+  updatedAt?: string;
 }
 
 export interface TaskFilter {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -457,6 +457,35 @@ describe("validateCreateTaskInput", () => {
     ).toBeNull();
   });
 
+  it("accepts imported timestamps in create", () => {
+    expect(
+      validateCreateTaskInput({
+        title: "Imported task",
+        projectId,
+        createdAt: "2021-04-17T14:30:00Z",
+        updatedAt: "2021-04-18T09:15:00Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects invalid createdAt in create", () => {
+    const error = validateCreateTaskInput({
+      title: "Imported task",
+      projectId,
+      createdAt: "not-a-date",
+    });
+    expect(error?.field).toBe("createdAt");
+  });
+
+  it("rejects invalid updatedAt in create", () => {
+    const error = validateCreateTaskInput({
+      title: "Imported task",
+      projectId,
+      updatedAt: "not-a-date",
+    });
+    expect(error?.field).toBe("updatedAt");
+  });
+
   it("rejects empty assignee string in create", () => {
     const error = validateCreateTaskInput({ title: "Test", projectId, assignees: [""] });
     expect(error?.field).toBe("assignees");
@@ -552,6 +581,15 @@ describe("validateUpdateTaskInput", () => {
         sourceUrl: "https://example.com/issues/101",
       }),
     ).toBeNull();
+  });
+
+  it("accepts imported updatedAt in update", () => {
+    expect(validateUpdateTaskInput({ updatedAt: "2021-04-18T09:15:00Z" })).toBeNull();
+  });
+
+  it("rejects invalid updatedAt in update", () => {
+    const error = validateUpdateTaskInput({ updatedAt: "not-a-date" });
+    expect(error?.field).toBe("updatedAt");
   });
 
   it("rejects empty assignee string in update", () => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -376,6 +376,16 @@ export function validateCreateTaskInput(input: CreateTaskInput): ValidationError
     if (sourceUrlError) return sourceUrlError;
   }
 
+  if (input.createdAt !== undefined) {
+    const createdAtError = validateISODate("createdAt", input.createdAt);
+    if (createdAtError) return createdAtError;
+  }
+
+  if (input.updatedAt !== undefined) {
+    const updatedAtError = validateISODate("updatedAt", input.updatedAt);
+    if (updatedAtError) return updatedAtError;
+  }
+
   return null;
 }
 
@@ -393,7 +403,8 @@ export function validateUpdateTaskInput(
     input.dueDate === undefined &&
     input.scheduledDate === undefined &&
     input.externalId === undefined &&
-    input.sourceUrl === undefined
+    input.sourceUrl === undefined &&
+    input.updatedAt === undefined
   ) {
     return validationError("input", "At least one field must be provided");
   }
@@ -447,6 +458,11 @@ export function validateUpdateTaskInput(
   if (input.sourceUrl !== undefined) {
     const sourceUrlError = validateTaskLinkField("sourceUrl", input.sourceUrl);
     if (sourceUrlError) return sourceUrlError;
+  }
+
+  if (input.updatedAt !== undefined) {
+    const updatedAtError = validateISODate("updatedAt", input.updatedAt);
+    if (updatedAtError) return updatedAtError;
   }
 
   return null;

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -769,6 +769,7 @@ describe("sync-worker-runtime", () => {
         title: "Pulled bug",
         description: "Imported from GitHub",
         sourceUrl: "https://example.com/issues/101",
+        createdAt: "2021-04-17T14:30:00Z",
         updatedAt: "2026-03-10T15:00:00Z",
       },
     ];
@@ -826,6 +827,8 @@ describe("sync-worker-runtime", () => {
       assignees: ["octocat"],
       externalId: "gh-101",
       sourceUrl: "https://example.com/issues/101",
+      createdAt: "2021-04-17T14:30:00.000Z",
+      updatedAt: "2026-03-10T15:00:00.000Z",
     });
 
     handle.stop();
@@ -836,6 +839,7 @@ describe("sync-worker-runtime", () => {
     const existingTask = {
       ...createTask(project.id),
       externalId: "gh-101",
+      createdAt: "2021-04-17T14:30:00Z",
       updatedAt: "2026-03-09T10:00:00Z",
     };
     const binding = createBinding(project.id, { strategy: "pull" });
@@ -899,6 +903,75 @@ describe("sync-worker-runtime", () => {
       assignees: ["octocat"],
       externalId: "gh-101",
       sourceUrl: "https://example.com/issues/101",
+      updatedAt: "2026-03-10T15:00:00.000Z",
+    });
+
+    handle.stop();
+  });
+
+  it("pull falls back imported updatedAt to createdAt when missing", async () => {
+    const project = createProject();
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledTasks: ExternalTask[] = [
+      {
+        externalId: "gh-101",
+        title: "Pulled bug",
+        description: "Imported from GitHub",
+        createdAt: "2021-04-17T14:30:00Z",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: pulledTasks,
+      }),
+      mapToTask: vi
+        .fn<SyncProvider["mapToTask"]>()
+        .mockImplementation((external, activeProject) => ({
+          id: createTaskId(`task-${external.externalId}`),
+          title: external.title,
+          status: "waiting",
+          priority: "high",
+          projectId: activeProject.id,
+          labels: ["bug"],
+          assignees: ["octocat"],
+          sourceUrl: external.sourceUrl,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        })),
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.create).toHaveBeenCalledWith({
+      title: "Pulled bug",
+      projectId: project.id,
+      status: "waiting",
+      priority: "high",
+      description: "Imported from GitHub",
+      labels: ["bug"],
+      assignees: ["octocat"],
+      externalId: "gh-101",
+      createdAt: "2021-04-17T14:30:00.000Z",
+      updatedAt: "2021-04-17T14:30:00.000Z",
     });
 
     handle.stop();
@@ -950,6 +1023,49 @@ describe("sync-worker-runtime", () => {
     expect(provider.mapToTask).toHaveBeenCalledTimes(1);
     expect(todu.task.update).not.toHaveBeenCalled();
     expect(todu.task.create).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
+
+  it("pull fails safely when a pulled task timestamp is invalid", async () => {
+    const project = createProject();
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const pulledTasks: ExternalTask[] = [
+      {
+        externalId: "gh-101",
+        title: "Pulled bug",
+        createdAt: "not-a-date",
+      },
+    ];
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: pulledTasks,
+      }),
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.create).not.toHaveBeenCalled();
+    expect(todu.task.update).not.toHaveBeenCalled();
 
     handle.stop();
   });
@@ -1430,6 +1546,8 @@ function createTodu(
         assignees?: string[];
         externalId?: string;
         sourceUrl?: string;
+        createdAt?: string;
+        updatedAt?: string;
       }) => {
         const createdTask: Task = {
           id: createTaskId(`task-created-${tasks.length + 1}`),
@@ -1439,8 +1557,8 @@ function createTodu(
           projectId: input.projectId as Project["id"],
           labels: input.labels ?? [],
           assignees: input.assignees ?? [],
-          createdAt: new Date(0).toISOString(),
-          updatedAt: new Date(0).toISOString(),
+          createdAt: input.createdAt ?? new Date(0).toISOString(),
+          updatedAt: input.updatedAt ?? input.createdAt ?? new Date(0).toISOString(),
         };
         if (input.externalId !== undefined) createdTask.externalId = input.externalId;
         if (input.sourceUrl !== undefined) createdTask.sourceUrl = input.sourceUrl;
@@ -1461,6 +1579,7 @@ function createTodu(
         assignees?: string[];
         externalId?: string;
         sourceUrl?: string;
+        updatedAt?: string;
       },
     ) => {
       const task = tasks.find((candidate) => candidate.id === id);
@@ -1472,7 +1591,7 @@ function createTodu(
       if (input.assignees !== undefined) task.assignees = [...input.assignees];
       if (input.externalId !== undefined) task.externalId = input.externalId;
       if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl;
-      task.updatedAt = new Date(0).toISOString();
+      task.updatedAt = input.updatedAt ?? new Date(0).toISOString();
       return ok({ ...task, description: input.description });
     },
   );

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -457,14 +457,47 @@ async function applyPushTaskLinks(todu: Todu, links: SyncProviderPushTaskLink[])
   }
 }
 
-function getPulledTaskTimestamp(task: ExternalTask): string | null {
-  return task.updatedAt ?? task.createdAt ?? null;
+function normalizePulledTaskTimestamp(
+  task: ExternalTask,
+  field: "createdAt" | "updatedAt",
+): string | null {
+  const value = task[field];
+  if (value === undefined) {
+    return null;
+  }
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(
+      `pulled task has invalid ${field}: externalId=${task.externalId} value=${value}`,
+    );
+  }
+
+  return timestamp.toISOString();
+}
+
+function getPulledTaskTimestamps(task: ExternalTask): {
+  createdAt?: string;
+  updatedAt?: string;
+  comparisonTimestamp: string | null;
+} {
+  const createdAt = normalizePulledTaskTimestamp(task, "createdAt");
+  const updatedAt = normalizePulledTaskTimestamp(task, "updatedAt");
+  const effectiveCreatedAt = createdAt ?? updatedAt ?? undefined;
+  const effectiveUpdatedAt = updatedAt ?? createdAt ?? undefined;
+
+  return {
+    createdAt: effectiveCreatedAt,
+    updatedAt: effectiveUpdatedAt,
+    comparisonTimestamp: effectiveUpdatedAt ?? null,
+  };
 }
 
 function buildPulledTaskCreateInput(
   mappedTask: Task,
   project: Project,
   externalTask: ExternalTask,
+  timestamps: { createdAt?: string; updatedAt?: string },
 ): {
   title: string;
   projectId: Project["id"];
@@ -475,6 +508,8 @@ function buildPulledTaskCreateInput(
   assignees: string[];
   externalId: string;
   sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
 } {
   const input: {
     title: string;
@@ -486,6 +521,8 @@ function buildPulledTaskCreateInput(
     assignees: string[];
     externalId: string;
     sourceUrl?: string;
+    createdAt?: string;
+    updatedAt?: string;
   } = {
     title: mappedTask.title,
     projectId: project.id,
@@ -505,12 +542,21 @@ function buildPulledTaskCreateInput(
     input.sourceUrl = sourceUrl;
   }
 
+  if (timestamps.createdAt !== undefined) {
+    input.createdAt = timestamps.createdAt;
+  }
+
+  if (timestamps.updatedAt !== undefined) {
+    input.updatedAt = timestamps.updatedAt;
+  }
+
   return input;
 }
 
 function buildPulledTaskUpdateInput(
   mappedTask: Task,
   externalTask: ExternalTask,
+  timestamps: { updatedAt?: string },
 ): {
   title: string;
   status: Task["status"];
@@ -520,6 +566,7 @@ function buildPulledTaskUpdateInput(
   assignees: string[];
   externalId: string;
   sourceUrl?: string;
+  updatedAt?: string;
 } {
   const input: {
     title: string;
@@ -530,6 +577,7 @@ function buildPulledTaskUpdateInput(
     assignees: string[];
     externalId: string;
     sourceUrl?: string;
+    updatedAt?: string;
   } = {
     title: mappedTask.title,
     status: mappedTask.status,
@@ -546,6 +594,10 @@ function buildPulledTaskUpdateInput(
   const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
   if (sourceUrl !== undefined) {
     input.sourceUrl = sourceUrl;
+  }
+
+  if (timestamps.updatedAt !== undefined) {
+    input.updatedAt = timestamps.updatedAt;
   }
 
   return input;
@@ -573,11 +625,12 @@ async function applyPulledTasks(
   for (const externalTask of tasks) {
     const mappedTask = provider.mapToTask(externalTask, project);
     const existingTask = localByExternalId.get(externalTask.externalId);
-    const externalUpdatedAt = getPulledTaskTimestamp(externalTask);
+    const pulledTimestamps = getPulledTaskTimestamps(externalTask);
+    const externalUpdatedAt = pulledTimestamps.comparisonTimestamp;
 
     if (!existingTask) {
       const createResult = await todu.task.create(
-        buildPulledTaskCreateInput(mappedTask, project, externalTask),
+        buildPulledTaskCreateInput(mappedTask, project, externalTask, pulledTimestamps),
       );
       if (!createResult.ok) {
         throw new Error(
@@ -597,7 +650,7 @@ async function applyPulledTasks(
 
     const updateResult = await todu.task.update(
       existingTask.id,
-      buildPulledTaskUpdateInput(mappedTask, externalTask),
+      buildPulledTaskUpdateInput(mappedTask, externalTask, pulledTimestamps),
     );
     if (!updateResult.ok) {
       throw new Error(

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -131,6 +131,33 @@ describe("task namespace", () => {
       expect(result.value.sourceUrl).toBe("https://example.com/issues/101");
     });
 
+    it("creates a task with imported timestamps", async () => {
+      const result = await todu.task.create({
+        title: "Imported task",
+        projectId,
+        createdAt: "2021-04-17T14:30:00Z",
+        updatedAt: "2021-04-18T09:15:00Z",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.createdAt).toBe("2021-04-17T14:30:00.000Z");
+      expect(result.value.updatedAt).toBe("2021-04-18T09:15:00.000Z");
+    });
+
+    it("falls back imported updatedAt to createdAt on create", async () => {
+      const result = await todu.task.create({
+        title: "Imported task",
+        projectId,
+        createdAt: "2021-04-17T14:30:00Z",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.createdAt).toBe("2021-04-17T14:30:00.000Z");
+      expect(result.value.updatedAt).toBe("2021-04-17T14:30:00.000Z");
+    });
+
     it("trims whitespace from title", async () => {
       const result = await todu.task.create({ title: "  Trimmed  ", projectId });
       expect(result.ok).toBe(true);
@@ -435,6 +462,26 @@ describe("task namespace", () => {
       if (!result.ok) return;
       expect(result.value.externalId).toBe("gh-101");
       expect(result.value.sourceUrl).toBe("https://example.com/issues/101");
+    });
+
+    it("updates imported updatedAt without changing createdAt", async () => {
+      const imported = await todu.task.create({
+        title: "Imported task",
+        projectId,
+        createdAt: "2021-04-17T14:30:00Z",
+        updatedAt: "2021-04-18T09:15:00Z",
+      });
+      if (!imported.ok) throw new Error("create failed");
+
+      const result = await todu.task.update(imported.value.id, {
+        title: "Updated import",
+        updatedAt: "2021-05-01T12:00:00Z",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.title).toBe("Updated import");
+      expect(result.value.createdAt).toBe("2021-04-17T14:30:00.000Z");
+      expect(result.value.updatedAt).toBe("2021-05-01T12:00:00.000Z");
     });
 
     it("replaces assignees entirely on update", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -161,6 +161,16 @@ export function createTaskNamespace(
       if (!project) return err(notFound("project", input.projectId));
 
       const now = new Date().toISOString();
+      const createdAt = input.createdAt
+        ? normalizeTaskTimestamp(input.createdAt)
+        : input.updatedAt
+          ? normalizeTaskTimestamp(input.updatedAt)
+          : now;
+      const updatedAt = input.updatedAt
+        ? normalizeTaskTimestamp(input.updatedAt)
+        : input.createdAt
+          ? normalizeTaskTimestamp(input.createdAt)
+          : now;
       const id = overrideTaskId ?? createTaskId(`task-${crypto.randomUUID().slice(0, 8)}`);
 
       const task: Task = {
@@ -171,8 +181,8 @@ export function createTaskNamespace(
         projectId: input.projectId,
         labels: input.labels ?? [],
         assignees: input.assignees ?? [],
-        createdAt: now,
-        updatedAt: now,
+        createdAt,
+        updatedAt,
       };
       // Automerge doesn't allow undefined — only set optional fields if present
       if (input.dueDate !== undefined) task.dueDate = input.dueDate;
@@ -318,7 +328,9 @@ export function createTaskNamespace(
       const validationErr = validateUpdateTaskInput(input, result.task.status);
       if (validationErr) return err(validationErr);
 
-      const now = new Date().toISOString();
+      const updatedAt = input.updatedAt
+        ? normalizeTaskTimestamp(input.updatedAt)
+        : new Date().toISOString();
 
       // Update metadata in task list document
       result.listHandle.change((doc) => {
@@ -338,7 +350,7 @@ export function createTaskNamespace(
         if (input.scheduledDate !== undefined) task.scheduledDate = input.scheduledDate;
         if (input.externalId !== undefined) task.externalId = input.externalId.trim();
         if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
-        task.updatedAt = now;
+        task.updatedAt = updatedAt;
       });
 
       // Update description in detail document if changed
@@ -538,4 +550,8 @@ function stripUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
     }
   }
   return result as Partial<T>;
+}
+
+function normalizeTaskTimestamp(value: string): string {
+  return new Date(value).toISOString();
 }


### PR DESCRIPTION
## Summary

Preserve external task timestamps when sync-provider pull creates or updates local tasks so imported issue history stays aligned with the source system.

## Task

- #2283

## Changes

- extend task create and update inputs with imported timestamp support
- validate imported task timestamps in core
- preserve imported task timestamps in the engine while keeping normal local task creation unchanged
- update sync-provider pull runtime to normalize and persist external task timestamps
- fail pull safely on invalid external task timestamps
- document imported timestamp semantics for sync providers
- add validation, engine, and sync runtime regression coverage

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/core/src/validation.test.ts packages/engine/src/tasks.integration.test.ts packages/daemon/src/sync-worker-runtime.test.ts`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated
- [x] No unrelated changes included