### PR TITLE
fix: truncate oversized descriptions and note content on pull

### DIFF
--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1382,6 +1382,251 @@ describe("sync-worker-runtime", () => {
 
     handle.stop();
   });
+
+  it("pull truncates task description that exceeds MAX_DESCRIPTION_LENGTH", async () => {
+    const project = createProject();
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const overLimitDescription = "x".repeat(10001);
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [
+          {
+            externalId: "gh-task-1",
+            title: "Task with long description",
+            description: overLimitDescription,
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.create).toHaveBeenCalledTimes(1);
+    const createdDescription = todu.task.create.mock.calls[0][0].description as string;
+    expect(createdDescription.length).toBe(10000);
+    expect(createdDescription.endsWith("... [truncated]")).toBe(true);
+
+    handle.stop();
+  });
+
+  it("pull does not truncate task description within MAX_DESCRIPTION_LENGTH", async () => {
+    const project = createProject();
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const atLimitDescription = "x".repeat(10000);
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [
+          {
+            externalId: "gh-task-1",
+            title: "Task with at-limit description",
+            description: atLimitDescription,
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.task.create).toHaveBeenCalledTimes(1);
+    const createdDescription = todu.task.create.mock.calls[0][0].description as string;
+    expect(createdDescription).toBe(atLimitDescription);
+
+    handle.stop();
+  });
+
+  it("pull truncates note body that exceeds MAX_NOTE_CONTENT_LENGTH when creating", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const overLimitBody = "y".repeat(10001);
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: overLimitBody,
+            author: "octocat",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.create).toHaveBeenCalledTimes(1);
+    const createdContent = todu.note.create.mock.calls[0][0].content as string;
+    expect(createdContent.length).toBe(10000);
+    expect(createdContent.endsWith("... [truncated]")).toBe(true);
+
+    handle.stop();
+  });
+
+  it("pull truncates note body that exceeds MAX_NOTE_CONTENT_LENGTH when updating", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const existingNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "old content",
+      tags: ["sync:externalId:gh-comment-1"],
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const overLimitBody = "y".repeat(10001);
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: overLimitBody,
+            author: "octocat",
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [existingNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.update).toHaveBeenCalledTimes(1);
+    const updatedContent = todu.note.update.mock.calls[0][1].content as string;
+    expect(updatedContent.length).toBe(10000);
+    expect(updatedContent.endsWith("... [truncated]")).toBe(true);
+
+    handle.stop();
+  });
+
+  it("pull does not truncate note body within MAX_NOTE_CONTENT_LENGTH", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const atLimitBody = "y".repeat(10000);
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: atLimitBody,
+            author: "octocat",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.create).toHaveBeenCalledTimes(1);
+    const createdContent = todu.note.create.mock.calls[0][0].content as string;
+    expect(createdContent).toBe(atLimitBody);
+
+    handle.stop();
+  });
 });
 
 function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -3,6 +3,8 @@ import {
   type ExternalComment,
   type ExternalTask,
   type IntegrationBinding,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_NOTE_CONTENT_LENGTH,
   type Note,
   type Project,
   type SyncProvider,
@@ -20,6 +22,12 @@ const DEFAULT_SYNC_INTERVAL_SECONDS = 300;
 const DEFAULT_RETRY_INITIAL_SECONDS = 5;
 const DEFAULT_RETRY_MAX_SECONDS = 60;
 const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
+const TRUNCATION_SUFFIX = "... [truncated]";
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return value.slice(0, maxLength - TRUNCATION_SUFFIX.length) + TRUNCATION_SUFFIX;
+}
 
 export interface SyncPluginExecutionConfig {
   enabled: boolean;
@@ -534,7 +542,7 @@ function buildPulledTaskCreateInput(
   };
 
   if (externalTask.description !== undefined) {
-    input.description = externalTask.description;
+    input.description = truncate(externalTask.description, MAX_DESCRIPTION_LENGTH);
   }
 
   const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
@@ -588,7 +596,7 @@ function buildPulledTaskUpdateInput(
   };
 
   if (externalTask.description !== undefined) {
-    input.description = externalTask.description;
+    input.description = truncate(externalTask.description, MAX_DESCRIPTION_LENGTH);
   }
 
   const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
@@ -776,7 +784,7 @@ async function applyPulledComments(
       if (!localNote) {
         // Create new note
         await todu.note.create({
-          content: pulled.body,
+          content: truncate(pulled.body, MAX_NOTE_CONTENT_LENGTH),
           author: pulled.author ?? "external",
           entityType: "task",
           entityId: taskId,
@@ -790,7 +798,7 @@ async function applyPulledComments(
 
         if (externalUpdatedAt > localCreatedAt) {
           await todu.note.update(localNote.id, {
-            content: pulled.body,
+            content: truncate(pulled.body, MAX_NOTE_CONTENT_LENGTH),
           });
           stats.updated++;
         }


### PR DESCRIPTION
## Summary

Fixes a bug where external issues with descriptions or comments exceeding the 10,000 character validation limit would cause the entire sync cycle to abort, leaving all subsequent tasks and comments in that cycle unprocessed.

## Changes

- Added `truncate()` helper in `sync-worker-runtime.ts` that clips to the max length and appends `... [truncated]`
- Applied to `buildPulledTaskCreateInput()` and `buildPulledTaskUpdateInput()` for descriptions
- Applied to `applyPulledComments()` for note create and update
- 4 new unit tests covering: over-limit description, at-limit description, over-limit note body (create), over-limit note body (update), at-limit note body

## Test

```
582 passed (45 test files)
```

Task: #task-5c9f92da