### PR TITLE
feat: add note date range filters

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -285,11 +285,19 @@ todu note add "Floss method: Water Pick" --habit hab-123
 todu --format json note list --habit hab-123
 ```
 
+Filter notes by created-at date range:
+
+```bash
+todu --format json note list --from 2026-03-01 --to 2026-03-31
+todu --format json note list --tag journal --from 2026-03-01T00:00:00Z --to 2026-03-31T23:59:59Z
+```
+
 Behavior notes:
 - `--created-at` accepts an ISO-8601 date or datetime string.
+- `note list --from/--to` accepts either `YYYY-MM-DD` or ISO-8601 date/datetime strings.
 - Stored journal timestamps are normalized to ISO datetime form.
 - Standalone journal notes are bucketed by the provided historical month, not by import time.
-- Invalid `--created-at` input fails with a validation error.
+- Invalid note date input fails with a validation error.
 - `--habit <id>` attaches a note to a habit or filters notes for a habit.
 
 ## Validate connectivity

--- a/packages/cli/src/commands/label-note.integration.test.ts
+++ b/packages/cli/src/commands/label-note.integration.test.ts
@@ -156,6 +156,27 @@ describe("label + note CLI commands", () => {
       expect(output).toContain("not-a-date");
     });
 
+    it("filters notes by created-at date range", () => {
+      run(
+        '--format json note add "February note" --created-at "2026-02-10T08:00:00Z" --tag journal',
+      );
+      run('--format json note add "March note" --created-at "2026-03-12T09:30:00Z" --tag journal');
+      run('--format json note add "April note" --created-at "2026-04-02T14:00:00Z" --tag journal');
+
+      const listJson = run(
+        '--format json note list --from "2026-03-01" --to "2026-03-31" --tag journal',
+      );
+      const notes = JSON.parse(listJson);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].content).toBe("March note");
+    });
+
+    it("fails clearly for invalid note list date filters", () => {
+      const output = run('note list --from "not-a-date"', true);
+      expect(output).toContain("Invalid date");
+      expect(output).toContain("not-a-date");
+    });
+
     it("shows 'No notes.' when empty", () => {
       const output = run("note list");
       expect(output).toBe("No notes.");

--- a/packages/cli/src/commands/note.test.ts
+++ b/packages/cli/src/commands/note.test.ts
@@ -95,6 +95,8 @@ describe("note commands", () => {
         entityId: "hab-123",
         tag: undefined,
         author: undefined,
+        createdFrom: undefined,
+        createdTo: undefined,
       },
     });
     expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toMatchObject([
@@ -103,5 +105,43 @@ describe("note commands", () => {
         entityId: "hab-123",
       },
     ]);
+  });
+
+  it("passes date range filtering through on note list", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "note.list") {
+        return {
+          ok: true,
+          value: [],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(
+      ["--format", "json", "note", "list", "--from", "2026-03-01", "--to", "2026-03-31"],
+      {
+        from: "user",
+      },
+    );
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("note.list", {
+      filter: {
+        entityType: undefined,
+        entityId: undefined,
+        tag: undefined,
+        author: undefined,
+        createdFrom: "2026-03-01",
+        createdTo: "2026-03-31",
+      },
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -131,6 +131,8 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--habit <id>", "filter by habit")
     .option("--tag <tag>", "filter by tag")
     .option("--author <author>", "filter by author")
+    .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
+    .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
     .action(async (opts) => {
       let entityType: NoteEntityType | undefined;
       let entityId: string | undefined;
@@ -159,6 +161,8 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
           entityId,
           tag: opts.tag,
           author: opts.author,
+          createdFrom: opts.from,
+          createdTo: opts.to,
         },
       });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -369,6 +369,8 @@ export interface NoteFilter {
   entityId?: string;
   tag?: string;
   author?: string;
+  createdFrom?: string;
+  createdTo?: string;
 }
 
 // ============================================================================

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -23,6 +23,7 @@ import {
   validateLabelColor,
   validateLabelName,
   validateNoteContent,
+  validateNoteFilter,
   validateProjectName,
   validateTaskTitle,
   validateUpdateHabitInput,
@@ -961,5 +962,36 @@ describe("validateUpdateNoteInput", () => {
   it("rejects content exceeding max length", () => {
     const error = validateUpdateNoteInput({ content: "x".repeat(MAX_NOTE_CONTENT_LENGTH + 1) });
     expect(error?.field).toBe("content");
+  });
+});
+
+describe("validateNoteFilter", () => {
+  it("accepts ISO datetime bounds", () => {
+    expect(
+      validateNoteFilter({
+        createdFrom: "2026-03-01T00:00:00Z",
+        createdTo: "2026-03-31T23:59:59Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts YYYY-MM-DD bounds", () => {
+    expect(validateNoteFilter({ createdFrom: "2026-03-01", createdTo: "2026-03-31" })).toBeNull();
+  });
+
+  it("rejects invalid createdFrom", () => {
+    const error = validateNoteFilter({ createdFrom: "not-a-date" });
+    expect(error?.field).toBe("createdFrom");
+  });
+
+  it("rejects invalid createdTo", () => {
+    const error = validateNoteFilter({ createdTo: "2026-02-30" });
+    expect(error?.field).toBe("createdTo");
+  });
+
+  it("rejects inverted date ranges", () => {
+    const error = validateNoteFilter({ createdFrom: "2026-04-01", createdTo: "2026-03-31" });
+    expect(error?.field).toBe("createdTo");
+    expect(error?.message).toContain("on or after");
   });
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -9,6 +9,7 @@ import type {
   CreateTaskInput,
   IntegrationBinding,
   IntegrationBindingId,
+  NoteFilter,
   TaskStatus,
   UpdateHabitInput,
   UpdateIntegrationBindingInput,
@@ -595,6 +596,56 @@ export function validateUpdateNoteInput(input: UpdateNoteInput): ValidationError
   if (input.content !== undefined) {
     const contentError = validateNoteContent(input.content);
     if (contentError) return contentError;
+  }
+
+  return null;
+}
+
+function validateNoteFilterDate(
+  field: "createdFrom" | "createdTo",
+  value: string,
+): ValidationError | null {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return validateDateString(field, value);
+  }
+
+  return validateISODate(field, value);
+}
+
+function normalizeNoteFilterDate(field: "createdFrom" | "createdTo", value: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [year, month, day] = value.split("-").map(Number);
+    const time =
+      field === "createdFrom"
+        ? Date.UTC(year, month - 1, day, 0, 0, 0, 0)
+        : Date.UTC(year, month - 1, day, 23, 59, 59, 999);
+    return new Date(time).toISOString();
+  }
+
+  return new Date(value).toISOString();
+}
+
+export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
+  if (filter.entityType !== undefined && !isNoteEntityType(filter.entityType)) {
+    return validationError("entityType", `Invalid entity type: ${filter.entityType}`);
+  }
+
+  if (filter.createdFrom !== undefined) {
+    const createdFromError = validateNoteFilterDate("createdFrom", filter.createdFrom);
+    if (createdFromError) return createdFromError;
+  }
+
+  if (filter.createdTo !== undefined) {
+    const createdToError = validateNoteFilterDate("createdTo", filter.createdTo);
+    if (createdToError) return createdToError;
+  }
+
+  if (filter.createdFrom !== undefined && filter.createdTo !== undefined) {
+    const createdFrom = normalizeNoteFilterDate("createdFrom", filter.createdFrom);
+    const createdTo = normalizeNoteFilterDate("createdTo", filter.createdTo);
+    if (createdFrom > createdTo) {
+      return validationError("createdTo", "createdTo must be on or after createdFrom");
+    }
   }
 
   return null;

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -246,6 +246,12 @@ const ListNotesParams = Type.Object({
   entityId: Type.Optional(Type.String({ description: "Filter by entity ID" })),
   tag: Type.Optional(Type.String({ description: "Filter by tag" })),
   author: Type.Optional(Type.String({ description: "Filter by author" })),
+  createdFrom: Type.Optional(
+    Type.String({ description: "Filter by created-at start (YYYY-MM-DD or ISO-8601)" }),
+  ),
+  createdTo: Type.Optional(
+    Type.String({ description: "Filter by created-at end (YYYY-MM-DD or ISO-8601)" }),
+  ),
 });
 
 // ============================================================================
@@ -482,7 +488,8 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     },
     {
       name: "list_notes",
-      description: "List notes, optionally filtered by entity, tag, or author.",
+      description:
+        "List notes, optionally filtered by entity, tag, author, or created-at date range.",
       label: "List Notes",
       parameters: ListNotesParams,
       execute: async (_toolCallId, params) => {

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -12,7 +12,7 @@ import {
   type Note,
   type ProjectId,
 } from "@todu/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
 
@@ -245,6 +245,92 @@ describe("note namespace", () => {
       if (!result.ok) return;
       expect(result.value).toHaveLength(1);
       expect(result.value[0].content).toBe("Agent note");
+    });
+
+    it("filters by created-at date range and composes with tag filters", async () => {
+      await todu.note.create({
+        content: "February journal",
+        tags: ["journal"],
+        createdAt: "2026-02-20T12:00:00Z",
+      });
+      await todu.note.create({
+        content: "March journal",
+        tags: ["journal"],
+        createdAt: "2026-03-12T08:30:00Z",
+      });
+      await todu.note.create({
+        content: "March work log",
+        tags: ["work"],
+        createdAt: "2026-03-18T18:45:00Z",
+      });
+      await todu.note.create({
+        content: "April journal",
+        tags: ["journal"],
+        createdAt: "2026-04-01T09:00:00Z",
+      });
+
+      const result = await todu.note.list({
+        tag: "journal",
+        createdFrom: "2026-03-01",
+        createdTo: "2026-03-31",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((note) => note.content)).toEqual(["March journal"]);
+    });
+
+    it("rejects invalid date range filters", async () => {
+      const result = await todu.note.list({ createdFrom: "not-a-date" });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("validation");
+      if (result.error.type !== "validation") return;
+      expect(result.error.field).toBe("createdFrom");
+    });
+
+    it("narrows journal bucket reads for global date range queries", async () => {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      const previousDiagnostics = process.env.TODU_NOTES_DIAGNOSTICS;
+      process.env.TODU_NOTES_DIAGNOSTICS = "1";
+
+      try {
+        const task = await todu.task.create({ title: "Task note", projectId });
+        if (!task.ok) throw new Error("create failed");
+
+        await todu.note.create({ content: "January journal", createdAt: "2026-01-15T12:00:00Z" });
+        await todu.note.create({ content: "March journal", createdAt: "2026-03-15T12:00:00Z" });
+        await todu.note.create({ content: "April journal", createdAt: "2026-04-15T12:00:00Z" });
+        await todu.note.create({
+          content: "March task note",
+          entityType: "task",
+          entityId: task.value.id,
+          createdAt: "2026-03-20T09:00:00Z",
+        });
+
+        const result = await todu.note.list({ createdFrom: "2026-03-01", createdTo: "2026-03-31" });
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.map((note) => note.content)).toEqual([
+          "March task note",
+          "March journal",
+        ]);
+
+        const listDiagnostic = infoSpy.mock.calls
+          .map((call) => call[0])
+          .find(
+            (entry): entry is string =>
+              typeof entry === "string" && entry.startsWith("[notes] list "),
+          );
+        expect(listDiagnostic).toBeDefined();
+        expect(listDiagnostic).toContain('"bucketCount":2');
+      } finally {
+        if (previousDiagnostics === undefined) {
+          delete process.env.TODU_NOTES_DIAGNOSTICS;
+        } else {
+          process.env.TODU_NOTES_DIAGNOSTICS = previousDiagnostics;
+        }
+        infoSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -16,6 +16,7 @@ import {
   type TaskListDocument,
   type UpdateNoteInput,
   validateCreateNoteInput,
+  validateNoteFilter,
   validateUpdateNoteInput,
 } from "@todu/core";
 import type { NoteNamespace } from "./todu.js";
@@ -60,6 +61,47 @@ export function createNoteNamespace(
       return `entity:${filter.entityType}:${filter.entityId}`;
     }
     return null;
+  }
+
+  function normalizeRangeBoundary(value: string, bound: "start" | "end"): string {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      const [year, month, day] = value.split("-").map(Number);
+      const time =
+        bound === "start"
+          ? Date.UTC(year, month - 1, day, 0, 0, 0, 0)
+          : Date.UTC(year, month - 1, day, 23, 59, 59, 999);
+      return new Date(time).toISOString();
+    }
+
+    return new Date(value).toISOString();
+  }
+
+  function normalizeNoteFilter(filter?: NoteFilter): NoteFilter | undefined {
+    if (!filter) return undefined;
+
+    const normalized: NoteFilter = { ...filter };
+    if (filter.createdFrom !== undefined) {
+      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start");
+    }
+    if (filter.createdTo !== undefined) {
+      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end");
+    }
+
+    return normalized;
+  }
+
+  function journalBucketMatchesCreatedRange(bucketKey: string, filter?: NoteFilter): boolean {
+    if (!bucketKey.startsWith("journal:")) return true;
+    if (!filter?.createdFrom && !filter?.createdTo) return true;
+
+    const month = bucketKey.slice("journal:".length);
+    if (filter.createdFrom && month < filter.createdFrom.slice(0, 7)) {
+      return false;
+    }
+    if (filter.createdTo && month > filter.createdTo.slice(0, 7)) {
+      return false;
+    }
+    return true;
   }
 
   async function getBucketHandle(bucketKey: string): Promise<DocHandle<NotesDocument> | null> {
@@ -239,6 +281,12 @@ export function createNoteNamespace(
       return allBucketKeys.filter((bucketKey) => bucketKey.startsWith(prefix));
     }
 
+    if (filter.createdFrom || filter.createdTo) {
+      return allBucketKeys.filter((bucketKey) =>
+        journalBucketMatchesCreatedRange(bucketKey, filter),
+      );
+    }
+
     return allBucketKeys;
   }
 
@@ -316,9 +364,13 @@ export function createNoteNamespace(
     },
 
     async list(filter?: NoteFilter): Promise<Result<Note[]>> {
+      const validationErr = filter ? validateNoteFilter(filter) : null;
+      if (validationErr) return err(validationErr);
+
       await ensurePartitionModelReady();
 
-      const bucketKeys = listBucketKeys(filter);
+      const normalizedFilter = normalizeNoteFilter(filter);
+      const bucketKeys = listBucketKeys(normalizedFilter);
       if (bucketKeys.length === 0) return ok([]);
 
       const allNotes: Note[] = [];
@@ -334,19 +386,25 @@ export function createNoteNamespace(
       let notes = allNotes;
 
       // Apply filters
-      if (filter?.entityType) {
-        notes = notes.filter((n) => n.entityType === filter.entityType);
+      if (normalizedFilter?.entityType) {
+        notes = notes.filter((n) => n.entityType === normalizedFilter.entityType);
       }
-      if (filter?.entityId) {
-        notes = notes.filter((n) => n.entityId === filter.entityId);
+      if (normalizedFilter?.entityId) {
+        notes = notes.filter((n) => n.entityId === normalizedFilter.entityId);
       }
-      if (filter?.tag) {
-        const tag = filter.tag;
+      if (normalizedFilter?.tag) {
+        const tag = normalizedFilter.tag;
         notes = notes.filter((n) => n.tags.includes(tag));
       }
-      if (filter?.author) {
-        const author = filter.author;
+      if (normalizedFilter?.author) {
+        const author = normalizedFilter.author;
         notes = notes.filter((n) => n.author === author);
+      }
+      if (normalizedFilter?.createdFrom) {
+        notes = notes.filter((n) => n.createdAt >= normalizedFilter.createdFrom!);
+      }
+      if (normalizedFilter?.createdTo) {
+        notes = notes.filter((n) => n.createdAt <= normalizedFilter.createdTo!);
       }
 
       // Sort by createdAt desc (newest first)
@@ -355,8 +413,8 @@ export function createNoteNamespace(
       emitDiagnostic("list", {
         bucketCount: bucketKeys.length,
         resultCount: notes.length,
-        entityType: filter?.entityType,
-        hasEntityId: filter?.entityId !== undefined,
+        entityType: normalizedFilter?.entityType,
+        hasEntityId: normalizedFilter?.entityId !== undefined,
       });
 
       return ok(notes);


### PR DESCRIPTION
## Summary

Add created-at date range filtering for notes across the CLI, engine, and shared note filter model.

## Task

- task-e6007c9e

## Changes

- add `createdFrom` and `createdTo` to `NoteFilter`
- validate note date range input for ISO and `YYYY-MM-DD` values
- add `todu note list --from/--to`
- prune unrelated journal buckets before filtering global note date range queries
- add tests and CLI docs for the new behavior

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] `npm run check`
- [x] `npx vitest run --config vitest.all.config.ts packages/engine/src/notes.integration.test.ts`
- [x] `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
