### PR TITLE
Migrate config, data, and runtime naming to todu

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,7 +223,7 @@ Baseline worker lifecycle states are:
 - Sync provider plugins use `SyncProviderRegistration` from `@todu/core` and export `syncProvider`.
 - Plugin load paths validate registrations at load time before worker registration.
 - Compatibility baseline for sync providers is API-version based (current provider API version: `2`).
-- Daemon plugin module paths resolve from `TODUAI_DAEMON_PLUGIN_PATHS` first, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
+- Daemon plugin module paths resolve from `TODU_DAEMON_PLUGIN_PATHS` first, then legacy `TODUAI_DAEMON_PLUGIN_PATHS`, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.
 - External sync uses a small synced core integration binding model consumed by sync provider plugins, and integration bindings are the sole core control plane for that work. Provider runtime internals remain local to the authority daemon host. See `docs/architecture/integrations.md`.
@@ -256,7 +256,7 @@ Baseline worker lifecycle states are:
 
 - Assignment configured via local config file/env vars.
 - Config file model uses `daemon.workers.assigned` (list of worker types).
-- Environment override uses `TODUAI_DAEMON_ASSIGNED_WORKERS` (comma-separated worker types) and takes precedence over file assignment.
+- Environment override uses `TODU_DAEMON_ASSIGNED_WORKERS` (comma-separated worker types), then legacy `TODUAI_DAEMON_ASSIGNED_WORKERS`, and takes precedence over file assignment.
 - Empty assignment is allowed and means no local workers are assigned.
 - Duplicate assignment entries are tolerated and logged for observability; first occurrence wins.
 - No lease system initially.

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -6,6 +6,14 @@ The legacy `todu serve` path has been removed.
 
 For always-on daemon startup (recommended), use OS service manager setup from [`daemon-service-operations.md`](daemon-service-operations.md).
 
+## Config/data migration defaults
+
+- Default home config path is now `~/.config/todu/config.yaml`.
+- Existing `~/.config/toduai` state is migrated automatically to `~/.config/todu` when the new default path is absent.
+- `todu config init` now creates `.todu/config.yaml` by default and migrates a sibling `.toduai/` directory when present.
+- Absolute legacy config values under `~/.config/toduai/...` or `.toduai/...` are normalized to `todu` paths when config is loaded.
+- `TODU_*` env vars are primary; legacy `TODUAI_*` env vars remain supported temporarily as fallback.
+
 ## Start/stop/restart the local daemon
 
 Recommended for persistent operation:
@@ -49,7 +57,7 @@ npm run --workspace=packages/daemon dev
 
 ## Daemon log levels
 
-Set daemon log level via `TODUAI_LOG_LEVEL`:
+Set daemon log level via `TODU_LOG_LEVEL` (legacy `TODUAI_LOG_LEVEL` is still accepted during the transition):
 
 - `error`
 - `warn`
@@ -59,8 +67,8 @@ Set daemon log level via `TODUAI_LOG_LEVEL`:
 Examples:
 
 ```bash
-TODUAI_LOG_LEVEL=debug make dev
-TODUAI_LOG_LEVEL=warn todu daemon run
+TODU_LOG_LEVEL=debug make dev
+TODU_LOG_LEVEL=warn todu daemon run
 ```
 
 `debug` adds RPC operation context (method, request id, param keys, outcome, duration) to help trace CRUD flows.
@@ -73,7 +81,8 @@ By default, CLI connects to:
 
 Override with:
 
-- `TODUAI_DAEMON_SOCKET=/path/to/daemon.sock`
+- `TODU_DAEMON_SOCKET=/path/to/daemon.sock`
+- legacy fallback: `TODUAI_DAEMON_SOCKET=/path/to/daemon.sock`
 
 ## Worker assignment configuration
 
@@ -90,12 +99,13 @@ daemon:
 Override with env var (comma-separated):
 
 ```bash
-export TODUAI_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
+export TODU_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
 ```
 
 Notes:
 - Env var overrides config file assignment.
-- Empty assignment (`TODUAI_DAEMON_ASSIGNED_WORKERS=""`) means no local workers are assigned.
+- Legacy fallback: `TODUAI_DAEMON_ASSIGNED_WORKERS`.
+- Empty assignment (`TODU_DAEMON_ASSIGNED_WORKERS=""`) means no local workers are assigned.
 - Duplicate entries are tolerated and logged; first occurrence wins.
 
 ## Sync plugin module configuration
@@ -113,13 +123,14 @@ daemon:
 Override with env var (comma-separated module paths):
 
 ```bash
-export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
+export TODU_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
 ```
 
 Notes:
 - Env var overrides config file plugin paths.
+- Legacy fallback: `TODUAI_DAEMON_PLUGIN_PATHS`.
 - Config file plugin paths are resolved relative to the config file directory.
-- Empty plugin path list (`TODUAI_DAEMON_PLUGIN_PATHS=""`) disables plugin loading.
+- Empty plugin path list (`TODU_DAEMON_PLUGIN_PATHS=""`) disables plugin loading.
 - Duplicate entries are tolerated and logged; first occurrence wins.
 - Changes require daemon restart to apply.
 

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -16,11 +16,18 @@ todu daemon status
 todu --format json daemon status
 ```
 
+## Config/data migration defaults
+
+- Default home config path is now `~/.config/todu/config.yaml`.
+- Existing `~/.config/toduai` state is migrated automatically to `~/.config/todu` when the new default path is absent.
+- Absolute legacy config values under `~/.config/toduai/...` are normalized to `todu` paths when config is loaded.
+- `TODU_*` env vars are primary; legacy `TODUAI_*` env vars remain supported temporarily as fallback.
+
 ## CLI lifecycle wrappers (`daemon start|stop|restart`)
 
 `todu daemon start`, `todu daemon stop`, and `todu daemon restart` follow this deterministic order:
 
-1. If `TODUAI_DAEMON_LIFECYCLE_MODE` is set to one of
+1. If `TODU_DAEMON_LIFECYCLE_MODE` is set to one of
    - `systemd-user`
    - `launchd`
    - `direct`
@@ -43,13 +50,15 @@ Direct managed fallback mode:
 To force a specific behavior (for scripting/testing):
 
 ```bash
-export TODUAI_DAEMON_LIFECYCLE_MODE=direct # or systemd-user / launchd / auto
+export TODU_DAEMON_LIFECYCLE_MODE=direct # or systemd-user / launchd / auto
 ```
 
-Daemon logging level is controlled with `TODUAI_LOG_LEVEL`:
+Legacy fallback: `TODUAI_DAEMON_LIFECYCLE_MODE`.
+
+Daemon logging level is controlled with `TODU_LOG_LEVEL`:
 
 ```bash
-export TODUAI_LOG_LEVEL=debug  # error | warn | info | debug
+export TODU_LOG_LEVEL=debug  # error | warn | info | debug
 ```
 
 ---
@@ -67,7 +76,7 @@ After=network.target
 
 [Service]
 Type=simple
-Environment=TODUAI_DATA_DIR=%h/.local/share/todu
+Environment=TODU_DATA_DIR=%h/.local/share/todu
 ExecStart=/usr/bin/env toduai-daemon
 Restart=on-failure
 RestartSec=2
@@ -124,7 +133,7 @@ cat > ~/Library/LaunchAgents/com.todu.daemon.plist <<EOF
 
     <key>EnvironmentVariables</key>
     <dict>
-      <key>TODUAI_DATA_DIR</key>
+      <key>TODU_DATA_DIR</key>
       <string>${HOME}/.local/share/todu</string>
     </dict>
 
@@ -167,31 +176,39 @@ tail -f ~/Library/Logs/toduai-daemon.out.log ~/Library/Logs/toduai-daemon.err.lo
 - Worker assignment env override (comma-separated worker types):
 
 ```bash
-export TODUAI_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
+export TODU_DAEMON_ASSIGNED_WORKERS="recurring,github-sync"
 ```
+
+Legacy fallback: `TODUAI_DAEMON_ASSIGNED_WORKERS`.
 
 - Sync plugin module paths can be defined in config file under `daemon.plugins.paths`.
 - Sync plugin module path env override (comma-separated module paths):
 
 ```bash
-export TODUAI_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
+export TODU_DAEMON_PLUGIN_PATHS="/opt/todu/plugins/github/index.js,/opt/todu/plugins/forgejo/index.js"
 ```
+
+Legacy fallback: `TODUAI_DAEMON_PLUGIN_PATHS`.
 
 - Plugin path resolution order is env first, then config file.
 - Config file plugin paths resolve relative to the config file directory.
 - Plugin path/config changes apply on daemon restart.
 - Plugins can export `workerPlugin` (generic worker plugin) or `syncProvider` (sync provider plugin).
-- Sync plugin scheduler config can be overridden via `TODUAI_DAEMON_PLUGIN_CONFIG` (JSON object keyed by plugin name).
+- Sync plugin scheduler config can be overridden via `TODU_DAEMON_PLUGIN_CONFIG` (JSON object keyed by plugin name).
 
 ```bash
-export TODUAI_DAEMON_PLUGIN_CONFIG='{"github":{"intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}}'
+export TODU_DAEMON_PLUGIN_CONFIG='{"github":{"intervalSeconds":300,"retryInitialSeconds":5,"retryMaxSeconds":60,"settings":{"token":"env:GITHUB_TOKEN"}}}'
 ```
+
+Legacy fallback: `TODUAI_DAEMON_PLUGIN_CONFIG`.
 
 - Optional socket override:
 
 ```bash
-export TODUAI_DAEMON_SOCKET=/custom/path/daemon.sock
+export TODU_DAEMON_SOCKET=/custom/path/daemon.sock
 ```
+
+Legacy fallback: `TODUAI_DAEMON_SOCKET`.
 
 If you set a socket override for the daemon service, CLI invocations must use the same override.
 
@@ -200,7 +217,8 @@ If you set a socket override for the daemon service, CLI invocations must use th
 ### CLI says daemon unavailable
 
 - Confirm service status (`systemctl --user status ...` or `launchctl print ...`).
-- Confirm `TODUAI_DATA_DIR` is what you expect.
+- Confirm `TODU_DATA_DIR` is what you expect.
+- Legacy fallback is `TODUAI_DATA_DIR`.
 - Confirm socket path matches CLI expectations.
 
 ### Daemon starts but CLI still fails

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -183,8 +183,9 @@ Daemon plugin host loads sync plugin modules from configured local module paths.
 
 Resolution order:
 
-1. `TODUAI_DAEMON_PLUGIN_PATHS` env var (comma-separated module paths)
-2. `daemon.plugins.paths` in config file (paths resolved relative to config file location)
+1. `TODU_DAEMON_PLUGIN_PATHS` env var (comma-separated module paths)
+2. legacy `TODUAI_DAEMON_PLUGIN_PATHS` env var
+3. `daemon.plugins.paths` in config file (paths resolved relative to config file location)
 
 Runtime behavior:
 
@@ -192,7 +193,7 @@ Runtime behavior:
 - Path/config changes apply on daemon restart.
 - Duplicate path entries are tolerated and logged; first occurrence wins.
 
-Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginName>` in config file or `TODUAI_DAEMON_PLUGIN_CONFIG` env var (JSON object). Supported fields:
+Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginName>` in config file, `TODU_DAEMON_PLUGIN_CONFIG`, or legacy `TODUAI_DAEMON_PLUGIN_CONFIG` (JSON object). Supported fields:
 
 - `intervalSeconds`: steady-state cycle interval.
 - `retryInitialSeconds` / `retryMaxSeconds`: retry backoff controls.

--- a/docs/worker-plugin-api.md
+++ b/docs/worker-plugin-api.md
@@ -58,12 +58,14 @@ validateWorkerPluginRegistration(workerPlugin)
 
 Plugin module paths resolve in this order:
 
-1. `TODUAI_DAEMON_PLUGIN_PATHS` env var
-2. `daemon.plugins.paths` in config file
+1. `TODU_DAEMON_PLUGIN_PATHS` env var
+2. legacy `TODUAI_DAEMON_PLUGIN_PATHS` env var
+3. `daemon.plugins.paths` in config file
 
 Plugin settings resolve in this order:
 
-1. `TODUAI_DAEMON_PLUGIN_CONFIG` env var
-2. `daemon.plugins.config` in config file
+1. `TODU_DAEMON_PLUGIN_CONFIG` env var
+2. legacy `TODUAI_DAEMON_PLUGIN_CONFIG` env var
+3. `daemon.plugins.config` in config file
 
 Both changes apply on daemon restart.

--- a/packages/cli/src/commands/config.integration.test.ts
+++ b/packages/cli/src/commands/config.integration.test.ts
@@ -25,17 +25,24 @@ describe("config CLI commands", () => {
   function run(args: string): string {
     return execSync(`node ${cliPath} ${args}`, {
       cwd: tmpDir,
-      env: { ...process.env, TODUAI_DATA_DIR: "", TODUAI_CONFIG: "", TODUAI_NO_SYNC: "1" },
+      env: {
+        ...process.env,
+        TODU_DATA_DIR: "",
+        TODUAI_DATA_DIR: "",
+        TODU_CONFIG: "",
+        TODUAI_CONFIG: "",
+        TODUAI_NO_SYNC: "1",
+      },
       encoding: "utf-8",
       timeout: 15000,
     }).trim();
   }
 
-  it("config init creates config and gitignore", { timeout: 30000 }, () => {
+  it("config init creates config and gitignore in .todu", { timeout: 30000 }, () => {
     const output = run("config init");
 
-    const configPath = path.join(tmpDir, ".toduai", "config.yaml");
-    const gitignorePath = path.join(tmpDir, ".toduai", ".gitignore");
+    const configPath = path.join(tmpDir, ".todu", "config.yaml");
+    const gitignorePath = path.join(tmpDir, ".todu", ".gitignore");
 
     expect(fs.existsSync(configPath)).toBe(true);
     expect(fs.existsSync(gitignorePath)).toBe(true);
@@ -50,9 +57,29 @@ describe("config CLI commands", () => {
     expect(output).toContain(`todu --config ${configPath} task list`);
   });
 
+  it(
+    "config init migrates legacy .toduai directory when .todu is absent",
+    { timeout: 30000 },
+    () => {
+      const legacyDir = path.join(tmpDir, ".toduai");
+      const legacyConfigPath = path.join(legacyDir, "config.yaml");
+      fs.mkdirSync(legacyDir, { recursive: true });
+      fs.writeFileSync(legacyConfigPath, "data_dir: ./data\n", "utf-8");
+
+      const output = run("config init");
+
+      const newDir = path.join(tmpDir, ".todu");
+      const newConfigPath = path.join(newDir, "config.yaml");
+      expect(fs.existsSync(newConfigPath)).toBe(true);
+      expect(fs.existsSync(legacyDir)).toBe(false);
+      expect(output).toContain(`Migrated: ${legacyDir} -> ${newDir}`);
+      expect(output).toContain(`todu --config ${newConfigPath} task list`);
+    },
+  );
+
   it("config show displays resolved config", { timeout: 30000 }, () => {
     run("config init");
-    const configPath = path.join(tmpDir, ".toduai", "config.yaml");
+    const configPath = path.join(tmpDir, ".todu", "config.yaml");
 
     const output = run(`--config ${configPath} config show`);
     expect(output).toContain("Config file:");
@@ -62,12 +89,11 @@ describe("config CLI commands", () => {
 
   it("--config flag routes data to config data_dir", { timeout: 30000 }, async () => {
     run("config init");
-    const configPath = path.join(tmpDir, ".toduai", "config.yaml");
-    const dataDir = path.join(tmpDir, ".toduai", "data");
+    const configPath = path.join(tmpDir, ".todu", "config.yaml");
+    const dataDir = path.join(tmpDir, ".todu", "data");
 
     const daemon = await startDaemonForTests(rootDir, dataDir);
     try {
-      // Create a project using the dev config
       run(`--config ${configPath} project create --name "Dev Project"`);
       const output = run(`--config ${configPath} --format json project list`);
       const projects = JSON.parse(output);
@@ -77,7 +103,6 @@ describe("config CLI commands", () => {
       await daemon.stop("test-cleanup");
     }
 
-    // Data should be in .toduai/data/
     expect(fs.existsSync(dataDir)).toBe(true);
   });
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -4,6 +4,9 @@ import type { Command } from "commander";
 import { getConfigPath, loadConfig, resolveConfigSources, saveConfig } from "../config.js";
 import { formatJSON } from "../format.js";
 
+const DEFAULT_LOCAL_CONFIG_DIR = ".todu";
+const LEGACY_LOCAL_CONFIG_DIR = ".toduai";
+
 export function registerConfigCommands(program: Command): void {
   const config = program.command("config").description("Manage configuration");
 
@@ -41,13 +44,23 @@ export function registerConfigCommands(program: Command): void {
   config
     .command("init")
     .description("Create a config file for local development")
-    .option("--dir <path>", "directory to create config in", ".toduai")
+    .option("--dir <path>", "directory to create config in", DEFAULT_LOCAL_CONFIG_DIR)
     .action((opts) => {
       const dir = path.resolve(opts.dir);
       const configPath = path.join(dir, "config.yaml");
 
       if (fs.existsSync(configPath)) {
         console.log(`Config already exists: ${configPath}`);
+        return;
+      }
+
+      const migratedFromLegacy = maybeMigrateLegacyProjectConfigDir(dir, opts.dir);
+      if (migratedFromLegacy !== null) {
+        console.log(`Migrated: ${migratedFromLegacy} -> ${dir}`);
+        console.log(`Config available: ${configPath}`);
+        console.log("");
+        console.log("Usage:");
+        console.log(`  todu --config ${configPath} task list`);
         return;
       }
 
@@ -67,4 +80,21 @@ export function registerConfigCommands(program: Command): void {
       console.log("Usage:");
       console.log(`  todu --config ${configPath} task list`);
     });
+}
+
+function maybeMigrateLegacyProjectConfigDir(
+  currentDir: string,
+  requestedDir: string | undefined,
+): string | null {
+  if (requestedDir !== DEFAULT_LOCAL_CONFIG_DIR) {
+    return null;
+  }
+
+  const legacyDir = path.join(path.dirname(currentDir), LEGACY_LOCAL_CONFIG_DIR);
+  if (fs.existsSync(currentDir) || !fs.existsSync(legacyDir)) {
+    return null;
+  }
+
+  fs.renameSync(legacyDir, currentDir);
+  return legacyDir;
 }

--- a/packages/cli/src/commands/daemon.integration.test.ts
+++ b/packages/cli/src/commands/daemon.integration.test.ts
@@ -52,9 +52,9 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
       cwd: rootDir,
       env: {
         ...process.env,
-        TODUAI_DATA_DIR: tmpDir,
+        TODU_DATA_DIR: tmpDir,
         TODUAI_NO_SYNC: "1",
-        TODUAI_DAEMON_LIFECYCLE_MODE: "direct",
+        TODU_DAEMON_LIFECYCLE_MODE: "direct",
         HOME: homeDir,
         ...(options.env ?? {}),
       },
@@ -111,7 +111,7 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
       cwd: rootDir,
       env: {
         ...process.env,
-        TODUAI_DATA_DIR: tmpDir,
+        TODU_DATA_DIR: tmpDir,
         TODUAI_NO_SYNC: "1",
         HOME: homeDir,
       },
@@ -195,7 +195,7 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
 
     const stop = runCli(["daemon", "stop"], {
       env: {
-        TODUAI_DAEMON_LIFECYCLE_MODE: "direct",
+        TODU_DAEMON_LIFECYCLE_MODE: "direct",
       },
     });
 
@@ -209,14 +209,16 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
 
     const result = runCli(["--format", "json", "daemon", "start"], {
       env: {
-        TODUAI_DAEMON_LIFECYCLE_MODE: "invalid-mode",
+        TODU_DAEMON_LIFECYCLE_MODE: "invalid-mode",
       },
     });
 
     expect(result.status).toBe(1);
     const json = JSON.parse(result.stdout);
     expect(json.ok).toBe(false);
-    expect(json.message).toContain("Invalid TODUAI_DAEMON_LIFECYCLE_MODE value");
+    expect(json.message).toContain(
+      "Invalid TODU_DAEMON_LIFECYCLE_MODE/TODUAI_DAEMON_LIFECYCLE_MODE value",
+    );
   });
 
   it("serve command is removed", () => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -13,14 +13,17 @@ import {
 } from "../daemon-command-client.js";
 import {
   resolveDaemonPluginConfig,
+  TODU_DAEMON_PLUGIN_CONFIG_ENV,
   TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
 } from "../daemon-plugin-config.js";
 import {
   resolveDaemonPluginPaths,
+  TODU_DAEMON_PLUGIN_PATHS_ENV,
   TODUAI_DAEMON_PLUGIN_PATHS_ENV,
 } from "../daemon-plugin-paths.js";
 import {
   resolveDaemonAssignedWorkers,
+  TODU_DAEMON_ASSIGNED_WORKERS_ENV,
   TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
 } from "../daemon-worker-assignment.js";
 import { formatJSON } from "../format.js";
@@ -79,7 +82,8 @@ const SYSTEMD_SERVICE_NAME = "toduai-daemon";
 const SYSTEMD_SERVICE_PATH = ".config/systemd/user/toduai-daemon.service";
 const LAUNCHD_LABEL = "com.todu.daemon";
 const LAUNCHD_PLIST_PATH = "Library/LaunchAgents/com.todu.daemon.plist";
-const LIFECYCLE_MODE_ENV = "TODUAI_DAEMON_LIFECYCLE_MODE";
+const TODU_DAEMON_LIFECYCLE_MODE_ENV = "TODU_DAEMON_LIFECYCLE_MODE";
+const TODUAI_DAEMON_LIFECYCLE_MODE_ENV = "TODUAI_DAEMON_LIFECYCLE_MODE";
 const INTERNAL_DAEMON_RUN_SUBCOMMAND = "__run-internal";
 const STARTUP_TIMEOUT_MS = 5_000;
 const STOP_TIMEOUT_MS = 5_000;
@@ -850,28 +854,36 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
 function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
-    TODUAI_DATA_DIR: context.storagePath,
+    TODU_DATA_DIR: context.storagePath,
   };
 
+  delete childEnv.TODUAI_DATA_DIR;
+
   if (context.remoteSyncServer) {
-    childEnv.TODUAI_SYNC_SERVER = context.remoteSyncServer;
-    childEnv.TODUAI_SYNC_ENABLED = "1";
+    childEnv.TODU_SYNC_SERVER = context.remoteSyncServer;
+    childEnv.TODU_SYNC_ENABLED = "1";
+    delete childEnv.TODUAI_SYNC_SERVER;
+    delete childEnv.TODUAI_SYNC_ENABLED;
   }
 
   if (context.socketPath) {
-    childEnv.TODUAI_DAEMON_SOCKET = context.socketPath;
+    childEnv.TODU_DAEMON_SOCKET = context.socketPath;
+    delete childEnv.TODUAI_DAEMON_SOCKET;
   }
 
   if (context.assignedWorkersEnvValue !== undefined) {
-    childEnv[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV] = context.assignedWorkersEnvValue;
+    childEnv[TODU_DAEMON_ASSIGNED_WORKERS_ENV] = context.assignedWorkersEnvValue;
+    delete childEnv[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
   }
 
   if (context.pluginPathsEnvValue !== undefined) {
-    childEnv[TODUAI_DAEMON_PLUGIN_PATHS_ENV] = context.pluginPathsEnvValue;
+    childEnv[TODU_DAEMON_PLUGIN_PATHS_ENV] = context.pluginPathsEnvValue;
+    delete childEnv[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
   }
 
   if (context.pluginConfigEnvValue !== undefined) {
-    childEnv[TODUAI_DAEMON_PLUGIN_CONFIG_ENV] = context.pluginConfigEnvValue;
+    childEnv[TODU_DAEMON_PLUGIN_CONFIG_ENV] = context.pluginConfigEnvValue;
+    delete childEnv[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
   }
 
   return childEnv;
@@ -900,7 +912,9 @@ function isExistingFile(filePath: string): boolean {
 }
 
 function resolveLifecycleMode(): DaemonLifecycleMode {
-  const override = process.env[LIFECYCLE_MODE_ENV]?.trim();
+  const override =
+    process.env[TODU_DAEMON_LIFECYCLE_MODE_ENV]?.trim() ??
+    process.env[TODUAI_DAEMON_LIFECYCLE_MODE_ENV]?.trim();
 
   if (override && override !== "auto") {
     if (override === "direct" || override === "systemd-user" || override === "launchd") {
@@ -908,7 +922,7 @@ function resolveLifecycleMode(): DaemonLifecycleMode {
     }
 
     throw new Error(
-      `Invalid ${LIFECYCLE_MODE_ENV} value: ${override}. Expected auto, direct, systemd-user, or launchd.`,
+      `Invalid ${TODU_DAEMON_LIFECYCLE_MODE_ENV}/${TODUAI_DAEMON_LIFECYCLE_MODE_ENV} value: ${override}. Expected auto, direct, systemd-user, or launchd.`,
     );
   }
 

--- a/packages/cli/src/config.integration.test.ts
+++ b/packages/cli/src/config.integration.test.ts
@@ -13,18 +13,17 @@ import {
 describe("config", () => {
   let tmpDir: string;
   const origEnv: Record<string, string | undefined> = {};
+  const configEnvKeys = ["TODU_CONFIG", "TODUAI_CONFIG", "TODU_DATA_DIR", "TODUAI_DATA_DIR"];
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-config-test-"));
-    // Save and clear env vars
-    for (const key of ["TODUAI_CONFIG", "TODUAI_DATA_DIR"]) {
+    for (const key of configEnvKeys) {
       origEnv[key] = process.env[key];
       delete process.env[key];
     }
   });
 
   afterEach(() => {
-    // Restore env vars
     for (const [key, value] of Object.entries(origEnv)) {
       if (value === undefined) {
         delete process.env[key];
@@ -41,18 +40,24 @@ describe("config", () => {
       expect(result).toBe("/custom/config.yaml");
     });
 
-    it("uses TODUAI_CONFIG env var", () => {
-      process.env.TODUAI_CONFIG = "/env/config.yaml";
+    it("uses TODU_CONFIG env var", () => {
+      process.env.TODU_CONFIG = "/env/config.yaml";
       expect(getConfigPath()).toBe("/env/config.yaml");
     });
 
-    it("falls back to default", () => {
-      const result = getConfigPath();
-      expect(result).toContain(".config/toduai/config.yaml");
+    it("falls back to legacy TODUAI_CONFIG env var", () => {
+      process.env.TODUAI_CONFIG = "/env/legacy-config.yaml";
+      expect(getConfigPath()).toBe("/env/legacy-config.yaml");
     });
 
-    it("override beats env var", () => {
-      process.env.TODUAI_CONFIG = "/env/config.yaml";
+    it("falls back to new default path", () => {
+      const result = getConfigPath();
+      expect(result).toContain(".config/todu/config.yaml");
+    });
+
+    it("override beats env vars", () => {
+      process.env.TODU_CONFIG = "/env/config.yaml";
+      process.env.TODUAI_CONFIG = "/env/legacy-config.yaml";
       expect(getConfigPath("/override/config.yaml")).toBe("/override/config.yaml");
     });
   });
@@ -82,6 +87,20 @@ describe("config", () => {
       fs.writeFileSync(configPath, "data_dir: [invalid: yaml: {{{\n");
       expect(() => loadConfig(configPath)).toThrow();
     });
+
+    it("normalizes embedded absolute legacy paths for .todu configs", () => {
+      const configDir = path.join(tmpDir, ".todu");
+      const configPath = path.join(configDir, "config.yaml");
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        `data_dir: ${JSON.stringify(path.join(tmpDir, ".toduai", "data"))}\n`,
+        "utf-8",
+      );
+
+      const config = loadConfig(configPath);
+      expect(config.data_dir).toBe(path.join(tmpDir, ".todu", "data"));
+    });
   });
 
   describe("saveConfig", () => {
@@ -101,11 +120,19 @@ describe("config", () => {
   });
 
   describe("resolveDataDir", () => {
-    it("uses TODUAI_DATA_DIR env var first", () => {
-      process.env.TODUAI_DATA_DIR = "/env/data";
+    it("uses TODU_DATA_DIR env var first", () => {
+      process.env.TODU_DATA_DIR = "/env/data";
+      process.env.TODUAI_DATA_DIR = "/env/legacy-data";
       const configPath = path.join(tmpDir, "config.yaml");
       const result = resolveDataDir(configPath, { data_dir: "./other" });
       expect(result).toBe("/env/data");
+    });
+
+    it("falls back to legacy TODUAI_DATA_DIR env var", () => {
+      process.env.TODUAI_DATA_DIR = "/env/legacy-data";
+      const configPath = path.join(tmpDir, "config.yaml");
+      const result = resolveDataDir(configPath, { data_dir: "./other" });
+      expect(result).toBe("/env/legacy-data");
     });
 
     it("resolves data_dir relative to config file", () => {
@@ -120,10 +147,10 @@ describe("config", () => {
       expect(result).toBe("/absolute/path");
     });
 
-    it("falls back to default when no config", () => {
+    it("falls back to new default when no config", () => {
       const configPath = path.join(tmpDir, "config.yaml");
       const result = resolveDataDir(configPath, {});
-      expect(result).toContain(".config/toduai/data");
+      expect(result).toContain(".config/todu/data");
     });
   });
 
@@ -138,11 +165,18 @@ describe("config", () => {
       expect(sources.dataDir).toBe(path.join(tmpDir, "mydata"));
     });
 
-    it("reports TODUAI_DATA_DIR as source when set", () => {
-      process.env.TODUAI_DATA_DIR = "/override/data";
+    it("reports TODU_DATA_DIR as source when set", () => {
+      process.env.TODU_DATA_DIR = "/override/data";
       const sources = resolveConfigSources();
-      expect(sources.dataDirSource).toBe("TODUAI_DATA_DIR env var");
+      expect(sources.dataDirSource).toBe("TODU_DATA_DIR env var");
       expect(sources.dataDir).toBe("/override/data");
+    });
+
+    it("reports legacy TODUAI_DATA_DIR as source when set", () => {
+      process.env.TODUAI_DATA_DIR = "/override/legacy-data";
+      const sources = resolveConfigSources();
+      expect(sources.dataDirSource).toBe("TODUAI_DATA_DIR env var (legacy)");
+      expect(sources.dataDir).toBe("/override/legacy-data");
     });
 
     it("reports default when nothing configured", () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ToduFileConfig } from "@todu/core";
+import { normalizeConfigPaths, type ToduFileConfig } from "@todu/core";
 import { parse, stringify } from "yaml";
 
 // ============================================================================
@@ -30,7 +30,8 @@ export function loadConfig(configPath: string): ToduFileConfig {
     return {}; // File not found — that's fine
   }
   // Let YAML parse errors surface
-  return (parse(content) as ToduFileConfig) ?? {};
+  const parsed = (parse(content) as ToduFileConfig) ?? {};
+  return normalizeConfigPaths(parsed, configPath);
 }
 
 /**

--- a/packages/cli/src/daemon-command-client.ts
+++ b/packages/cli/src/daemon-command-client.ts
@@ -76,7 +76,7 @@ function stringDetail(details: Record<string, unknown> | undefined, key: string)
 }
 
 export function resolveDaemonSocketPath(storagePath: string): string {
-  const socketOverride = process.env.TODUAI_DAEMON_SOCKET;
+  const socketOverride = process.env.TODU_DAEMON_SOCKET ?? process.env.TODUAI_DAEMON_SOCKET;
   if (socketOverride && socketOverride.trim().length > 0) {
     return path.resolve(socketOverride);
   }

--- a/packages/cli/src/daemon-plugin-config.test.ts
+++ b/packages/cli/src/daemon-plugin-config.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveDaemonPluginConfig,
+  TODU_DAEMON_PLUGIN_CONFIG_ENV,
   TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
 } from "./daemon-plugin-config.js";
 
 describe("resolveDaemonPluginConfig", () => {
-  it("prefers env override over config file plugin config", () => {
+  it("prefers TODU_DAEMON_PLUGIN_CONFIG over legacy env var and config file plugin config", () => {
     const resolved = resolveDaemonPluginConfig(
       {
         daemon: {
@@ -19,12 +20,37 @@ describe("resolveDaemonPluginConfig", () => {
         },
       },
       {
-        [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"intervalSeconds":60}}',
+        [TODU_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"intervalSeconds":60}}',
+        [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"intervalSeconds":30}}',
       },
     );
 
     expect(resolved).toEqual({
       value: '{"github":{"intervalSeconds":60}}',
+      source: "env",
+    });
+  });
+
+  it("falls back to legacy env override", () => {
+    const resolved = resolveDaemonPluginConfig(
+      {
+        daemon: {
+          plugins: {
+            config: {
+              github: {
+                intervalSeconds: 300,
+              },
+            },
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"intervalSeconds":30}}',
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: '{"github":{"intervalSeconds":30}}',
       source: "env",
     });
   });

--- a/packages/cli/src/daemon-plugin-config.ts
+++ b/packages/cli/src/daemon-plugin-config.ts
@@ -1,5 +1,6 @@
 import type { ToduFileConfig } from "@todu/core";
 
+export const TODU_DAEMON_PLUGIN_CONFIG_ENV = "TODU_DAEMON_PLUGIN_CONFIG";
 export const TODUAI_DAEMON_PLUGIN_CONFIG_ENV = "TODUAI_DAEMON_PLUGIN_CONFIG";
 
 export interface ResolvedDaemonPluginConfig {
@@ -11,7 +12,7 @@ export function resolveDaemonPluginConfig(
   config: ToduFileConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedDaemonPluginConfig {
-  const envValue = env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
+  const envValue = env[TODU_DAEMON_PLUGIN_CONFIG_ENV] ?? env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
   if (envValue !== undefined) {
     return {
       value: envValue,

--- a/packages/cli/src/daemon-plugin-paths.test.ts
+++ b/packages/cli/src/daemon-plugin-paths.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { resolveDaemonPluginPaths, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./daemon-plugin-paths.js";
+import {
+  resolveDaemonPluginPaths,
+  TODU_DAEMON_PLUGIN_PATHS_ENV,
+  TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+} from "./daemon-plugin-paths.js";
 
 describe("resolveDaemonPluginPaths", () => {
-  it("prefers env override over config file plugin paths", () => {
+  it("prefers TODU_DAEMON_PLUGIN_PATHS over legacy env var and config file plugin paths", () => {
     const resolved = resolveDaemonPluginPaths(
       "/tmp/config.yaml",
       {
@@ -13,19 +17,41 @@ describe("resolveDaemonPluginPaths", () => {
         },
       },
       {
-        [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/opt/plugins/github.js",
+        [TODU_DAEMON_PLUGIN_PATHS_ENV]: "/opt/plugins/current-github.js",
+        [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/opt/plugins/legacy-github.js",
       },
     );
 
     expect(resolved).toEqual({
-      value: "/opt/plugins/github.js",
+      value: "/opt/plugins/current-github.js",
+      source: "env",
+    });
+  });
+
+  it("falls back to legacy env override over config file plugin paths", () => {
+    const resolved = resolveDaemonPluginPaths(
+      "/tmp/config.yaml",
+      {
+        daemon: {
+          plugins: {
+            paths: ["./plugins/github.js"],
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/opt/plugins/legacy-github.js",
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: "/opt/plugins/legacy-github.js",
       source: "env",
     });
   });
 
   it("resolves config file plugin paths relative to config location", () => {
     const resolved = resolveDaemonPluginPaths(
-      "/workspace/.toduai/config.yaml",
+      "/workspace/.todu/config.yaml",
       {
         daemon: {
           plugins: {
@@ -37,14 +63,14 @@ describe("resolveDaemonPluginPaths", () => {
     );
 
     expect(resolved).toEqual({
-      value: "/workspace/.toduai/plugins/github.js,/workspace/shared/forgejo.js",
+      value: "/workspace/.todu/plugins/github.js,/workspace/shared/forgejo.js",
       source: "file",
     });
   });
 
   it("keeps explicit empty plugin path list from config", () => {
     const resolved = resolveDaemonPluginPaths(
-      "/workspace/.toduai/config.yaml",
+      "/workspace/.todu/config.yaml",
       {
         daemon: {
           plugins: {
@@ -63,7 +89,7 @@ describe("resolveDaemonPluginPaths", () => {
 
   it("ignores empty plugin path entries from config file", () => {
     const resolved = resolveDaemonPluginPaths(
-      "/workspace/.toduai/config.yaml",
+      "/workspace/.todu/config.yaml",
       {
         daemon: {
           plugins: {
@@ -75,7 +101,7 @@ describe("resolveDaemonPluginPaths", () => {
     );
 
     expect(resolved).toEqual({
-      value: "/workspace/.toduai/plugins/github.js",
+      value: "/workspace/.todu/plugins/github.js",
       source: "file",
     });
   });

--- a/packages/cli/src/daemon-plugin-paths.ts
+++ b/packages/cli/src/daemon-plugin-paths.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { ToduFileConfig } from "@todu/core";
 
+export const TODU_DAEMON_PLUGIN_PATHS_ENV = "TODU_DAEMON_PLUGIN_PATHS";
 export const TODUAI_DAEMON_PLUGIN_PATHS_ENV = "TODUAI_DAEMON_PLUGIN_PATHS";
 
 export interface ResolvedDaemonPluginPaths {
@@ -13,7 +14,7 @@ export function resolveDaemonPluginPaths(
   config: ToduFileConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedDaemonPluginPaths {
-  const envValue = env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
+  const envValue = env[TODU_DAEMON_PLUGIN_PATHS_ENV] ?? env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
   if (envValue !== undefined) {
     return {
       value: envValue,

--- a/packages/cli/src/daemon-worker-assignment.test.ts
+++ b/packages/cli/src/daemon-worker-assignment.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveDaemonAssignedWorkers,
+  TODU_DAEMON_ASSIGNED_WORKERS_ENV,
   TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
 } from "./daemon-worker-assignment.js";
 
 describe("resolveDaemonAssignedWorkers", () => {
-  it("prefers env override over config file assignments", () => {
+  it("prefers TODU_DAEMON_ASSIGNED_WORKERS over legacy env var and config file assignments", () => {
     const resolved = resolveDaemonAssignedWorkers(
       {
         daemon: {
@@ -15,12 +16,33 @@ describe("resolveDaemonAssignedWorkers", () => {
         },
       },
       {
-        [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "habit,task",
+        [TODU_DAEMON_ASSIGNED_WORKERS_ENV]: "habit,task",
+        [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "legacy,task",
       },
     );
 
     expect(resolved).toEqual({
       value: "habit,task",
+      source: "env",
+    });
+  });
+
+  it("falls back to legacy env override", () => {
+    const resolved = resolveDaemonAssignedWorkers(
+      {
+        daemon: {
+          workers: {
+            assigned: ["recurring", "sync"],
+          },
+        },
+      },
+      {
+        [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "legacy,task",
+      },
+    );
+
+    expect(resolved).toEqual({
+      value: "legacy,task",
       source: "env",
     });
   });

--- a/packages/cli/src/daemon-worker-assignment.ts
+++ b/packages/cli/src/daemon-worker-assignment.ts
@@ -1,5 +1,6 @@
 import type { ToduFileConfig } from "@todu/core";
 
+export const TODU_DAEMON_ASSIGNED_WORKERS_ENV = "TODU_DAEMON_ASSIGNED_WORKERS";
 export const TODUAI_DAEMON_ASSIGNED_WORKERS_ENV = "TODUAI_DAEMON_ASSIGNED_WORKERS";
 
 export interface ResolvedDaemonAssignedWorkers {
@@ -11,7 +12,7 @@ export function resolveDaemonAssignedWorkers(
   config: ToduFileConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedDaemonAssignedWorkers {
-  const envValue = env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
+  const envValue = env[TODU_DAEMON_ASSIGNED_WORKERS_ENV] ?? env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
   if (envValue !== undefined) {
     return {
       value: envValue,

--- a/packages/cli/src/test-helpers/daemon-process.ts
+++ b/packages/cli/src/test-helpers/daemon-process.ts
@@ -14,7 +14,7 @@ export async function startDaemonForTests(
   const socketPath = path.join(storagePath, "daemon.sock");
   const daemonProcess = spawn("node", [daemonEntrypoint], {
     cwd: rootDir,
-    env: { ...process.env, TODUAI_DATA_DIR: storagePath },
+    env: { ...process.env, TODU_DATA_DIR: storagePath },
     stdio: ["ignore", "pipe", "pipe"],
   });
 

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -5,18 +6,40 @@ import {
   DEFAULT_CONFIG_DIR,
   DEFAULT_CONFIG_FILE,
   DEFAULT_DATA_DIR,
+  LEGACY_DEFAULT_CONFIG_DIR,
+  LEGACY_DEFAULT_CONFIG_FILE,
+  LEGACY_DEFAULT_DATA_DIR,
+  migrateLegacyDefaultConfigDirectory,
+  normalizeConfigPaths,
   resolveConfigPath,
   resolveConfigSources,
   resolveDataDir,
   resolveRemoteSyncConfig,
   resolveStoragePath,
+  TODU_CONFIG_ENV,
+  TODU_DATA_DIR_ENV,
+  TODU_SYNC_ENABLED_ENV,
+  TODU_SYNC_SERVER_ENV,
+  TODUAI_CONFIG_ENV,
+  TODUAI_DATA_DIR_ENV,
+  TODUAI_SYNC_ENABLED_ENV,
+  TODUAI_SYNC_SERVER_ENV,
 } from "./config.js";
 
 describe("config resolution", () => {
+  let tmpHome: string;
   const origEnv: Record<string, string | undefined> = {};
+  const configEnvKeys = [
+    TODU_CONFIG_ENV,
+    TODUAI_CONFIG_ENV,
+    TODU_DATA_DIR_ENV,
+    TODUAI_DATA_DIR_ENV,
+  ];
 
   beforeEach(() => {
-    for (const key of ["TODUAI_CONFIG", "TODUAI_DATA_DIR"]) {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "todu-core-config-test-"));
+
+    for (const key of configEnvKeys) {
       origEnv[key] = process.env[key];
       delete process.env[key];
     }
@@ -30,19 +53,29 @@ describe("config resolution", () => {
         process.env[key] = value;
       }
     }
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
   describe("defaults", () => {
-    it("DEFAULT_CONFIG_DIR is ~/.config/toduai", () => {
-      expect(DEFAULT_CONFIG_DIR).toBe(path.join(os.homedir(), ".config", "toduai"));
+    it("DEFAULT_CONFIG_DIR is ~/.config/todu", () => {
+      expect(DEFAULT_CONFIG_DIR).toBe(path.join(os.homedir(), ".config", "todu"));
     });
 
-    it("DEFAULT_CONFIG_FILE is ~/.config/toduai/config.yaml", () => {
-      expect(DEFAULT_CONFIG_FILE).toBe(path.join(os.homedir(), ".config", "toduai", "config.yaml"));
+    it("DEFAULT_CONFIG_FILE is ~/.config/todu/config.yaml", () => {
+      expect(DEFAULT_CONFIG_FILE).toBe(path.join(os.homedir(), ".config", "todu", "config.yaml"));
     });
 
-    it("DEFAULT_DATA_DIR is ~/.config/toduai/data", () => {
-      expect(DEFAULT_DATA_DIR).toBe(path.join(os.homedir(), ".config", "toduai", "data"));
+    it("DEFAULT_DATA_DIR is ~/.config/todu/data", () => {
+      expect(DEFAULT_DATA_DIR).toBe(path.join(os.homedir(), ".config", "todu", "data"));
+    });
+
+    it("retains exported legacy path constants for migration logic", () => {
+      expect(LEGACY_DEFAULT_CONFIG_DIR).toBe(path.join(os.homedir(), ".config", "toduai"));
+      expect(LEGACY_DEFAULT_CONFIG_FILE).toBe(
+        path.join(os.homedir(), ".config", "toduai", "config.yaml"),
+      );
+      expect(LEGACY_DEFAULT_DATA_DIR).toBe(path.join(os.homedir(), ".config", "toduai", "data"));
     });
   });
 
@@ -51,31 +84,157 @@ describe("config resolution", () => {
       expect(resolveConfigPath("/custom/config.yaml")).toBe("/custom/config.yaml");
     });
 
-    it("uses TODUAI_CONFIG env var", () => {
-      process.env.TODUAI_CONFIG = "/env/config.yaml";
-      expect(resolveConfigPath()).toBe("/env/config.yaml");
+    it("uses TODU_CONFIG env var before legacy env var", () => {
+      process.env[TODU_CONFIG_ENV] = "/env/current-config.yaml";
+      process.env[TODUAI_CONFIG_ENV] = "/env/legacy-config.yaml";
+
+      expect(resolveConfigPath()).toBe("/env/current-config.yaml");
     });
 
-    it("falls back to default", () => {
-      expect(resolveConfigPath()).toBe(DEFAULT_CONFIG_FILE);
+    it("falls back to legacy TODUAI_CONFIG env var", () => {
+      process.env[TODUAI_CONFIG_ENV] = "/env/legacy-config.yaml";
+      expect(resolveConfigPath()).toBe("/env/legacy-config.yaml");
     });
 
-    it("override beats env var", () => {
-      process.env.TODUAI_CONFIG = "/env/config.yaml";
+    it("falls back to the new default path", () => {
+      expect(resolveConfigPath(undefined, { homeDir: tmpHome })).toBe(
+        path.join(tmpHome, ".config", "todu", "config.yaml"),
+      );
+    });
+
+    it("migrates default legacy config dir when legacy path exists and new path does not", () => {
+      const legacyConfigDir = path.join(tmpHome, ".config", "toduai");
+      const legacyConfigPath = path.join(legacyConfigDir, "config.yaml");
+      const legacyPluginStatePath = path.join(
+        legacyConfigDir,
+        "data",
+        "github-plugin-state",
+        "state.json",
+      );
+      fs.mkdirSync(path.dirname(legacyPluginStatePath), { recursive: true });
+      fs.writeFileSync(legacyConfigPath, "data_dir: ./data\n", "utf-8");
+      fs.writeFileSync(legacyPluginStatePath, '{"ok":true}', "utf-8");
+
+      const resolvedPath = resolveConfigPath(undefined, { homeDir: tmpHome });
+
+      expect(resolvedPath).toBe(path.join(tmpHome, ".config", "todu", "config.yaml"));
+      expect(
+        fs.existsSync(
+          path.join(tmpHome, ".config", "todu", "data", "github-plugin-state", "state.json"),
+        ),
+      ).toBe(true);
+      expect(fs.existsSync(legacyConfigDir)).toBe(false);
+    });
+
+    it("prefers the new default path when both new and legacy config dirs exist", () => {
+      const newConfigDir = path.join(tmpHome, ".config", "todu");
+      const legacyConfigDir = path.join(tmpHome, ".config", "toduai");
+      fs.mkdirSync(newConfigDir, { recursive: true });
+      fs.mkdirSync(legacyConfigDir, { recursive: true });
+
+      const resolvedPath = resolveConfigPath(undefined, { homeDir: tmpHome });
+
+      expect(resolvedPath).toBe(path.join(newConfigDir, "config.yaml"));
+      expect(fs.existsSync(legacyConfigDir)).toBe(true);
+    });
+
+    it("override beats env vars", () => {
+      process.env[TODU_CONFIG_ENV] = "/env/current-config.yaml";
+      process.env[TODUAI_CONFIG_ENV] = "/env/legacy-config.yaml";
       expect(resolveConfigPath("/override/config.yaml")).toBe("/override/config.yaml");
     });
   });
 
+  describe("migrateLegacyDefaultConfigDirectory", () => {
+    it("returns migrated=false when nothing needs migration", () => {
+      const result = migrateLegacyDefaultConfigDirectory({ homeDir: tmpHome });
+
+      expect(result).toEqual({
+        migrated: false,
+        configDir: path.join(tmpHome, ".config", "todu"),
+        legacyConfigDir: path.join(tmpHome, ".config", "toduai"),
+      });
+    });
+  });
+
+  describe("normalizeConfigPaths", () => {
+    it("rewrites embedded absolute legacy paths for migrated default config files", () => {
+      const configPath = path.join(tmpHome, ".config", "todu", "config.yaml");
+      const normalized = normalizeConfigPaths(
+        {
+          data_dir: path.join(tmpHome, ".config", "toduai", "data"),
+          daemon: {
+            plugins: {
+              paths: [path.join(tmpHome, ".config", "toduai", "plugins", "github.js")],
+              config: {
+                github: {
+                  cachePath: path.join(tmpHome, ".config", "toduai", "data", "github-cache.json"),
+                },
+              },
+            },
+          },
+        },
+        configPath,
+        { homeDir: tmpHome },
+      );
+
+      expect(normalized).toEqual({
+        data_dir: path.join(tmpHome, ".config", "todu", "data"),
+        daemon: {
+          plugins: {
+            paths: [path.join(tmpHome, ".config", "todu", "plugins", "github.js")],
+            config: {
+              github: {
+                cachePath: path.join(tmpHome, ".config", "todu", "data", "github-cache.json"),
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("rewrites embedded absolute legacy paths for project-local config dirs", () => {
+      const configPath = path.join(tmpHome, "workspace", ".todu", "config.yaml");
+      const normalized = normalizeConfigPaths(
+        {
+          data_dir: path.join(tmpHome, "workspace", ".toduai", "data"),
+        },
+        configPath,
+      );
+
+      expect(normalized.data_dir).toBe(path.join(tmpHome, "workspace", ".todu", "data"));
+    });
+  });
+
   describe("resolveDataDir", () => {
-    it("uses TODUAI_DATA_DIR env var first", () => {
-      process.env.TODUAI_DATA_DIR = "/env/data";
-      expect(resolveDataDir("/any/config.yaml", { data_dir: "./other" })).toBe("/env/data");
+    it("uses TODU_DATA_DIR env var first", () => {
+      process.env[TODU_DATA_DIR_ENV] = "/env/current-data";
+      process.env[TODUAI_DATA_DIR_ENV] = "/env/legacy-data";
+      expect(resolveDataDir("/any/config.yaml", { data_dir: "./other" })).toBe("/env/current-data");
+    });
+
+    it("falls back to legacy TODUAI_DATA_DIR env var", () => {
+      process.env[TODUAI_DATA_DIR_ENV] = "/env/legacy-data";
+      expect(resolveDataDir("/any/config.yaml", { data_dir: "./other" })).toBe("/env/legacy-data");
     });
 
     it("resolves data_dir relative to config file", () => {
-      expect(resolveDataDir("/home/user/.config/toduai/config.yaml", { data_dir: "./data" })).toBe(
-        "/home/user/.config/toduai/data",
+      expect(resolveDataDir("/home/user/.config/todu/config.yaml", { data_dir: "./data" })).toBe(
+        "/home/user/.config/todu/data",
       );
+    });
+
+    it("normalizes embedded absolute legacy data_dir paths", () => {
+      const configPath = path.join(tmpHome, ".config", "todu", "config.yaml");
+      expect(
+        resolveDataDir(
+          configPath,
+          {
+            data_dir: path.join(tmpHome, ".config", "toduai", "data"),
+          },
+          { homeDir: tmpHome },
+        ),
+      ).toBe(path.join(tmpHome, ".config", "todu", "data"));
     });
 
     it("handles absolute data_dir", () => {
@@ -84,19 +243,28 @@ describe("config resolution", () => {
       );
     });
 
-    it("falls back to DEFAULT_DATA_DIR when no config", () => {
-      expect(resolveDataDir("/any/config.yaml", {})).toBe(DEFAULT_DATA_DIR);
+    it("falls back to the new default data dir when no config is set", () => {
+      expect(resolveDataDir("/any/config.yaml", {}, { homeDir: tmpHome })).toBe(
+        path.join(tmpHome, ".config", "todu", "data"),
+      );
     });
   });
 
   describe("resolveStoragePath", () => {
-    it("uses TODUAI_DATA_DIR env var", () => {
-      process.env.TODUAI_DATA_DIR = "/env/data";
-      expect(resolveStoragePath()).toBe("/env/data");
+    it("uses TODU_DATA_DIR env var", () => {
+      process.env[TODU_DATA_DIR_ENV] = "/env/current-data";
+      expect(resolveStoragePath()).toBe("/env/current-data");
     });
 
-    it("falls back to DEFAULT_DATA_DIR", () => {
-      expect(resolveStoragePath()).toBe(DEFAULT_DATA_DIR);
+    it("falls back to legacy TODUAI_DATA_DIR env var", () => {
+      process.env[TODUAI_DATA_DIR_ENV] = "/env/legacy-data";
+      expect(resolveStoragePath()).toBe("/env/legacy-data");
+    });
+
+    it("falls back to migrated/default data dir", () => {
+      expect(resolveStoragePath({ homeDir: tmpHome })).toBe(
+        path.join(tmpHome, ".config", "todu", "data"),
+      );
     });
   });
 
@@ -108,33 +276,52 @@ describe("config resolution", () => {
       expect(sources.dataDir).toBe("/custom/mydata");
     });
 
-    it("reports TODUAI_CONFIG env var as source", () => {
-      process.env.TODUAI_CONFIG = "/env/config.yaml";
+    it("reports TODU_CONFIG env var as source", () => {
+      process.env[TODU_CONFIG_ENV] = "/env/current-config.yaml";
       const sources = resolveConfigSources();
-      expect(sources.configSource).toBe("TODUAI_CONFIG env var");
+      expect(sources.configSource).toBe("TODU_CONFIG env var");
     });
 
-    it("reports TODUAI_DATA_DIR as source when set", () => {
-      process.env.TODUAI_DATA_DIR = "/override/data";
+    it("reports legacy TODUAI_CONFIG env var as source", () => {
+      process.env[TODUAI_CONFIG_ENV] = "/env/legacy-config.yaml";
       const sources = resolveConfigSources();
-      expect(sources.dataDirSource).toBe("TODUAI_DATA_DIR env var");
-      expect(sources.dataDir).toBe("/override/data");
+      expect(sources.configSource).toBe("TODUAI_CONFIG env var (legacy)");
+    });
+
+    it("reports TODU_DATA_DIR env var as source when set", () => {
+      process.env[TODU_DATA_DIR_ENV] = "/override/current-data";
+      const sources = resolveConfigSources();
+      expect(sources.dataDirSource).toBe("TODU_DATA_DIR env var");
+      expect(sources.dataDir).toBe("/override/current-data");
+    });
+
+    it("reports legacy TODUAI_DATA_DIR env var as source when set", () => {
+      process.env[TODUAI_DATA_DIR_ENV] = "/override/legacy-data";
+      const sources = resolveConfigSources();
+      expect(sources.dataDirSource).toBe("TODUAI_DATA_DIR env var (legacy)");
+      expect(sources.dataDir).toBe("/override/legacy-data");
     });
 
     it("reports default when nothing configured", () => {
-      const sources = resolveConfigSources();
+      const sources = resolveConfigSources(undefined, {}, { homeDir: tmpHome });
       expect(sources.configSource).toBe("default");
       expect(sources.dataDirSource).toBe("default");
-      expect(sources.dataDir).toBe(DEFAULT_DATA_DIR);
+      expect(sources.dataDir).toBe(path.join(tmpHome, ".config", "todu", "data"));
     });
   });
 });
 
 describe("resolveRemoteSyncConfig", () => {
   const origEnv: Record<string, string | undefined> = {};
+  const syncEnvKeys = [
+    TODU_SYNC_SERVER_ENV,
+    TODUAI_SYNC_SERVER_ENV,
+    TODU_SYNC_ENABLED_ENV,
+    TODUAI_SYNC_ENABLED_ENV,
+  ];
 
   beforeEach(() => {
-    for (const key of ["TODUAI_SYNC_SERVER", "TODUAI_SYNC_ENABLED"]) {
+    for (const key of syncEnvKeys) {
       origEnv[key] = process.env[key];
       delete process.env[key];
     }
@@ -173,32 +360,48 @@ describe("resolveRemoteSyncConfig", () => {
     expect(result).toEqual({ server: "ws://localhost:3030" });
   });
 
-  it("TODUAI_SYNC_SERVER overrides config file server", () => {
-    process.env.TODUAI_SYNC_SERVER = "ws://localhost:9999";
+  it("TODU_SYNC_SERVER overrides config file server", () => {
+    process.env[TODU_SYNC_SERVER_ENV] = "ws://localhost:9999";
     const result = resolveRemoteSyncConfig({
       sync: { remote: { server: "ws://localhost:3030", enabled: true } },
     });
     expect(result).toEqual({ server: "ws://localhost:9999" });
   });
 
-  it("TODUAI_SYNC_ENABLED=true enables sync", () => {
-    process.env.TODUAI_SYNC_ENABLED = "true";
+  it("falls back to legacy TODUAI_SYNC_SERVER", () => {
+    process.env[TODUAI_SYNC_SERVER_ENV] = "ws://localhost:9999";
+    const result = resolveRemoteSyncConfig({
+      sync: { remote: { server: "ws://localhost:3030", enabled: true } },
+    });
+    expect(result).toEqual({ server: "ws://localhost:9999" });
+  });
+
+  it("TODU_SYNC_ENABLED=true enables sync", () => {
+    process.env[TODU_SYNC_ENABLED_ENV] = "true";
     const result = resolveRemoteSyncConfig({
       sync: { remote: { server: "ws://localhost:3030" } },
     });
     expect(result).toEqual({ server: "ws://localhost:3030" });
   });
 
-  it("TODUAI_SYNC_ENABLED=1 enables sync", () => {
-    process.env.TODUAI_SYNC_ENABLED = "1";
+  it("TODU_SYNC_ENABLED=1 enables sync", () => {
+    process.env[TODU_SYNC_ENABLED_ENV] = "1";
     const result = resolveRemoteSyncConfig({
       sync: { remote: { server: "ws://localhost:3030" } },
     });
     expect(result).toEqual({ server: "ws://localhost:3030" });
   });
 
-  it("TODUAI_SYNC_ENABLED=false disables sync even when config has enabled:true", () => {
-    process.env.TODUAI_SYNC_ENABLED = "false";
+  it("falls back to legacy TODUAI_SYNC_ENABLED", () => {
+    process.env[TODUAI_SYNC_ENABLED_ENV] = "1";
+    const result = resolveRemoteSyncConfig({
+      sync: { remote: { server: "ws://localhost:3030" } },
+    });
+    expect(result).toEqual({ server: "ws://localhost:3030" });
+  });
+
+  it("TODU_SYNC_ENABLED=false disables sync even when config has enabled:true", () => {
+    process.env[TODU_SYNC_ENABLED_ENV] = "false";
     const result = resolveRemoteSyncConfig({
       sync: { remote: { server: "ws://localhost:3030", enabled: true } },
     });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,20 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+const CURRENT_CONFIG_DIRNAME = "todu";
+const LEGACY_CONFIG_DIRNAME = "toduai";
+const CURRENT_PROJECT_CONFIG_DIRNAME = ".todu";
+const LEGACY_PROJECT_CONFIG_DIRNAME = ".toduai";
+
+export const TODU_CONFIG_ENV = "TODU_CONFIG";
+export const TODUAI_CONFIG_ENV = "TODUAI_CONFIG";
+export const TODU_DATA_DIR_ENV = "TODU_DATA_DIR";
+export const TODUAI_DATA_DIR_ENV = "TODUAI_DATA_DIR";
+export const TODU_SYNC_SERVER_ENV = "TODU_SYNC_SERVER";
+export const TODUAI_SYNC_SERVER_ENV = "TODUAI_SYNC_SERVER";
+export const TODU_SYNC_ENABLED_ENV = "TODU_SYNC_ENABLED";
+export const TODUAI_SYNC_ENABLED_ENV = "TODUAI_SYNC_ENABLED";
 
 // ============================================================================
 // Shared configuration resolution
@@ -7,13 +22,40 @@ import path from "node:path";
 // Single source of truth for config and data directory paths.
 // Used by CLI, Electron, and any future client.
 //
-// This module handles path resolution only. Config file parsing (YAML)
-// stays in the CLI package which has the yaml dependency.
+// This module handles path resolution plus legacy-to-current migration-aware
+// normalization. Config file parsing (YAML) stays in the CLI/Electron packages.
 // ============================================================================
 
-export const DEFAULT_CONFIG_DIR = path.join(os.homedir(), ".config", "toduai");
-export const DEFAULT_CONFIG_FILE = path.join(DEFAULT_CONFIG_DIR, "config.yaml");
-export const DEFAULT_DATA_DIR = path.join(DEFAULT_CONFIG_DIR, "data");
+export function getDefaultConfigDir(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, ".config", CURRENT_CONFIG_DIRNAME);
+}
+
+export function getLegacyDefaultConfigDir(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, ".config", LEGACY_CONFIG_DIRNAME);
+}
+
+export function getDefaultConfigFile(homeDir: string = os.homedir()): string {
+  return path.join(getDefaultConfigDir(homeDir), "config.yaml");
+}
+
+export function getLegacyDefaultConfigFile(homeDir: string = os.homedir()): string {
+  return path.join(getLegacyDefaultConfigDir(homeDir), "config.yaml");
+}
+
+export function getDefaultDataDir(homeDir: string = os.homedir()): string {
+  return path.join(getDefaultConfigDir(homeDir), "data");
+}
+
+export function getLegacyDefaultDataDir(homeDir: string = os.homedir()): string {
+  return path.join(getLegacyDefaultConfigDir(homeDir), "data");
+}
+
+export const DEFAULT_CONFIG_DIR = getDefaultConfigDir();
+export const DEFAULT_CONFIG_FILE = getDefaultConfigFile();
+export const DEFAULT_DATA_DIR = getDefaultDataDir();
+export const LEGACY_DEFAULT_CONFIG_DIR = getLegacyDefaultConfigDir();
+export const LEGACY_DEFAULT_CONFIG_FILE = getLegacyDefaultConfigFile();
+export const LEGACY_DEFAULT_DATA_DIR = getLegacyDefaultDataDir();
 
 export interface ToduFileConfig {
   /** Path to data directory (absolute or relative to config file) */
@@ -48,29 +90,51 @@ export interface RemoteSyncConfig {
   server: string;
 }
 
+export interface ConfigResolutionOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}
+
+export interface LegacyConfigMigrationResult {
+  migrated: boolean;
+  configDir: string;
+  legacyConfigDir: string;
+}
+
+interface ResolvedEnvValue {
+  value: string;
+  source: string;
+  legacy: boolean;
+}
+
 /**
  * Resolve remote sync configuration from file config and env var overrides.
  *
  * Priority:
- * 1. TODUAI_SYNC_SERVER / TODUAI_SYNC_ENABLED env vars
- * 2. sync.remote fields from config file
+ * 1. TODU_SYNC_SERVER / TODU_SYNC_ENABLED env vars
+ * 2. Legacy TODUAI_SYNC_SERVER / TODUAI_SYNC_ENABLED env vars
+ * 3. sync.remote fields from config file
  *
  * Returns null when remote sync is disabled or not configured.
  *
  * IMPORTANT: Never use wss://sync.todu.sh in development or tests.
  * Use the local dev sync server (ws://localhost:3030) via `make dev`.
  */
-export function resolveRemoteSyncConfig(config: ToduFileConfig): RemoteSyncConfig | null {
-  const serverEnv = process.env.TODUAI_SYNC_SERVER;
-  const enabledEnv = process.env.TODUAI_SYNC_ENABLED;
+export function resolveRemoteSyncConfig(
+  config: ToduFileConfig,
+  options: ConfigResolutionOptions = {},
+): RemoteSyncConfig | null {
+  const env = options.env ?? process.env;
+  const serverEnv = resolvePreferredEnvValue(env, TODU_SYNC_SERVER_ENV, TODUAI_SYNC_SERVER_ENV);
+  const enabledEnv = resolvePreferredEnvValue(env, TODU_SYNC_ENABLED_ENV, TODUAI_SYNC_ENABLED_ENV);
 
-  const server = serverEnv ?? config.sync?.remote?.server;
+  const server = serverEnv?.value ?? config.sync?.remote?.server;
 
   // Default enabled to true when a server is configured — if someone
   // sets a sync server URL, they obviously want sync enabled.
   const enabled =
-    enabledEnv !== undefined
-      ? enabledEnv === "true" || enabledEnv === "1"
+    enabledEnv !== null
+      ? enabledEnv.value === "true" || enabledEnv.value === "1"
       : (config.sync?.remote?.enabled ?? true);
 
   if (!server || !enabled) return null;
@@ -79,72 +143,158 @@ export function resolveRemoteSyncConfig(config: ToduFileConfig): RemoteSyncConfi
 }
 
 /**
+ * Migrate the default legacy config directory (`~/.config/toduai`) to the
+ * current default (`~/.config/todu`) when the current path does not exist yet.
+ *
+ * This is intentionally narrow: explicit override paths and explicit env var
+ * overrides are not moved automatically.
+ */
+export function migrateLegacyDefaultConfigDirectory(
+  options: ConfigResolutionOptions = {},
+): LegacyConfigMigrationResult {
+  const homeDir = options.homeDir ?? os.homedir();
+  const configDir = getDefaultConfigDir(homeDir);
+  const legacyConfigDir = getLegacyDefaultConfigDir(homeDir);
+
+  if (fs.existsSync(configDir) || !fs.existsSync(legacyConfigDir)) {
+    return {
+      migrated: false,
+      configDir,
+      legacyConfigDir,
+    };
+  }
+
+  fs.mkdirSync(path.dirname(configDir), { recursive: true });
+  fs.renameSync(legacyConfigDir, configDir);
+
+  return {
+    migrated: true,
+    configDir,
+    legacyConfigDir,
+  };
+}
+
+/**
  * Resolve config file path.
  *
  * Priority:
  * 1. Explicit override (e.g. --config flag)
- * 2. TODUAI_CONFIG env var
- * 3. Default: ~/.config/toduai/config.yaml
+ * 2. TODU_CONFIG env var
+ * 3. Legacy TODUAI_CONFIG env var
+ * 4. Default: ~/.config/todu/config.yaml (after one-time migration from legacy
+ *    default path when needed)
  */
-export function resolveConfigPath(override?: string): string {
+export function resolveConfigPath(
+  override?: string,
+  options: ConfigResolutionOptions = {},
+): string {
   if (override) return path.resolve(override);
-  if (process.env.TODUAI_CONFIG) return path.resolve(process.env.TODUAI_CONFIG);
-  return DEFAULT_CONFIG_FILE;
+
+  const env = options.env ?? process.env;
+  const configEnv = resolvePreferredEnvValue(env, TODU_CONFIG_ENV, TODUAI_CONFIG_ENV);
+  if (configEnv !== null) {
+    return path.resolve(configEnv.value);
+  }
+
+  const migration = migrateLegacyDefaultConfigDirectory(options);
+  return path.join(migration.configDir, "config.yaml");
 }
 
 /**
  * Resolve the data directory path.
  *
  * Priority:
- * 1. TODUAI_DATA_DIR env var
- * 2. data_dir from config file (resolved relative to config file location)
- * 3. Default: ~/.config/toduai/data
+ * 1. TODU_DATA_DIR env var
+ * 2. Legacy TODUAI_DATA_DIR env var
+ * 3. data_dir from config file (resolved relative to config file location)
+ * 4. Default: ~/.config/todu/data
  */
-export function resolveDataDir(configPath: string, config: ToduFileConfig): string {
-  // Env var takes precedence (tests, explicit override)
-  if (process.env.TODUAI_DATA_DIR) {
-    return path.resolve(process.env.TODUAI_DATA_DIR);
+export function resolveDataDir(
+  configPath: string,
+  config: ToduFileConfig,
+  options: ConfigResolutionOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? os.homedir();
+
+  const dataDirEnv = resolvePreferredEnvValue(env, TODU_DATA_DIR_ENV, TODUAI_DATA_DIR_ENV);
+  if (dataDirEnv !== null) {
+    return path.resolve(dataDirEnv.value);
   }
 
-  // Config file data_dir
-  if (config.data_dir) {
-    const configDir = path.dirname(configPath);
-    return path.resolve(configDir, config.data_dir);
+  const normalizedConfig = normalizeConfigPaths(config, configPath, options);
+
+  if (normalizedConfig.data_dir) {
+    const configDir = path.dirname(path.resolve(configPath));
+    return path.resolve(configDir, normalizedConfig.data_dir);
   }
 
-  // Default
-  return DEFAULT_DATA_DIR;
+  return getDefaultDataDir(homeDir);
+}
+
+/**
+ * Normalize embedded absolute legacy path strings in config values when a
+ * config file has moved from a legacy `toduai` path to the current `todu`
+ * path. This covers values like `data_dir`, plugin module paths, and plugin
+ * config strings that reference the old absolute root.
+ */
+export function normalizeConfigPaths(
+  config: ToduFileConfig,
+  configPath: string,
+  options: ConfigResolutionOptions = {},
+): ToduFileConfig {
+  const replacement = resolveLegacyConfigReplacement(configPath, options.homeDir ?? os.homedir());
+  if (replacement === null) {
+    return config;
+  }
+
+  return rewriteLegacyPathStrings(
+    config,
+    replacement.legacyConfigDir,
+    replacement.configDir,
+  ) as ToduFileConfig;
 }
 
 /**
  * Describe where each resolved value came from.
- * Useful for `toduai config show` and debugging.
+ * Useful for `todu config show` and debugging.
  */
 export function resolveConfigSources(
   configOverride?: string,
   config?: ToduFileConfig,
+  options: ConfigResolutionOptions = {},
 ): {
   configPath: string;
   configSource: string;
   dataDir: string;
   dataDirSource: string;
 } {
-  const configPath = resolveConfigPath(configOverride);
+  const env = options.env ?? process.env;
+  const configPath = resolveConfigPath(configOverride, options);
+
   let configSource: string;
   if (configOverride) {
     configSource = "--config flag";
-  } else if (process.env.TODUAI_CONFIG) {
-    configSource = "TODUAI_CONFIG env var";
   } else {
-    configSource = "default";
+    const configEnv = resolvePreferredEnvValue(env, TODU_CONFIG_ENV, TODUAI_CONFIG_ENV);
+    if (configEnv !== null) {
+      configSource = configEnv.legacy
+        ? `${configEnv.source} env var (legacy)`
+        : `${configEnv.source} env var`;
+    } else {
+      configSource = "default";
+    }
   }
 
-  const resolvedConfig = config ?? {};
-  const dataDir = resolveDataDir(configPath, resolvedConfig);
+  const resolvedConfig = normalizeConfigPaths(config ?? {}, configPath, options);
+  const dataDir = resolveDataDir(configPath, resolvedConfig, options);
 
   let dataDirSource: string;
-  if (process.env.TODUAI_DATA_DIR) {
-    dataDirSource = "TODUAI_DATA_DIR env var";
+  const dataDirEnv = resolvePreferredEnvValue(env, TODU_DATA_DIR_ENV, TODUAI_DATA_DIR_ENV);
+  if (dataDirEnv !== null) {
+    dataDirSource = dataDirEnv.legacy
+      ? `${dataDirEnv.source} env var (legacy)`
+      : `${dataDirEnv.source} env var`;
   } else if (resolvedConfig.data_dir) {
     dataDirSource = `config file (${configPath})`;
   } else {
@@ -157,13 +307,107 @@ export function resolveConfigSources(
 /**
  * Resolve storage path using env vars and defaults.
  *
- * For clients that don't parse config files (e.g. Electron).
- * Checks TODUAI_DATA_DIR env var, then falls back to default.
- * If a config file with data_dir is needed, use resolveDataDir instead.
+ * For clients that don't parse config files.
+ * Checks TODU_DATA_DIR first, then legacy TODUAI_DATA_DIR, then falls back to
+ * the migrated/default data directory.
  */
-export function resolveStoragePath(): string {
-  if (process.env.TODUAI_DATA_DIR) {
-    return path.resolve(process.env.TODUAI_DATA_DIR);
+export function resolveStoragePath(options: ConfigResolutionOptions = {}): string {
+  const env = options.env ?? process.env;
+
+  const dataDirEnv = resolvePreferredEnvValue(env, TODU_DATA_DIR_ENV, TODUAI_DATA_DIR_ENV);
+  if (dataDirEnv !== null) {
+    return path.resolve(dataDirEnv.value);
   }
-  return DEFAULT_DATA_DIR;
+
+  const migration = migrateLegacyDefaultConfigDirectory(options);
+  return path.join(migration.configDir, "data");
+}
+
+function resolvePreferredEnvValue(
+  env: NodeJS.ProcessEnv,
+  currentName: string,
+  legacyName: string,
+): ResolvedEnvValue | null {
+  const currentValue = env[currentName];
+  if (currentValue !== undefined && currentValue.trim().length > 0) {
+    return {
+      value: currentValue,
+      source: currentName,
+      legacy: false,
+    };
+  }
+
+  const legacyValue = env[legacyName];
+  if (legacyValue !== undefined && legacyValue.trim().length > 0) {
+    return {
+      value: legacyValue,
+      source: legacyName,
+      legacy: true,
+    };
+  }
+
+  return null;
+}
+
+function resolveLegacyConfigReplacement(
+  configPath: string,
+  homeDir: string,
+): { configDir: string; legacyConfigDir: string } | null {
+  const resolvedConfigPath = path.resolve(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const defaultConfigDir = getDefaultConfigDir(homeDir);
+
+  if (configDir === defaultConfigDir) {
+    return {
+      configDir,
+      legacyConfigDir: getLegacyDefaultConfigDir(homeDir),
+    };
+  }
+
+  if (path.basename(configDir) === CURRENT_PROJECT_CONFIG_DIRNAME) {
+    return {
+      configDir,
+      legacyConfigDir: path.join(path.dirname(configDir), LEGACY_PROJECT_CONFIG_DIRNAME),
+    };
+  }
+
+  return null;
+}
+
+function rewriteLegacyPathStrings(
+  value: unknown,
+  legacyRoot: string,
+  currentRoot: string,
+): unknown {
+  if (typeof value === "string") {
+    return rewriteLegacyPathString(value, legacyRoot, currentRoot);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => rewriteLegacyPathStrings(entry, legacyRoot, currentRoot));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      rewriteLegacyPathStrings(entry, legacyRoot, currentRoot),
+    ]),
+  );
+}
+
+function rewriteLegacyPathString(value: string, legacyRoot: string, currentRoot: string): string {
+  if (value === legacyRoot) {
+    return currentRoot;
+  }
+
+  const legacyPrefix = `${legacyRoot}${path.sep}`;
+  if (value.startsWith(legacyPrefix)) {
+    return `${currentRoot}${value.slice(legacyRoot.length)}`;
+  }
+
+  return value;
 }

--- a/packages/daemon/src/logger.test.ts
+++ b/packages/daemon/src/logger.test.ts
@@ -3,6 +3,8 @@ import {
   createDaemonLogger,
   resolveDaemonLogLevel,
   resolveDaemonLogLevelFromEnv,
+  TODU_LOG_LEVEL_ENV,
+  TODUAI_LOG_LEVEL_ENV,
 } from "./logger.js";
 
 describe("daemon logger", () => {
@@ -10,14 +12,27 @@ describe("daemon logger", () => {
     expect(resolveDaemonLogLevelFromEnv({})).toBe("info");
   });
 
-  it("parses TODUAI_LOG_LEVEL values case-insensitively", () => {
+  it("prefers TODU_LOG_LEVEL over legacy TODUAI_LOG_LEVEL", () => {
+    expect(
+      resolveDaemonLogLevelFromEnv({
+        [TODU_LOG_LEVEL_ENV]: "warn",
+        [TODUAI_LOG_LEVEL_ENV]: "debug",
+      }),
+    ).toBe("warn");
+  });
+
+  it("falls back to legacy TODUAI_LOG_LEVEL", () => {
+    expect(resolveDaemonLogLevelFromEnv({ [TODUAI_LOG_LEVEL_ENV]: "debug" })).toBe("debug");
+  });
+
+  it("parses log level values case-insensitively", () => {
     expect(resolveDaemonLogLevel("DEBUG")).toBe("debug");
     expect(resolveDaemonLogLevel("Info")).toBe("info");
     expect(resolveDaemonLogLevel("warning")).toBe("warn");
     expect(resolveDaemonLogLevel("error")).toBe("error");
   });
 
-  it("falls back to info for invalid TODUAI_LOG_LEVEL values", () => {
+  it("falls back to info for invalid log level values", () => {
     expect(resolveDaemonLogLevel("verbose")).toBe("info");
   });
 

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -28,6 +28,9 @@ interface DaemonLogEntry {
   context?: Record<string, unknown>;
 }
 
+export const TODU_LOG_LEVEL_ENV = "TODU_LOG_LEVEL";
+export const TODUAI_LOG_LEVEL_ENV = "TODUAI_LOG_LEVEL";
+
 const DEFAULT_DAEMON_LOG_LEVEL: DaemonLogLevel = "info";
 
 export function createDaemonLogger(options: CreateDaemonLoggerOptions = {}): DaemonLogger {
@@ -100,7 +103,7 @@ export function resolveDaemonLogLevelFromEnv(
   env: NodeJS.ProcessEnv,
   fallback: DaemonLogLevel = DEFAULT_DAEMON_LOG_LEVEL,
 ): DaemonLogLevel {
-  return resolveDaemonLogLevel(env.TODUAI_LOG_LEVEL, fallback);
+  return resolveDaemonLogLevel(env[TODU_LOG_LEVEL_ENV] ?? env[TODUAI_LOG_LEVEL_ENV], fallback);
 }
 
 export function resolveDaemonLogLevel(

--- a/packages/daemon/src/plugin-config.test.ts
+++ b/packages/daemon/src/plugin-config.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   parseDaemonPluginConfigFromEnv,
+  TODU_DAEMON_PLUGIN_CONFIG_ENV,
   TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
 } from "./plugin-config.js";
 
 describe("parseDaemonPluginConfigFromEnv", () => {
-  it("returns undefined when env var is not set", () => {
+  it("returns undefined when env vars are not set", () => {
     const parsed = parseDaemonPluginConfigFromEnv({});
 
     expect(parsed).toEqual({
@@ -14,7 +15,23 @@ describe("parseDaemonPluginConfigFromEnv", () => {
     });
   });
 
-  it("parses plugin config object from JSON", () => {
+  it("prefers TODU_DAEMON_PLUGIN_CONFIG over the legacy env var", () => {
+    const parsed = parseDaemonPluginConfigFromEnv({
+      [TODU_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"projectId":"proj-current"}}',
+      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":{"projectId":"proj-legacy"}}',
+    });
+
+    expect(parsed).toEqual({
+      pluginConfigs: {
+        github: {
+          projectId: "proj-current",
+        },
+      },
+      ignoredEntries: [],
+    });
+  });
+
+  it("falls back to the legacy env var", () => {
     const parsed = parseDaemonPluginConfigFromEnv({
       [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]:
         '{"github":{"projectId":"proj-1","intervalSeconds":60},"forgejo":{"enabled":false}}',
@@ -36,7 +53,7 @@ describe("parseDaemonPluginConfigFromEnv", () => {
 
   it("reports invalid JSON as parse error", () => {
     const parsed = parseDaemonPluginConfigFromEnv({
-      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: "{bad",
+      [TODU_DAEMON_PLUGIN_CONFIG_ENV]: "{bad",
     });
 
     expect(parsed.pluginConfigs).toEqual({});
@@ -45,7 +62,7 @@ describe("parseDaemonPluginConfigFromEnv", () => {
 
   it("ignores non-object plugin entries", () => {
     const parsed = parseDaemonPluginConfigFromEnv({
-      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":true,"ok":{"enabled":true}}',
+      [TODU_DAEMON_PLUGIN_CONFIG_ENV]: '{"github":true,"ok":{"enabled":true}}',
     });
 
     expect(parsed).toEqual({
@@ -60,7 +77,7 @@ describe("parseDaemonPluginConfigFromEnv", () => {
 
   it("supports explicit empty plugin config object", () => {
     const parsed = parseDaemonPluginConfigFromEnv({
-      [TODUAI_DAEMON_PLUGIN_CONFIG_ENV]: "",
+      [TODU_DAEMON_PLUGIN_CONFIG_ENV]: "",
     });
 
     expect(parsed).toEqual({

--- a/packages/daemon/src/plugin-config.ts
+++ b/packages/daemon/src/plugin-config.ts
@@ -1,3 +1,4 @@
+export const TODU_DAEMON_PLUGIN_CONFIG_ENV = "TODU_DAEMON_PLUGIN_CONFIG";
 export const TODUAI_DAEMON_PLUGIN_CONFIG_ENV = "TODUAI_DAEMON_PLUGIN_CONFIG";
 
 export interface ParsedDaemonPluginConfigEnv {
@@ -9,7 +10,7 @@ export interface ParsedDaemonPluginConfigEnv {
 export function parseDaemonPluginConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): ParsedDaemonPluginConfigEnv {
-  const rawConfig = env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
+  const rawConfig = env[TODU_DAEMON_PLUGIN_CONFIG_ENV] ?? env[TODUAI_DAEMON_PLUGIN_CONFIG_ENV];
   if (rawConfig === undefined) {
     return {
       pluginConfigs: undefined,

--- a/packages/daemon/src/plugin-paths.test.ts
+++ b/packages/daemon/src/plugin-paths.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { parseDaemonPluginPathsFromEnv, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
+import {
+  parseDaemonPluginPathsFromEnv,
+  TODU_DAEMON_PLUGIN_PATHS_ENV,
+  TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+} from "./plugin-paths.js";
 
 describe("parseDaemonPluginPathsFromEnv", () => {
-  it("returns undefined module paths when env var is not set", () => {
+  it("returns undefined module paths when env vars are not set", () => {
     const parsed = parseDaemonPluginPathsFromEnv({});
 
     expect(parsed).toEqual({
@@ -12,7 +16,20 @@ describe("parseDaemonPluginPathsFromEnv", () => {
     });
   });
 
-  it("parses module paths from comma-separated env value", () => {
+  it("prefers TODU_DAEMON_PLUGIN_PATHS over the legacy env var", () => {
+    const parsed = parseDaemonPluginPathsFromEnv({
+      [TODU_DAEMON_PLUGIN_PATHS_ENV]: " /plugins/current.js ",
+      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: " /plugins/legacy.js ",
+    });
+
+    expect(parsed).toEqual({
+      modulePaths: ["/plugins/current.js"],
+      duplicateModulePaths: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("falls back to the legacy env var", () => {
     const parsed = parseDaemonPluginPathsFromEnv({
       [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: " /plugins/github.js,/plugins/forgejo.js ",
     });
@@ -26,7 +43,7 @@ describe("parseDaemonPluginPathsFromEnv", () => {
 
   it("reports duplicates and ignored empty entries", () => {
     const parsed = parseDaemonPluginPathsFromEnv({
-      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "/plugins/github.js,,/plugins/github.js, ",
+      [TODU_DAEMON_PLUGIN_PATHS_ENV]: "/plugins/github.js,,/plugins/github.js, ",
     });
 
     expect(parsed).toEqual({
@@ -38,7 +55,7 @@ describe("parseDaemonPluginPathsFromEnv", () => {
 
   it("supports explicit empty module path list", () => {
     const parsed = parseDaemonPluginPathsFromEnv({
-      [TODUAI_DAEMON_PLUGIN_PATHS_ENV]: "",
+      [TODU_DAEMON_PLUGIN_PATHS_ENV]: "",
     });
 
     expect(parsed).toEqual({

--- a/packages/daemon/src/plugin-paths.ts
+++ b/packages/daemon/src/plugin-paths.ts
@@ -1,3 +1,4 @@
+export const TODU_DAEMON_PLUGIN_PATHS_ENV = "TODU_DAEMON_PLUGIN_PATHS";
 export const TODUAI_DAEMON_PLUGIN_PATHS_ENV = "TODUAI_DAEMON_PLUGIN_PATHS";
 
 export interface ParsedDaemonPluginPathsEnv {
@@ -9,7 +10,7 @@ export interface ParsedDaemonPluginPathsEnv {
 export function parseDaemonPluginPathsFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): ParsedDaemonPluginPathsEnv {
-  const rawModulePaths = env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
+  const rawModulePaths = env[TODU_DAEMON_PLUGIN_PATHS_ENV] ?? env[TODUAI_DAEMON_PLUGIN_PATHS_ENV];
   if (rawModulePaths === undefined) {
     return {
       modulePaths: undefined,

--- a/packages/daemon/src/run-daemon.ts
+++ b/packages/daemon/src/run-daemon.ts
@@ -1,16 +1,18 @@
 import { resolveRemoteSyncConfig } from "@todu/core";
 import { createDaemonLogger, resolveDaemonLogLevelFromEnv } from "./logger.js";
-import {
-  parseDaemonPluginConfigFromEnv,
-  TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
-} from "./plugin-config.js";
-import { parseDaemonPluginPathsFromEnv, TODUAI_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
+import { parseDaemonPluginConfigFromEnv, TODU_DAEMON_PLUGIN_CONFIG_ENV } from "./plugin-config.js";
+import { parseDaemonPluginPathsFromEnv, TODU_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
 import { startDaemonProcess } from "./process.js";
 import { type DaemonRole, isDaemonRole } from "./runtime.js";
 import {
   parseAssignedWorkerTypesFromEnv,
-  TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+  TODU_DAEMON_ASSIGNED_WORKERS_ENV,
 } from "./worker-assignment.js";
+
+const TODU_DAEMON_ROLE_ENV = "TODU_DAEMON_ROLE";
+const TODUAI_DAEMON_ROLE_ENV = "TODUAI_DAEMON_ROLE";
+const TODU_DAEMON_SOCKET_ENV = "TODU_DAEMON_SOCKET";
+const TODUAI_DAEMON_SOCKET_ENV = "TODUAI_DAEMON_SOCKET";
 
 function parseDaemonRole(value: string | undefined): DaemonRole {
   if (!value) {
@@ -18,7 +20,9 @@ function parseDaemonRole(value: string | undefined): DaemonRole {
   }
 
   if (!isDaemonRole(value)) {
-    throw new Error(`Invalid TODUAI_DAEMON_ROLE: ${value}. Expected: node or authority`);
+    throw new Error(
+      `Invalid ${TODU_DAEMON_ROLE_ENV}/${TODUAI_DAEMON_ROLE_ENV} value: ${value}. Expected: node or authority`,
+    );
   }
 
   return value;
@@ -31,8 +35,11 @@ export async function runDaemonEntrypoint(): Promise<void> {
     level: daemonLogLevel,
   });
 
-  const daemonRole = parseDaemonRole(process.env.TODUAI_DAEMON_ROLE);
-  const daemonSocketPath = process.env.TODUAI_DAEMON_SOCKET;
+  const daemonRole = parseDaemonRole(
+    process.env[TODU_DAEMON_ROLE_ENV] ?? process.env[TODUAI_DAEMON_ROLE_ENV],
+  );
+  const daemonSocketPath =
+    process.env[TODU_DAEMON_SOCKET_ENV] ?? process.env[TODUAI_DAEMON_SOCKET_ENV];
   const remoteSync = resolveRemoteSyncConfig({});
   const assignmentConfig = parseAssignedWorkerTypesFromEnv(process.env);
   const pluginPathsConfig = parseDaemonPluginPathsFromEnv(process.env);
@@ -40,42 +47,42 @@ export async function runDaemonEntrypoint(): Promise<void> {
 
   if (assignmentConfig.duplicateWorkerTypes.length > 0) {
     logger.warn("duplicate daemon worker assignment entries detected", {
-      envVar: TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+      envVar: TODU_DAEMON_ASSIGNED_WORKERS_ENV,
       duplicateWorkerTypes: assignmentConfig.duplicateWorkerTypes,
     });
   }
 
   if (assignmentConfig.ignoredEntries.length > 0) {
     logger.warn("ignored empty daemon worker assignment entries", {
-      envVar: TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
+      envVar: TODU_DAEMON_ASSIGNED_WORKERS_ENV,
       ignoredEntryCount: assignmentConfig.ignoredEntries.length,
     });
   }
 
   if (pluginPathsConfig.duplicateModulePaths.length > 0) {
     logger.warn("duplicate daemon plugin path entries detected", {
-      envVar: TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+      envVar: TODU_DAEMON_PLUGIN_PATHS_ENV,
       duplicateModulePaths: pluginPathsConfig.duplicateModulePaths,
     });
   }
 
   if (pluginPathsConfig.ignoredEntries.length > 0) {
     logger.warn("ignored empty daemon plugin path entries", {
-      envVar: TODUAI_DAEMON_PLUGIN_PATHS_ENV,
+      envVar: TODU_DAEMON_PLUGIN_PATHS_ENV,
       ignoredEntryCount: pluginPathsConfig.ignoredEntries.length,
     });
   }
 
   if (pluginConfig.parseError) {
     logger.warn("daemon plugin config parse failed", {
-      envVar: TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+      envVar: TODU_DAEMON_PLUGIN_CONFIG_ENV,
       error: pluginConfig.parseError,
     });
   }
 
   if (pluginConfig.ignoredEntries.length > 0) {
     logger.warn("ignored invalid daemon plugin config entries", {
-      envVar: TODUAI_DAEMON_PLUGIN_CONFIG_ENV,
+      envVar: TODU_DAEMON_PLUGIN_CONFIG_ENV,
       ignoredEntryCount: pluginConfig.ignoredEntries.length,
       ignoredEntries: pluginConfig.ignoredEntries,
     });

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -146,10 +146,15 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     socketPath: resolvedSocketPath,
     socketMode: config.socketMode ?? 0o600,
     daemonVersion:
-      config.daemonVersion ?? process.env.TODUAI_DAEMON_VERSION ?? DEFAULT_DAEMON_VERSION,
+      config.daemonVersion ??
+      process.env.TODU_DAEMON_VERSION ??
+      process.env.TODUAI_DAEMON_VERSION ??
+      DEFAULT_DAEMON_VERSION,
     requestTimeoutMs:
       config.requestTimeoutMs ??
-      parsePositiveInteger(process.env.TODUAI_DAEMON_REQUEST_TIMEOUT_MS) ??
+      parsePositiveInteger(
+        process.env.TODU_DAEMON_REQUEST_TIMEOUT_MS ?? process.env.TODUAI_DAEMON_REQUEST_TIMEOUT_MS,
+      ) ??
       DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
     logLevel: resolvedLogLevel,
     enabledWorkerDomains: resolvedEnabledWorkerDomains,

--- a/packages/daemon/src/worker-assignment.test.ts
+++ b/packages/daemon/src/worker-assignment.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   parseAssignedWorkerTypesFromEnv,
+  TODU_DAEMON_ASSIGNED_WORKERS_ENV,
   TODUAI_DAEMON_ASSIGNED_WORKERS_ENV,
 } from "./worker-assignment.js";
 
 describe("parseAssignedWorkerTypesFromEnv", () => {
-  it("returns undefined assignment when env var is not set", () => {
+  it("returns undefined assignment when env vars are not set", () => {
     const parsed = parseAssignedWorkerTypesFromEnv({});
 
     expect(parsed).toEqual({
@@ -15,7 +16,20 @@ describe("parseAssignedWorkerTypesFromEnv", () => {
     });
   });
 
-  it("parses assigned worker types from comma-separated env value", () => {
+  it("prefers TODU_DAEMON_ASSIGNED_WORKERS over the legacy env var", () => {
+    const parsed = parseAssignedWorkerTypesFromEnv({
+      [TODU_DAEMON_ASSIGNED_WORKERS_ENV]: " recurring,sync ",
+      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: " habit,legacy ",
+    });
+
+    expect(parsed).toEqual({
+      assignedWorkerTypes: ["recurring", "sync"],
+      duplicateWorkerTypes: [],
+      ignoredEntries: [],
+    });
+  });
+
+  it("falls back to the legacy env var", () => {
     const parsed = parseAssignedWorkerTypesFromEnv({
       [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: " recurring,sync ",
     });
@@ -29,7 +43,7 @@ describe("parseAssignedWorkerTypesFromEnv", () => {
 
   it("reports duplicates and ignored empty entries", () => {
     const parsed = parseAssignedWorkerTypesFromEnv({
-      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "recurring,,sync,recurring, ",
+      [TODU_DAEMON_ASSIGNED_WORKERS_ENV]: "recurring,,sync,recurring, ",
     });
 
     expect(parsed).toEqual({
@@ -41,7 +55,7 @@ describe("parseAssignedWorkerTypesFromEnv", () => {
 
   it("supports explicit empty assignment list", () => {
     const parsed = parseAssignedWorkerTypesFromEnv({
-      [TODUAI_DAEMON_ASSIGNED_WORKERS_ENV]: "",
+      [TODU_DAEMON_ASSIGNED_WORKERS_ENV]: "",
     });
 
     expect(parsed).toEqual({

--- a/packages/daemon/src/worker-assignment.ts
+++ b/packages/daemon/src/worker-assignment.ts
@@ -1,3 +1,4 @@
+export const TODU_DAEMON_ASSIGNED_WORKERS_ENV = "TODU_DAEMON_ASSIGNED_WORKERS";
 export const TODUAI_DAEMON_ASSIGNED_WORKERS_ENV = "TODUAI_DAEMON_ASSIGNED_WORKERS";
 
 export interface ParsedWorkerAssignmentEnv {
@@ -9,7 +10,8 @@ export interface ParsedWorkerAssignmentEnv {
 export function parseAssignedWorkerTypesFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): ParsedWorkerAssignmentEnv {
-  const rawAssignments = env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
+  const rawAssignments =
+    env[TODU_DAEMON_ASSIGNED_WORKERS_ENV] ?? env[TODUAI_DAEMON_ASSIGNED_WORKERS_ENV];
   if (rawAssignments === undefined) {
     return {
       assignedWorkerTypes: undefined,

--- a/packages/electron/src/main/config.ts
+++ b/packages/electron/src/main/config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import type { ToduFileConfig } from "@todu/core";
 import {
+  normalizeConfigPaths,
   type RemoteSyncConfig,
   resolveConfigPath,
   resolveDataDir,
@@ -33,7 +34,7 @@ export function loadElectronConfig(): ElectronConfig {
   let fileConfig: ToduFileConfig = {};
   try {
     const content = fs.readFileSync(configPath, "utf-8");
-    fileConfig = (parse(content) as ToduFileConfig) ?? {};
+    fileConfig = normalizeConfigPaths((parse(content) as ToduFileConfig) ?? {}, configPath);
   } catch {
     // Config file not found or unreadable — use defaults
   }

--- a/packages/electron/src/main/daemon-connection-manager.ts
+++ b/packages/electron/src/main/daemon-connection-manager.ts
@@ -516,7 +516,7 @@ export function createDaemonConnectionManager(
 }
 
 export function resolveDaemonSocketPath(storagePath: string): string {
-  const socketOverride = process.env.TODUAI_DAEMON_SOCKET;
+  const socketOverride = process.env.TODU_DAEMON_SOCKET ?? process.env.TODUAI_DAEMON_SOCKET;
   if (socketOverride && socketOverride.trim().length > 0) {
     return path.resolve(socketOverride);
   }


### PR DESCRIPTION
## Summary
- migrate default config/data/runtime naming from `toduai` to `todu`
- keep deterministic fallback support for legacy `TODUAI_*` env vars
- normalize embedded absolute legacy config paths to the new `todu` locations
- document the migration and runtime precedence rules

## What changed
- change default home config/data paths to `~/.config/todu`
- add one-time default-dir migration from `~/.config/toduai` to `~/.config/todu` when the new path is absent
- make `todu config init` default to `.todu` and migrate sibling `.toduai/` when present
- normalize embedded absolute config values like plugin state paths from `.../toduai/...` to `.../todu/...`
- make `TODU_*` env vars primary for config, data, sync, daemon socket, daemon lifecycle, plugin paths/config, and worker assignment
- keep legacy `TODUAI_*` env vars working as fallback during the transition
- update CLI, daemon, and Electron config/runtime resolution to use the same migration-aware logic
- add migration-focused tests and update daemon/config integration coverage
- update docs for the new defaults and compatibility behavior

## Acceptance criteria coverage
- existing local state under `~/.config/toduai` upgrades to `todu` naming without manual copy
- plugin-owned local state paths are normalized along with main config/data resolution
- code now prefers `todu`-named paths after migration
- legacy `TODUAI_*` env vars still work as explicit fallback
- tests cover:
  - legacy path exists, new path absent
  - new path exists, legacy path absent
  - both exist
  - config file contains embedded absolute legacy paths

## Validation
Local:
- `make pre-pr`
- `npx vitest run --config vitest.all.config.ts packages/cli/src/config.integration.test.ts packages/cli/src/commands/config.integration.test.ts packages/cli/src/commands/daemon.integration.test.ts`

Live migration validation on real local dataset:
- backed up:
  - `/home/erik/.cache/todu-migration-backups/20260317-113311`
- verified branch CLI resolves:
  - config: `/home/erik/.config/todu/config.yaml`
  - data: `/home/erik/.config/todu/data`
- restarted daemon through branch build and verified:
  - socket: `/home/erik/.config/todu/data/daemon.sock`
  - catalog unchanged: `4Lm1D4YABL7AUKdTyLHheZigSUq3`
  - project list remained intact (`14` projects)
- verified normalized plugin state paths load as:
  - `/home/erik/.config/todu/data/github-plugin-state/item-links.json`
  - `/home/erik/.config/todu/data/forgejo-plugin-state`
- rebuilt Electron and verified bundled main process uses migration-aware config loading

## Notes
- This PR intentionally does not remove legacy compatibility yet.
- Daemon service/binary naming like `toduai-daemon` is still left in place for the transition period.

Task: `task-c23a941f`
