### PR TITLE
feat: add journal note filtering

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -290,11 +290,13 @@ Filter notes by created-at date range:
 ```bash
 todu --format json note list --from 2026-03-01 --to 2026-03-31
 todu --format json note list --tag journal --from 2026-03-01T00:00:00Z --to 2026-03-31T23:59:59Z
+todu --format json note list --journal --from 2026-03-01 --to 2026-03-31
 ```
 
 Behavior notes:
 - `--created-at` accepts an ISO-8601 date or datetime string.
 - `note list --from/--to` accepts either `YYYY-MM-DD` or ISO-8601 date/datetime strings.
+- `note list --journal` limits results to standalone notes with no task, project, or habit attachment.
 - Stored journal timestamps are normalized to ISO datetime form.
 - Standalone journal notes are bucketed by the provided historical month, not by import time.
 - Invalid note date input fails with a validation error.

--- a/packages/cli/src/commands/label-note.integration.test.ts
+++ b/packages/cli/src/commands/label-note.integration.test.ts
@@ -171,6 +171,28 @@ describe("label + note CLI commands", () => {
       expect(notes[0].content).toBe("March note");
     });
 
+    it("lists only standalone journal entries with --journal", () => {
+      const projJson = run('--format json project create --name "Journal Filter Project"');
+      const proj = JSON.parse(projJson);
+      const taskJson = run(
+        `--format json task create --title "Attached note task" --project "${proj.id}"`,
+      );
+      const task = JSON.parse(taskJson);
+
+      run('--format json note add "Standalone journal" --created-at "2026-03-12T09:30:00Z"');
+      run(
+        `--format json note add "Task note" --task "${task.id}" --created-at "2026-03-12T10:00:00Z"`,
+      );
+
+      const listJson = run(
+        '--format json note list --journal --from "2026-03-01" --to "2026-03-31"',
+      );
+      const notes = JSON.parse(listJson);
+      expect(notes).toHaveLength(1);
+      expect(notes[0].content).toBe("Standalone journal");
+      expect(notes[0].entityType).toBeUndefined();
+    });
+
     it("fails clearly for invalid note list date filters", () => {
       const output = run('note list --from "not-a-date"', true);
       expect(output).toContain("Invalid date");

--- a/packages/cli/src/commands/note.test.ts
+++ b/packages/cli/src/commands/note.test.ts
@@ -95,6 +95,7 @@ describe("note commands", () => {
         entityId: "hab-123",
         tag: undefined,
         author: undefined,
+        journal: undefined,
         createdFrom: undefined,
         createdTo: undefined,
       },
@@ -138,8 +139,45 @@ describe("note commands", () => {
         entityId: undefined,
         tag: undefined,
         author: undefined,
+        journal: undefined,
         createdFrom: "2026-03-01",
         createdTo: "2026-03-31",
+      },
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);
+  });
+
+  it("passes journal filtering through on note list", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "note.list") {
+        return {
+          ok: true,
+          value: [],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(["--format", "json", "note", "list", "--journal"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("note.list", {
+      filter: {
+        entityType: undefined,
+        entityId: undefined,
+        tag: undefined,
+        author: undefined,
+        journal: true,
+        createdFrom: undefined,
+        createdTo: undefined,
       },
     });
     expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -131,6 +131,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--habit <id>", "filter by habit")
     .option("--tag <tag>", "filter by tag")
     .option("--author <author>", "filter by author")
+    .option("--journal", "filter to standalone journal entries only")
     .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
     .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
     .action(async (opts) => {
@@ -161,6 +162,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
           entityId,
           tag: opts.tag,
           author: opts.author,
+          journal: opts.journal,
           createdFrom: opts.from,
           createdTo: opts.to,
         },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -371,6 +371,7 @@ export interface NoteFilter {
   author?: string;
   createdFrom?: string;
   createdTo?: string;
+  journal?: boolean;
 }
 
 // ============================================================================

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -994,4 +994,9 @@ describe("validateNoteFilter", () => {
     expect(error?.field).toBe("createdTo");
     expect(error?.message).toContain("on or after");
   });
+
+  it("rejects journal combined with entity filters", () => {
+    const error = validateNoteFilter({ journal: true, entityType: "task", entityId: "task-123" });
+    expect(error?.field).toBe("journal");
+  });
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -630,6 +630,10 @@ export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
     return validationError("entityType", `Invalid entity type: ${filter.entityType}`);
   }
 
+  if (filter.journal && (filter.entityType !== undefined || filter.entityId !== undefined)) {
+    return validationError("journal", "journal filter cannot be combined with entity filters");
+  }
+
   if (filter.createdFrom !== undefined) {
     const createdFromError = validateNoteFilterDate("createdFrom", filter.createdFrom);
     if (createdFromError) return createdFromError;

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -246,6 +246,7 @@ const ListNotesParams = Type.Object({
   entityId: Type.Optional(Type.String({ description: "Filter by entity ID" })),
   tag: Type.Optional(Type.String({ description: "Filter by tag" })),
   author: Type.Optional(Type.String({ description: "Filter by author" })),
+  journal: Type.Optional(Type.Boolean({ description: "Filter to standalone journal notes only" })),
   createdFrom: Type.Optional(
     Type.String({ description: "Filter by created-at start (YYYY-MM-DD or ISO-8601)" }),
   ),

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -288,7 +288,24 @@ describe("note namespace", () => {
       expect(result.error.field).toBe("createdFrom");
     });
 
-    it("narrows journal bucket reads for global date range queries", async () => {
+    it("lists only standalone journal notes when requested", async () => {
+      const task = await todu.task.create({ title: "Task note", projectId });
+      if (!task.ok) throw new Error("create failed");
+
+      await todu.note.create({ content: "Journal entry" });
+      await todu.note.create({
+        content: "Task attached",
+        entityType: "task",
+        entityId: task.value.id,
+      });
+
+      const result = await todu.note.list({ journal: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((note) => note.content)).toEqual(["Journal entry"]);
+    });
+
+    it("narrows journal bucket reads for journal-only date range queries", async () => {
       const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
       const previousDiagnostics = process.env.TODU_NOTES_DIAGNOSTICS;
       process.env.TODU_NOTES_DIAGNOSTICS = "1";
@@ -307,13 +324,14 @@ describe("note namespace", () => {
           createdAt: "2026-03-20T09:00:00Z",
         });
 
-        const result = await todu.note.list({ createdFrom: "2026-03-01", createdTo: "2026-03-31" });
+        const result = await todu.note.list({
+          journal: true,
+          createdFrom: "2026-03-01",
+          createdTo: "2026-03-31",
+        });
         expect(result.ok).toBe(true);
         if (!result.ok) return;
-        expect(result.value.map((note) => note.content)).toEqual([
-          "March task note",
-          "March journal",
-        ]);
+        expect(result.value.map((note) => note.content)).toEqual(["March journal"]);
 
         const listDiagnostic = infoSpy.mock.calls
           .map((call) => call[0])
@@ -322,7 +340,8 @@ describe("note namespace", () => {
               typeof entry === "string" && entry.startsWith("[notes] list "),
           );
         expect(listDiagnostic).toBeDefined();
-        expect(listDiagnostic).toContain('"bucketCount":2');
+        expect(listDiagnostic).toContain('"bucketCount":1');
+        expect(listDiagnostic).toContain('"journal":true');
       } finally {
         if (previousDiagnostics === undefined) {
           delete process.env.TODU_NOTES_DIAGNOSTICS;

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -90,8 +90,12 @@ export function createNoteNamespace(
     return normalized;
   }
 
+  function isJournalBucketKey(bucketKey: string): boolean {
+    return bucketKey.startsWith("journal:");
+  }
+
   function journalBucketMatchesCreatedRange(bucketKey: string, filter?: NoteFilter): boolean {
-    if (!bucketKey.startsWith("journal:")) return true;
+    if (!isJournalBucketKey(bucketKey)) return true;
     if (!filter?.createdFrom && !filter?.createdTo) return true;
 
     const month = bucketKey.slice("journal:".length);
@@ -281,6 +285,13 @@ export function createNoteNamespace(
       return allBucketKeys.filter((bucketKey) => bucketKey.startsWith(prefix));
     }
 
+    if (filter.journal) {
+      return allBucketKeys.filter(
+        (bucketKey) =>
+          isJournalBucketKey(bucketKey) && journalBucketMatchesCreatedRange(bucketKey, filter),
+      );
+    }
+
     if (filter.createdFrom || filter.createdTo) {
       return allBucketKeys.filter((bucketKey) =>
         journalBucketMatchesCreatedRange(bucketKey, filter),
@@ -400,6 +411,9 @@ export function createNoteNamespace(
         const author = normalizedFilter.author;
         notes = notes.filter((n) => n.author === author);
       }
+      if (normalizedFilter?.journal) {
+        notes = notes.filter((n) => n.entityType === undefined && n.entityId === undefined);
+      }
       if (normalizedFilter?.createdFrom) {
         notes = notes.filter((n) => n.createdAt >= normalizedFilter.createdFrom!);
       }
@@ -415,6 +429,7 @@ export function createNoteNamespace(
         resultCount: notes.length,
         entityType: normalizedFilter?.entityType,
         hasEntityId: normalizedFilter?.entityId !== undefined,
+        journal: normalizedFilter?.journal === true,
       });
 
       return ok(notes);


### PR DESCRIPTION
## Summary

Add a native `--journal` note list filter so users can list only standalone journal notes without post-processing JSON.

## Task

- task-c526cbac

## Changes

- add `journal` to `NoteFilter`
- add `todu note list --journal`
- prune note reads to `journal:*` buckets for journal-only queries
- exclude task/project/habit-attached notes from journal-only results
- add tests and docs for the new behavior

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] `npm run test -- packages/core/src/validation.test.ts packages/cli/src/commands/note.test.ts`
- [x] `npx vitest run --config vitest.all.config.ts packages/engine/src/notes.integration.test.ts`
- [x] `make check`
- [x] `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
