### PR TITLE
feat: add per-binding integration options

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -61,6 +61,7 @@ Each integration binding represents the user's intended relationship between one
 | `targetRef` | string | Normalized external target identity such as `owner/repo` | Provider interprets the value according to `provider` + `targetKind` |
 | `strategy` | enum | Desired sync behavior for this binding | Initial values: `bidirectional`, `pull`, `push`, `none` |
 | `enabled` | boolean | Desired execution state | `false` keeps binding visible but inactive |
+| `options` | object | Optional provider-specific desired-state options | Plain JSON object only; not for secrets or runtime internals |
 | `createdAt` | timestamp | Audit field | Core-owned |
 | `updatedAt` | timestamp | Audit field | Core-owned |
 
@@ -77,7 +78,7 @@ To keep the first version simple and avoid overlapping control planes:
 
 ### What stays out of the core integration binding
 
-Do not add provider-specific blobs or generic key/value bags for plugin internals.
+Provider-specific desired-state options may live in `binding.options`, but only as plain JSON configuration needed to express shared user intent. Do not use `binding.options` for plugin internals.
 
 The following remain outside synced core entities:
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -179,7 +179,9 @@ Use the generic integration command group to manage integration bindings through
 toduai integration list
 toduai integration list --provider github
 toduai integration add --provider github --project Work --target-kind repository --target owner/repo
+toduai integration add --provider forgejo --project Work --target-kind repository --target owner/repo --options '{"importClosedOnBootstrap":true}'
 toduai integration update <binding-id> --target-kind repository --target owner/renamed-repo
+toduai integration update <binding-id> --options '{"importClosedOnBootstrap":false}'
 toduai integration set-strategy <binding-id> --strategy pull
 toduai integration enable <binding-id>
 toduai integration disable <binding-id>
@@ -192,6 +194,8 @@ Behavior notes:
 - Integration bindings are the generic shared control plane for external integrations.
 - Project commands no longer expose project-level external sync settings; use `toduai integration ...` to manage external sync intent.
 - Provider-specific credential setup stays out of `integration add|update|remove` and remains local to the authority daemon host.
+- `integration add` and `integration update` accept `--options <json>` for provider-specific desired-state binding options.
+- Binding `options` are shared user intent only; do not store secrets, tokens, cursors, retry state, or diagnostics there.
 - `integration list` supports filtering by `--provider`, `--project`, `--enabled`, and `--disabled`.
 - `integration status` shows runtime status for one binding or all bindings.
 - Projects without integration bindings remain normal todu projects.

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -199,9 +199,9 @@ Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginNa
 - `enabled`: optional execution toggle for the local provider worker.
 - `settings`: provider-specific object passed to `initialize(...)`.
 
-Binding desired state is no longer configured through local plugin config. The daemon host now enumerates shared integration bindings from core state, filters by provider name and `enabled` state, and executes provider work according to each binding's `strategy`, `projectId`, `targetKind`, and `targetRef`.
+Binding desired state is no longer configured through local plugin config. The daemon host now enumerates shared integration bindings from core state, filters by provider name and `enabled` state, and executes provider work according to each binding's `strategy`, `projectId`, `targetKind`, `targetRef`, and optional `options` object.
 
-Architecture note: the generic integration direction in `docs/architecture/integrations.md` moves project-to-external integration binding desired state into synced core data. In that model, local provider config remains the place for secrets, credentials, retry tuning, and other host-local runtime settings.
+Architecture note: the generic integration direction in `docs/architecture/integrations.md` moves project-to-external integration binding desired state into synced core data. In that model, local provider config remains the place for secrets, credentials, retry tuning, and other host-local runtime settings. `binding.options` is for provider-specific desired-state configuration only and must not be used for secrets or runtime internals.
 
 Retry policy:
 

--- a/packages/cli/src/commands/integration.ts
+++ b/packages/cli/src/commands/integration.ts
@@ -62,6 +62,10 @@ function integrationDetail(binding: IntegrationBinding, projectName?: string): s
     `Updated:     ${binding.updatedAt}`,
   ];
 
+  if (binding.options !== undefined) {
+    lines.push(`Options:     ${JSON.stringify(binding.options)}`);
+  }
+
   return lines.join("\n");
 }
 
@@ -97,6 +101,10 @@ function integrationStatusDetail(item: IntegrationBindingWithStatus, projectName
     `Last Error:          ${item.status.lastErrorSummary ?? "-"}`,
     `Updated:             ${item.status.updatedAt}`,
   ];
+
+  if (item.binding.options !== undefined) {
+    lines.push(`Options:             ${JSON.stringify(item.binding.options)}`);
+  }
 
   return lines.join("\n");
 }
@@ -198,6 +206,56 @@ async function listIntegrationBindingsWithStatus(
   };
 }
 
+function parseIntegrationOptionsJson(
+  value: string | undefined,
+): { ok: true; value: Record<string, unknown> | undefined } | { ok: false; message: string } {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    return {
+      ok: false,
+      message: "integration options JSON cannot be empty",
+    };
+  }
+
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(trimmedValue);
+  } catch (error) {
+    return {
+      ok: false,
+      message: `invalid options JSON: ${stringifyUnknownError(error)}`,
+    };
+  }
+
+  if (!isRecord(parsedValue)) {
+    return {
+      ok: false,
+      message: "integration options must be a JSON object",
+    };
+  }
+
+  return {
+    ok: true,
+    value: parsedValue,
+  };
+}
+
+function stringifyUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function registerIntegrationCommands(
   program: Command,
   invokeDaemon: CliDaemonInvoker,
@@ -269,6 +327,7 @@ export function registerIntegrationCommands(
     .requiredOption("--target-kind <kind>", "target kind")
     .requiredOption("--target <target>", "target reference")
     .option("--strategy <strategy>", "sync strategy (bidirectional, pull, push, none)")
+    .option("--options <json>", "provider-specific desired-state options as JSON object")
     .option("--disabled", "create the integration binding disabled")
     .action(async (opts) => {
       const project = await resolveProjectId(invokeDaemon, opts.project);
@@ -284,6 +343,13 @@ export function registerIntegrationCommands(
         return;
       }
 
+      const parsedOptions = parseIntegrationOptionsJson(opts.options);
+      if (!parsedOptions.ok) {
+        console.error(`Error: ${parsedOptions.message}`);
+        process.exitCode = 1;
+        return;
+      }
+
       const result = await invokeDaemon<IntegrationBinding>("integration.create", {
         input: {
           provider: opts.provider,
@@ -292,6 +358,7 @@ export function registerIntegrationCommands(
           targetRef: opts.target,
           strategy: opts.strategy,
           enabled: opts.disabled ? false : undefined,
+          options: parsedOptions.value,
         },
       });
 
@@ -317,6 +384,7 @@ export function registerIntegrationCommands(
     .option("--project <project>", "new project (ID or name)")
     .option("--target-kind <kind>", "new target kind")
     .option("--target <target>", "new target reference")
+    .option("--options <json>", "replace provider-specific desired-state options with JSON object")
     .action(async (id, opts) => {
       let projectId: string | undefined;
       let projectName: string | undefined;
@@ -333,11 +401,19 @@ export function registerIntegrationCommands(
         projectName = project.name;
       }
 
+      const parsedOptions = parseIntegrationOptionsJson(opts.options);
+      if (!parsedOptions.ok) {
+        console.error(`Error: ${parsedOptions.message}`);
+        process.exitCode = 1;
+        return;
+      }
+
       const input: Record<string, unknown> = {};
       if (opts.provider) input.provider = opts.provider;
       if (projectId) input.projectId = projectId;
       if (opts.targetKind) input.targetKind = opts.targetKind;
       if (opts.target) input.targetRef = opts.target;
+      if (parsedOptions.value !== undefined) input.options = parsedOptions.value;
 
       if (Object.keys(input).length === 0) {
         console.error("Error: at least one update field is required");

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,6 +158,7 @@ export interface IntegrationBinding {
   targetRef: string;
   strategy: SyncStrategy;
   enabled: boolean;
+  options?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
 }
@@ -259,6 +260,7 @@ export interface CreateIntegrationBindingInput {
   targetRef: string;
   strategy?: SyncStrategy;
   enabled?: boolean;
+  options?: Record<string, unknown>;
 }
 
 export interface UpdateIntegrationBindingInput {
@@ -268,6 +270,7 @@ export interface UpdateIntegrationBindingInput {
   targetRef?: string;
   strategy?: SyncStrategy;
   enabled?: boolean;
+  options?: Record<string, unknown>;
 }
 
 export interface IntegrationBindingFilter {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -242,6 +242,32 @@ describe("validateCreateIntegrationBindingInput", () => {
     expect(error?.field).toBe("strategy");
   });
 
+  it("accepts object options", () => {
+    expect(
+      validateCreateIntegrationBindingInput({
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+        options: {
+          importClosedOnBootstrap: true,
+          labels: ["bug"],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects non-object options", () => {
+    const error = validateCreateIntegrationBindingInput({
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      options: ["bad"] as unknown as Record<string, unknown>,
+    });
+    expect(error?.field).toBe("options");
+  });
+
   it("rejects a duplicate project binding", () => {
     const error = validateCreateIntegrationBindingInput(
       {
@@ -310,6 +336,23 @@ describe("validateUpdateIntegrationBindingInput", () => {
   it("rejects invalid strategy", () => {
     const error = validateUpdateIntegrationBindingInput({ strategy: "sync" as "push" });
     expect(error?.field).toBe("strategy");
+  });
+
+  it("accepts object options update", () => {
+    expect(
+      validateUpdateIntegrationBindingInput({
+        options: {
+          importClosedOnBootstrap: true,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects non-object options update", () => {
+    const error = validateUpdateIntegrationBindingInput({
+      options: null as unknown as Record<string, unknown>,
+    });
+    expect(error?.field).toBe("options");
   });
 
   it("rejects moving to a project that already has a binding", () => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -90,6 +90,27 @@ export function validateIntegrationBindingField(
   return null;
 }
 
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function validateIntegrationBindingOptions(options: unknown): ValidationError | null {
+  if (options === undefined) {
+    return null;
+  }
+
+  if (!isPlainJsonObject(options)) {
+    return validationError("options", "options must be a JSON object");
+  }
+
+  return null;
+}
+
 export function validateIntegrationBindingProjectUniqueness(
   projectId: string,
   bindings: IntegrationBinding[],
@@ -190,6 +211,9 @@ export function validateCreateIntegrationBindingInput(
     return validationError("strategy", `Invalid sync strategy: ${input.strategy}`);
   }
 
+  const optionsError = validateIntegrationBindingOptions(input.options);
+  if (optionsError) return optionsError;
+
   return validateIntegrationBindingProjectUniqueness(input.projectId, bindings);
 }
 
@@ -208,7 +232,8 @@ export function validateUpdateIntegrationBindingInput(
     input.targetKind === undefined &&
     input.targetRef === undefined &&
     input.strategy === undefined &&
-    input.enabled === undefined
+    input.enabled === undefined &&
+    input.options === undefined
   ) {
     return validationError("input", "At least one field must be provided");
   }
@@ -231,6 +256,9 @@ export function validateUpdateIntegrationBindingInput(
   if (input.strategy !== undefined && !isSyncStrategy(input.strategy)) {
     return validationError("strategy", `Invalid sync strategy: ${input.strategy}`);
   }
+
+  const optionsError = validateIntegrationBindingOptions(input.options);
+  if (optionsError) return optionsError;
 
   if (input.projectId !== undefined) {
     return validateIntegrationBindingProjectUniqueness(

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -115,6 +115,51 @@ describe("sync-worker-runtime", () => {
     expect(provider.shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("passes binding options through to providers on the first sync cycle", async () => {
+    const provider = createProvider();
+    const project = createProject();
+    const binding = createBinding(project.id, {
+      options: {
+        importClosedOnBootstrap: true,
+      },
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(provider.pull).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: binding.id,
+        options: {
+          importClosedOnBootstrap: true,
+        },
+      }),
+      project,
+    );
+
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+  });
+
   it("retries failed cycles with exponential backoff and writes error status", async () => {
     const provider = createProvider({
       pull: vi
@@ -1411,6 +1456,7 @@ function createBinding(
     targetRef: overrides.targetRef ?? "owner/repo",
     strategy: overrides.strategy ?? "bidirectional",
     enabled: overrides.enabled ?? true,
+    options: overrides.options,
     createdAt: now,
     updatedAt: now,
   };

--- a/packages/engine/src/integrations.ts
+++ b/packages/engine/src/integrations.ts
@@ -25,7 +25,12 @@ import {
 import type { IntegrationNamespace } from "./todu.js";
 
 function cloneIntegrationBinding(binding: IntegrationBinding): IntegrationBinding {
-  return { ...binding };
+  return {
+    ...binding,
+    ...(binding.options !== undefined
+      ? { options: JSON.parse(JSON.stringify(binding.options)) as Record<string, unknown> }
+      : {}),
+  };
 }
 
 function cloneIntegrationBindingStatus(
@@ -165,6 +170,9 @@ export function createIntegrationNamespace(
         targetRef: input.targetRef.trim(),
         strategy: input.strategy ?? "bidirectional",
         enabled: input.enabled ?? true,
+        ...(input.options !== undefined
+          ? { options: JSON.parse(JSON.stringify(input.options)) as Record<string, unknown> }
+          : {}),
         createdAt: now,
         updatedAt: now,
       };
@@ -226,6 +234,9 @@ export function createIntegrationNamespace(
         if (input.targetRef !== undefined) binding.targetRef = input.targetRef.trim();
         if (input.strategy !== undefined) binding.strategy = input.strategy;
         if (input.enabled !== undefined) binding.enabled = input.enabled;
+        if (input.options !== undefined) {
+          binding.options = JSON.parse(JSON.stringify(input.options)) as Record<string, unknown>;
+        }
         binding.updatedAt = now;
       });
 


### PR DESCRIPTION
## Summary

Add optional per-binding `options` to shared integration bindings so provider-specific desired-state can be set at binding creation time and seen on the first sync cycle.

## Task

#2306

## Changes

- add optional `options` object to integration binding core types and validation
- persist and round-trip binding options through the engine integration registry
- add CLI support for `integration add --options <json>` and `integration update --options <json>`
- surface binding options in detailed integration text output
- document binding options as shared desired-state only, not secrets or runtime internals
- add fast coverage for core validation and provider receipt of binding options

## Verification

- [x] `make check`
- [x] `npm test -- packages/core/src/validation.test.ts packages/daemon/src/sync-worker-runtime.test.ts`
- [x] manual smoke check for `integration add/update --options`
- [x] `make pre-pr`

## Notes

Per request, no new integration tests were added.