### PR TITLE
fix: add CLI habit note support

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -267,11 +267,19 @@ toduai note add "Started new role today" --created-at 2019-06-03T09:00:00Z
 toduai note add "Moved apartments" --created-at 2020-08-29T18:45:00Z
 ```
 
+Attach a comment to a habit from the CLI:
+
+```bash
+toduai note add "Floss method: Water Pick" --habit hab-123
+toduai --format json note list --habit hab-123
+```
+
 Behavior notes:
 - `--created-at` accepts an ISO-8601 date or datetime string.
 - Stored journal timestamps are normalized to ISO datetime form.
 - Standalone journal notes are bucketed by the provided historical month, not by import time.
 - Invalid `--created-at` input fails with a validation error.
+- `--habit <id>` attaches a note to a habit or filters notes for a habit.
 
 ## Validate connectivity
 

--- a/packages/cli/src/commands/note.test.ts
+++ b/packages/cli/src/commands/note.test.ts
@@ -1,0 +1,107 @@
+import type { Note } from "@todu/core";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliDaemonInvoker } from "../daemon-command-client.js";
+import { registerNoteCommands } from "./note.js";
+
+describe("note commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("passes habit attachment through on note add", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "note.create") {
+        return {
+          ok: true,
+          value: {
+            id: "note-1",
+            content: "Floss method: Water Pick",
+            author: "user",
+            entityType: "habit",
+            entityId: "hab-123",
+            tags: [],
+            createdAt: "2026-03-14T15:00:00.000Z",
+          } satisfies Note,
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("toduai").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(
+      ["--format", "json", "note", "add", "Floss method: Water Pick", "--habit", "hab-123"],
+      { from: "user" },
+    );
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("note.create", {
+      input: {
+        content: "Floss method: Water Pick",
+        entityType: "habit",
+        entityId: "hab-123",
+        tags: undefined,
+        author: undefined,
+        createdAt: undefined,
+      },
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toMatchObject({
+      entityType: "habit",
+      entityId: "hab-123",
+    });
+  });
+
+  it("passes habit filtering through on note list", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "note.list") {
+        return {
+          ok: true,
+          value: [
+            {
+              id: "note-1",
+              content: "Floss method: Water Pick",
+              author: "user",
+              entityType: "habit",
+              entityId: "hab-123",
+              tags: [],
+              createdAt: "2026-03-14T15:00:00.000Z",
+            } satisfies Note,
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("toduai").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(["--format", "json", "note", "list", "--habit", "hab-123"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("note.list", {
+      filter: {
+        entityType: "habit",
+        entityId: "hab-123",
+        tag: undefined,
+        author: undefined,
+      },
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toMatchObject([
+      {
+        entityType: "habit",
+        entityId: "hab-123",
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -71,6 +71,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .description("Add a note (standalone journal entry, or attached to an entity)")
     .option("--task <id>", "attach to a task")
     .option("--project <ref>", "attach to a project")
+    .option("--habit <id>", "attach to a habit")
     .option("--tag <tags...>", "tags")
     .option("--author <author>", "author (default: user)")
     .option("--created-at <iso>", "ISO timestamp for importing/backdating a journal entry")
@@ -91,6 +92,9 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
 
         entityType = "project";
         entityId = project.value;
+      } else if (opts.habit) {
+        entityType = "habit";
+        entityId = opts.habit;
       }
 
       const result = await invokeDaemon<Note>("note.create", {
@@ -124,6 +128,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .description("List notes")
     .option("--task <id>", "filter by task")
     .option("--project <ref>", "filter by project")
+    .option("--habit <id>", "filter by habit")
     .option("--tag <tag>", "filter by tag")
     .option("--author <author>", "filter by author")
     .action(async (opts) => {
@@ -143,6 +148,9 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
 
         entityType = "project";
         entityId = project.value;
+      } else if (opts.habit) {
+        entityType = "habit";
+        entityId = opts.habit;
       }
 
       const result = await invokeDaemon<Note[]>("note.list", {


### PR DESCRIPTION
## Summary

Add CLI support for habit-attached notes so habit comments can be managed from `toduai` like they already can from Electron.

## Task

#2312

## Changes

- add `--habit <id>` to `toduai note add`
- add `--habit <id>` to `toduai note list`
- add fast unit coverage for habit note attachment and filtering
- document the CLI habit comment path in `docs/cli-daemon-usage.md`

## Verification

- [x] `npm test -- packages/cli/src/commands/note.test.ts`
- [x] `make check`
- [x] temp-dir manual smoke check for `note add --habit` / `note list --habit`
- [x] `make pre-pr`

## Notes

No new integration tests were added.