### PR TITLE
feat: add task list created-at range filters

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -302,6 +302,18 @@ Behavior notes:
 - Invalid note date input fails with a validation error.
 - `--habit <id>` attaches a note to a habit or filters notes for a habit.
 
+Filter tasks by created-at date range:
+
+```bash
+todu --format json task list --from 2026-03-01 --to 2026-03-31
+todu --format json task list --project proj-123 --from 2026-03-01T00:00:00Z --to 2026-03-31T23:59:59Z
+```
+
+Task date-range behavior notes:
+- `task list --from/--to` uses created-at timestamps, not due dates.
+- `task list --from/--to` accepts either `YYYY-MM-DD` or ISO-8601 date/datetime strings.
+- Invalid task date input fails with a validation error.
+
 ## Validate connectivity
 
 ```bash

--- a/packages/cli/src/commands/task.integration.test.ts
+++ b/packages/cli/src/commands/task.integration.test.ts
@@ -168,6 +168,25 @@ describe("task CLI commands", () => {
     expect(sortedParsed[1].title).toBe("Bravo");
   });
 
+  it("filters tasks by created-at date range", { timeout: 30000 }, async () => {
+    run('project create --name "Date Filter"');
+    run('--format json task create --title "Earlier task" --project "Date Filter"');
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const from = new Date().toISOString();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    run('--format json task create --title "March task" --project "Date Filter"');
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const to = new Date().toISOString();
+
+    const marchOnly = run(`--format json task list --from "${from}" --to "${to}"`);
+    const parsed = JSON.parse(marchOnly);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].title).toBe("March task");
+  });
+
   it("handles errors gracefully", () => {
     // Show nonexistent task
     const showErr = run("task show task-nonexistent", true);

--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -1,0 +1,53 @@
+import type { Task } from "@todu/core";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliDaemonInvoker } from "../daemon-command-client.js";
+import { registerTaskCommands } from "./task.js";
+
+describe("task commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("passes created-at date range filtering through on task list", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "task.list") {
+        return {
+          ok: true,
+          value: [] satisfies Task[],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerTaskCommands(program, invokeDaemon);
+
+    await program.parseAsync(
+      ["--format", "json", "task", "list", "--from", "2026-03-01", "--to", "2026-03-31"],
+      {
+        from: "user",
+      },
+    );
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("task.list", {
+      filter: {
+        projectId: undefined,
+        status: undefined,
+        priority: undefined,
+        label: undefined,
+        createdFrom: "2026-03-01",
+        createdTo: "2026-03-31",
+        overdue: undefined,
+        today: undefined,
+      },
+      sort: undefined,
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -152,6 +152,8 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--status <statuses>", "filter by status (comma-separated)")
     .option("--priority <priority>", "filter by priority")
     .option("--label <label>", "filter by label")
+    .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
+    .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
     .option("--overdue", "show overdue tasks only")
     .option("--today", "show tasks due or scheduled today")
     .option("--sort <field>", "sort by field (priority, dueDate, createdAt, updatedAt, title)")
@@ -205,6 +207,8 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           status,
           priority: opts.priority,
           label: opts.label,
+          createdFrom: opts.from,
+          createdTo: opts.to,
           overdue: opts.overdue,
           today: opts.today,
         },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -322,6 +322,8 @@ export interface TaskFilter {
   priority?: TaskPriority;
   projectId?: ProjectId;
   label?: string;
+  createdFrom?: string;
+  createdTo?: string;
   dueBefore?: string;
   dueAfter?: string;
   overdue?: boolean;

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -25,6 +25,7 @@ import {
   validateNoteContent,
   validateNoteFilter,
   validateProjectName,
+  validateTaskFilter,
   validateTaskTitle,
   validateUpdateHabitInput,
   validateUpdateIntegrationBindingInput,
@@ -962,6 +963,37 @@ describe("validateUpdateNoteInput", () => {
   it("rejects content exceeding max length", () => {
     const error = validateUpdateNoteInput({ content: "x".repeat(MAX_NOTE_CONTENT_LENGTH + 1) });
     expect(error?.field).toBe("content");
+  });
+});
+
+describe("validateTaskFilter", () => {
+  it("accepts ISO datetime bounds", () => {
+    expect(
+      validateTaskFilter({
+        createdFrom: "2026-03-01T00:00:00Z",
+        createdTo: "2026-03-31T23:59:59Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts YYYY-MM-DD bounds", () => {
+    expect(validateTaskFilter({ createdFrom: "2026-03-01", createdTo: "2026-03-31" })).toBeNull();
+  });
+
+  it("rejects invalid createdFrom", () => {
+    const error = validateTaskFilter({ createdFrom: "not-a-date" });
+    expect(error?.field).toBe("createdFrom");
+  });
+
+  it("rejects invalid createdTo", () => {
+    const error = validateTaskFilter({ createdTo: "2026-02-30" });
+    expect(error?.field).toBe("createdTo");
+  });
+
+  it("rejects inverted date ranges", () => {
+    const error = validateTaskFilter({ createdFrom: "2026-04-01", createdTo: "2026-03-31" });
+    expect(error?.field).toBe("createdTo");
+    expect(error?.message).toContain("on or after");
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -10,6 +10,7 @@ import type {
   IntegrationBinding,
   IntegrationBindingId,
   NoteFilter,
+  TaskFilter,
   TaskStatus,
   UpdateHabitInput,
   UpdateIntegrationBindingInput,
@@ -601,7 +602,7 @@ export function validateUpdateNoteInput(input: UpdateNoteInput): ValidationError
   return null;
 }
 
-function validateNoteFilterDate(
+function validateCreatedRangeDate(
   field: "createdFrom" | "createdTo",
   value: string,
 ): ValidationError | null {
@@ -612,7 +613,7 @@ function validateNoteFilterDate(
   return validateISODate(field, value);
 }
 
-function normalizeNoteFilterDate(field: "createdFrom" | "createdTo", value: string): string {
+function normalizeCreatedRangeDate(field: "createdFrom" | "createdTo", value: string): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     const [year, month, day] = value.split("-").map(Number);
     const time =
@@ -625,6 +626,28 @@ function normalizeNoteFilterDate(field: "createdFrom" | "createdTo", value: stri
   return new Date(value).toISOString();
 }
 
+export function validateTaskFilter(filter: TaskFilter): ValidationError | null {
+  if (filter.createdFrom !== undefined) {
+    const createdFromError = validateCreatedRangeDate("createdFrom", filter.createdFrom);
+    if (createdFromError) return createdFromError;
+  }
+
+  if (filter.createdTo !== undefined) {
+    const createdToError = validateCreatedRangeDate("createdTo", filter.createdTo);
+    if (createdToError) return createdToError;
+  }
+
+  if (filter.createdFrom !== undefined && filter.createdTo !== undefined) {
+    const createdFrom = normalizeCreatedRangeDate("createdFrom", filter.createdFrom);
+    const createdTo = normalizeCreatedRangeDate("createdTo", filter.createdTo);
+    if (createdFrom > createdTo) {
+      return validationError("createdTo", "createdTo must be on or after createdFrom");
+    }
+  }
+
+  return null;
+}
+
 export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
   if (filter.entityType !== undefined && !isNoteEntityType(filter.entityType)) {
     return validationError("entityType", `Invalid entity type: ${filter.entityType}`);
@@ -635,18 +658,18 @@ export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
   }
 
   if (filter.createdFrom !== undefined) {
-    const createdFromError = validateNoteFilterDate("createdFrom", filter.createdFrom);
+    const createdFromError = validateCreatedRangeDate("createdFrom", filter.createdFrom);
     if (createdFromError) return createdFromError;
   }
 
   if (filter.createdTo !== undefined) {
-    const createdToError = validateNoteFilterDate("createdTo", filter.createdTo);
+    const createdToError = validateCreatedRangeDate("createdTo", filter.createdTo);
     if (createdToError) return createdToError;
   }
 
   if (filter.createdFrom !== undefined && filter.createdTo !== undefined) {
-    const createdFrom = normalizeNoteFilterDate("createdFrom", filter.createdFrom);
-    const createdTo = normalizeNoteFilterDate("createdTo", filter.createdTo);
+    const createdFrom = normalizeCreatedRangeDate("createdFrom", filter.createdFrom);
+    const createdTo = normalizeCreatedRangeDate("createdTo", filter.createdTo);
     if (createdFrom > createdTo) {
       return validationError("createdTo", "createdTo must be on or after createdFrom");
     }

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -270,6 +270,46 @@ describe("task namespace", () => {
       expect(result.value[0].title).toBe("Bug");
     });
 
+    it("filters by created-at date range", async () => {
+      await todu.task.create({
+        title: "February task",
+        projectId,
+        createdAt: "2026-02-20T12:00:00Z",
+      });
+      await todu.task.create({
+        title: "March task",
+        projectId,
+        createdAt: "2026-03-12T08:30:00Z",
+      });
+      await todu.task.create({
+        title: "Late March task",
+        projectId,
+        createdAt: "2026-03-28T18:45:00Z",
+      });
+      await todu.task.create({
+        title: "April task",
+        projectId,
+        createdAt: "2026-04-01T09:00:00Z",
+      });
+
+      const result = await todu.task.list({
+        createdFrom: "2026-03-01",
+        createdTo: "2026-03-31",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((task) => task.title)).toEqual(["Late March task", "March task"]);
+    });
+
+    it("rejects invalid created-at date range filters", async () => {
+      const result = await todu.task.list({ createdFrom: "not-a-date" });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("validation");
+      if (result.error.type !== "validation") return;
+      expect(result.error.field).toBe("createdFrom");
+    });
+
     it("sorts by priority desc then createdAt desc", async () => {
       await todu.task.create({ title: "Low", projectId, priority: "low" });
       await todu.task.create({ title: "High", projectId, priority: "high" });

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -21,6 +21,7 @@ import {
   type TaskWithDetail,
   type UpdateTaskInput,
   validateCreateTaskInput,
+  validateTaskFilter,
   validateUpdateTaskInput,
   validationError,
 } from "@todu/core";
@@ -53,6 +54,33 @@ export function createTaskNamespace(
   catalog: DocHandle<CatalogDocument>,
   repo: Repo,
 ): InternalTaskNamespace {
+  function normalizeRangeBoundary(value: string, bound: "start" | "end"): string {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      const [year, month, day] = value.split("-").map(Number);
+      const time =
+        bound === "start"
+          ? Date.UTC(year, month - 1, day, 0, 0, 0, 0)
+          : Date.UTC(year, month - 1, day, 23, 59, 59, 999);
+      return new Date(time).toISOString();
+    }
+
+    return new Date(value).toISOString();
+  }
+
+  function normalizeTaskFilter(filter?: TaskFilter): TaskFilter | undefined {
+    if (!filter) return undefined;
+
+    const normalized: TaskFilter = { ...filter };
+    if (filter.createdFrom !== undefined) {
+      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start");
+    }
+    if (filter.createdTo !== undefined) {
+      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end");
+    }
+
+    return normalized;
+  }
+
   function migrateTaskListDoc(handle: DocHandle<TaskListDocument>): void {
     const doc = handle.doc();
     if (!doc) return;
@@ -216,14 +244,18 @@ export function createTaskNamespace(
     },
 
     async list(filter?: TaskFilter, sort?: TaskSortOptions): Promise<Result<Task[]>> {
+      const validationErr = filter ? validateTaskFilter(filter) : null;
+      if (validationErr) return err(validationErr);
+
       const catalogDoc = catalog.doc();
       if (!catalogDoc) return ok([]);
 
+      const normalizedFilter = normalizeTaskFilter(filter);
       const allTasks: Task[] = [];
 
       // If filtering by project, only load that project's task list
-      const docIds = filter?.projectId
-        ? [catalogDoc.taskListDocIds[filter.projectId]].filter(Boolean)
+      const docIds = normalizedFilter?.projectId
+        ? [catalogDoc.taskListDocIds[normalizedFilter.projectId]].filter(Boolean)
         : Object.values(catalogDoc.taskListDocIds);
 
       for (const docId of docIds) {
@@ -238,25 +270,36 @@ export function createTaskNamespace(
 
       // Apply filters
       let filtered = allTasks;
-      if (filter?.status) {
-        const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
+      if (normalizedFilter?.status) {
+        const statuses = Array.isArray(normalizedFilter.status)
+          ? normalizedFilter.status
+          : [normalizedFilter.status];
         filtered = filtered.filter((t) => statuses.includes(t.status));
       }
-      if (filter?.priority) {
-        filtered = filtered.filter((t) => t.priority === filter.priority);
+      if (normalizedFilter?.priority) {
+        filtered = filtered.filter((t) => t.priority === normalizedFilter.priority);
       }
-      if (filter?.label) {
-        filtered = filtered.filter((t) => t.labels.includes(filter.label!));
+      if (normalizedFilter?.label) {
+        const label = normalizedFilter.label;
+        filtered = filtered.filter((t) => t.labels.includes(label));
       }
-      if (filter?.dueBefore) {
+      if (normalizedFilter?.createdFrom) {
+        filtered = filtered.filter((t) => t.createdAt >= normalizedFilter.createdFrom!);
+      }
+      if (normalizedFilter?.createdTo) {
+        filtered = filtered.filter((t) => t.createdAt <= normalizedFilter.createdTo!);
+      }
+      if (normalizedFilter?.dueBefore) {
         filtered = filtered.filter(
-          (t) => t.dueDate !== undefined && t.dueDate <= filter.dueBefore!,
+          (t) => t.dueDate !== undefined && t.dueDate <= normalizedFilter.dueBefore!,
         );
       }
-      if (filter?.dueAfter) {
-        filtered = filtered.filter((t) => t.dueDate !== undefined && t.dueDate >= filter.dueAfter!);
+      if (normalizedFilter?.dueAfter) {
+        filtered = filtered.filter(
+          (t) => t.dueDate !== undefined && t.dueDate >= normalizedFilter.dueAfter!,
+        );
       }
-      if (filter?.overdue) {
+      if (normalizedFilter?.overdue) {
         const today = new Date().toISOString().slice(0, 10);
         filtered = filtered.filter(
           (t) =>
@@ -266,7 +309,7 @@ export function createTaskNamespace(
             t.status !== "canceled",
         );
       }
-      if (filter?.today) {
+      if (normalizedFilter?.today) {
         const today = new Date().toISOString().slice(0, 10);
         filtered = filtered.filter(
           (t) => t.dueDate?.startsWith(today) || t.scheduledDate?.startsWith(today),


### PR DESCRIPTION
## Summary
- add `task list --from/--to` CLI filters for task created-at ranges
- validate and normalize task created-at range filters to match note list behavior
- apply created-at filtering in engine task listing and document the new usage

## Testing
- make pre-pr

Task: #task-69879dc7