### PR TITLE
fix: remove unnecessary engine prefetch from daemon startup

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,4 @@
 import {
-  type DocumentId,
   type PeerCandidatePayload,
   type PeerDisconnectedPayload,
   Repo,
@@ -128,36 +127,6 @@ export async function createTodu(
     await processTemplates(storage.catalog, {
       excludeTypes: config.startupTemplateProcessing.excludeTypes,
     });
-  }
-
-  // Prefetch all sub-documents referenced in the catalog so the relay
-  // syncs them before the UI renders. Without this, notes and habit logs
-  // only arrive when a view explicitly requests them — too late for the
-  // first render on a freshly joined device.
-  const catalogDoc = storage.catalog.doc();
-  if (catalogDoc) {
-    const docIds: string[] = [
-      ...Object.values(catalogDoc.taskListDocIds ?? {}),
-      ...Object.values(catalogDoc.habitLogDocIds ?? {}),
-      ...Object.values(catalogDoc.notesBucketDocIds ?? {}),
-      ...Object.values(catalogDoc.integrationStatusDocIds ?? {}),
-    ];
-    if (catalogDoc.notesDocId) docIds.push(catalogDoc.notesDocId);
-    if (catalogDoc.integrationRegistryDocId) docIds.push(catalogDoc.integrationRegistryDocId);
-    if (docIds.length > 0) {
-      const settled = await Promise.allSettled(
-        docIds.map((id) =>
-          storage.repo.find(id as DocumentId, {
-            signal: AbortSignal.timeout(10_000),
-          }),
-        ),
-      );
-      const ok = settled.filter((r) => r.status === "fulfilled").length;
-      const failed = settled.length - ok;
-      if (failed > 0) {
-        console.warn(`[engine] prefetch: ${ok} ok, ${failed} failed`);
-      }
-    }
   }
 
   // Determine local sync mode


### PR DESCRIPTION
## Summary

Removes the eager prefetch of all sub-documents from `createTodu()` engine initialization.

The prefetch was designed for an older Electron-as-sync-server architecture where Electron needed all sub-documents pre-loaded to relay them to ephemeral CLI clients over WebSocket. Both the CLI and Electron app are now thin RPC clients connected to the daemon — no consumer needs all documents pre-loaded at startup.

With hundreds of monthly journal bucket documents the parallel `repo.find()` calls were saturating the storage layer, causing at least one to exceed the 10s `AbortSignal.timeout`. This pushed daemon startup past the 10s health check window, making `toduai daemon start/restart` always report failure.

## Changes

- Removed prefetch block (~30 lines) from `packages/engine/src/index.ts`
- Removed now-unused `DocumentId` import

## Test

```
582 passed (45 test files)
```

Task: #task-e9bc7736