### PR TITLE
fix: reduce note sync memory pressure

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ daemon(A) <--> relay <--> daemon(B) <--> relay <--> daemon(C)
 Notes are partitioned into multiple Automerge documents instead of one global notes document.
 
 - Catalog keeps `notesBucketDocIds` (bucket key → document ID).
-- Catalog keeps `noteBucketByNoteId` (note ID → bucket key) for direct update/delete lookup.
+- Legacy `noteBucketByNoteId` entries are cleared during migration/startup to avoid unbounded catalog growth; note update/delete now locate notes by scanning bucket documents on demand.
 - Bucket selection:
   - Entity-attached notes use `entity:<type>:<entityId>`.
   - Standalone journal notes use monthly buckets `journal:<YYYY-MM>`.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -45,7 +45,7 @@ export interface CatalogDocument {
   /** Map of notes partition key → Automerge document ID */
   notesBucketDocIds: Record<string, string>;
 
-  /** Map of note ID → notes partition key */
+  /** Legacy map of note ID → notes partition key retained for migration compatibility */
   noteBucketByNoteId: Record<string, string>;
 
   /** Recurring task templates */

--- a/packages/electron/src/renderer/views/JournalList.test.ts
+++ b/packages/electron/src/renderer/views/JournalList.test.ts
@@ -1,6 +1,13 @@
 import type { Note } from "@todu/core/browser";
 import { describe, expect, it } from "vitest";
-import { formatDayHeader, groupByDay } from "./JournalList.js";
+import {
+  formatDayHeader,
+  formatMonthLabel,
+  groupByDay,
+  monthRangeFilter,
+  shiftMonth,
+  startOfMonth,
+} from "./JournalList.js";
 
 function makeNote(overrides: Partial<Note> = {}): Note {
   return {
@@ -63,5 +70,29 @@ describe("formatDayHeader", () => {
     // 2026-02-13 is a Friday
     const result = formatDayHeader("2026-02-13");
     expect(result).toContain("Friday");
+  });
+});
+
+describe("journal month helpers", () => {
+  it("normalizes a date to the start of its UTC month", () => {
+    const result = startOfMonth(new Date("2026-03-15T18:45:00Z"));
+    expect(result.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("shifts months in UTC without drifting the day", () => {
+    const result = shiftMonth(new Date("2026-03-01T00:00:00.000Z"), -1);
+    expect(result.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+  });
+
+  it("builds a month-scoped journal filter", () => {
+    expect(monthRangeFilter(new Date("2026-02-13T10:00:00Z"))).toEqual({
+      journal: true,
+      createdFrom: "2026-02-01",
+      createdTo: "2026-02-28",
+    });
+  });
+
+  it("formats a readable month label", () => {
+    expect(formatMonthLabel(new Date("2026-02-01T00:00:00.000Z"))).toBe("February 2026");
   });
 });

--- a/packages/electron/src/renderer/views/JournalList.tsx
+++ b/packages/electron/src/renderer/views/JournalList.tsx
@@ -1,4 +1,4 @@
-import type { Note } from "@todu/core/browser";
+import type { Note, NoteFilter } from "@todu/core/browser";
 import { type ReactNode, useMemo, useState } from "react";
 import { useNotes } from "../hooks/useTodu.js";
 
@@ -41,40 +41,63 @@ export function formatDayHeader(dateStr: string): string {
   });
 }
 
+export function startOfMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+export function shiftMonth(date: Date, delta: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + delta, 1));
+}
+
+export function formatMonthLabel(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    timeZone: "UTC",
+  });
+}
+
+export function monthRangeFilter(date: Date): NoteFilter {
+  const monthStart = startOfMonth(date);
+  const monthEnd = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0));
+
+  return {
+    journal: true,
+    createdFrom: monthStart.toISOString().slice(0, 10),
+    createdTo: monthEnd.toISOString().slice(0, 10),
+  };
+}
+
 // ============================================================================
 // JournalList
 // ============================================================================
 
 export function JournalList({ onCreateEntry, onViewEntry }: JournalListProps): ReactNode {
+  const currentMonth = useMemo(() => startOfMonth(new Date()), []);
   const [filterTag, setFilterTag] = useState("");
+  const [visibleMonth, setVisibleMonth] = useState<Date>(currentMonth);
 
-  // Always fetch all notes (unfiltered) so we can derive the full tag list
-  const { data: allNotes, isLoading, isError, error } = useNotes({});
+  const filter = useMemo(() => monthRangeFilter(visibleMonth), [visibleMonth]);
+  const { data: journalNotes, isLoading, isError, error } = useNotes(filter);
 
-  // Filter to standalone notes only (no entityType)
-  const allStandaloneNotes = useMemo(
-    () => allNotes?.filter((n) => !n.entityType) ?? [],
-    [allNotes],
-  );
-
-  // Collect all tags from ALL standalone notes (not filtered subset)
   const allTags = useMemo(() => {
     const tags = new Set<string>();
-    for (const note of allStandaloneNotes) {
+    for (const note of journalNotes ?? []) {
       for (const tag of note.tags) tags.add(tag);
     }
     return Array.from(tags).sort();
-  }, [allStandaloneNotes]);
+  }, [journalNotes]);
 
-  // Apply tag filter client-side
-  const standaloneNotes = useMemo(
+  const visibleNotes = useMemo(
     () =>
-      filterTag ? allStandaloneNotes.filter((n) => n.tags.includes(filterTag)) : allStandaloneNotes,
-    [allStandaloneNotes, filterTag],
+      filterTag
+        ? (journalNotes ?? []).filter((n) => n.tags.includes(filterTag))
+        : (journalNotes ?? []),
+    [journalNotes, filterTag],
   );
 
-  // Group by day (already sorted newest first from engine)
-  const dayGroups = useMemo(() => groupByDay(standaloneNotes), [standaloneNotes]);
+  const dayGroups = useMemo(() => groupByDay(visibleNotes), [visibleNotes]);
+  const isCurrentMonth = visibleMonth.getTime() === currentMonth.getTime();
 
   if (isLoading) {
     return (
@@ -112,6 +135,28 @@ export function JournalList({ onCreateEntry, onViewEntry }: JournalListProps): R
 
       <div className="filter-bar">
         <div className="filter-row">
+          <button
+            type="button"
+            className="btn btn-secondary btn-sm"
+            onClick={() => {
+              setVisibleMonth((month) => shiftMonth(month, -1));
+              setFilterTag("");
+            }}
+          >
+            ← Older
+          </button>
+          <span>{formatMonthLabel(visibleMonth)}</span>
+          <button
+            type="button"
+            className="btn btn-secondary btn-sm"
+            onClick={() => {
+              setVisibleMonth((month) => shiftMonth(month, 1));
+              setFilterTag("");
+            }}
+            disabled={isCurrentMonth}
+          >
+            Newer →
+          </button>
           <select
             className="filter-select"
             value={filterTag}
@@ -127,9 +172,9 @@ export function JournalList({ onCreateEntry, onViewEntry }: JournalListProps): R
         </div>
       </div>
 
-      {standaloneNotes.length === 0 ? (
+      {visibleNotes.length === 0 ? (
         <div className="empty-state">
-          <p>No journal entries found</p>
+          <p>No journal entries found for {formatMonthLabel(visibleMonth)}</p>
         </div>
       ) : (
         <div className="journal-entries">

--- a/packages/electron/src/renderer/views/NoteList.tsx
+++ b/packages/electron/src/renderer/views/NoteList.tsx
@@ -14,9 +14,11 @@ export function NoteList({
   const [filterTag, setFilterTag] = useState("");
 
   const filter: NoteFilter = {
-    ...(filterType !== "all" && filterType !== "standalone"
-      ? { entityType: filterType as NoteEntityType }
-      : {}),
+    ...(filterType === "standalone"
+      ? { journal: true }
+      : filterType !== "all"
+        ? { entityType: filterType as NoteEntityType }
+        : {}),
     ...(filterTag ? { tag: filterTag } : {}),
   };
 
@@ -43,8 +45,7 @@ export function NoteList({
     return Array.from(tags).sort();
   }, [notes]);
 
-  // Filter standalone notes client-side (no entityType)
-  const displayNotes = filterType === "standalone" ? notes?.filter((n) => !n.entityType) : notes;
+  const displayNotes = notes;
 
   const handleDelete = () => {
     if (!deleteTarget) return;

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -492,8 +492,7 @@ describe("note namespace", () => {
       expect(Object.keys(catalogDoc.notesBucketDocIds)).toEqual(
         expect.arrayContaining([journalBucket, taskBucket]),
       );
-      expect(catalogDoc.noteBucketByNoteId[journalNote.value.id]).toBe(journalBucket);
-      expect(catalogDoc.noteBucketByNoteId[taskNote.value.id]).toBe(taskBucket);
+      expect(catalogDoc.noteBucketByNoteId).toEqual({});
       expect(journalBucket).toBe("journal:2021-04");
     });
 
@@ -552,7 +551,43 @@ describe("note namespace", () => {
 
       const catalogDoc = await readCatalogDocument(tmpDir);
       expect(catalogDoc.notesDocId).toBeUndefined();
-      expect(catalogDoc.noteBucketByNoteId[legacyNote.id]).toBe("journal:2026-02");
+      expect(catalogDoc.noteBucketByNoteId).toEqual({});
+    });
+
+    it("clears legacy note bucket indexes and still updates notes", async () => {
+      const created = await todu.note.create({
+        content: "Indexed note",
+        createdAt: "2026-02-24T12:00:00.000Z",
+      });
+      if (!created.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const repo = new Repo({
+        storage: new NodeFSStorageAdapter(tmpDir),
+      });
+      const catalogDocId = fs.readFileSync(path.join(tmpDir, "todu-catalog.id"), "utf-8").trim();
+      const catalogHandle = await repo.find<CatalogDocument>(catalogDocId as DocumentId);
+      catalogHandle.change((doc) => {
+        doc.noteBucketByNoteId = { [created.value.id]: "journal:2026-02" };
+      });
+      await repo.flush();
+      await repo.shutdown();
+      await new Promise((r) => setTimeout(r, 50));
+
+      todu = await createTodu({ storagePath: tmpDir });
+      const updated = await todu.note.update(created.value.id, { content: "Updated note" });
+      expect(updated.ok).toBe(true);
+      if (!updated.ok) return;
+      expect(updated.value.content).toBe("Updated note");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const catalogDoc = await readCatalogDocument(tmpDir);
+      expect(catalogDoc.noteBucketByNoteId).toEqual({});
     });
   });
 });

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -183,10 +183,6 @@ export function createNoteNamespace(
         doc.noteBucketByNoteId = {};
       }
 
-      for (const note of notesToMigrate) {
-        doc.noteBucketByNoteId[note.id] = noteBucketKeyForNote(note);
-      }
-
       delete doc.notesDocId;
     });
 
@@ -198,6 +194,20 @@ export function createNoteNamespace(
     emitDiagnostic("legacy-migration", {
       migratedNoteCount: notesToMigrate.length,
       targetBucketCount: byBucket.size,
+    });
+  }
+
+  function clearLegacyNoteBucketIndex(): void {
+    const catalogDoc = catalog.doc();
+    const legacyEntryCount = Object.keys(catalogDoc?.noteBucketByNoteId ?? {}).length;
+    if (legacyEntryCount === 0) return;
+
+    catalog.change((doc) => {
+      doc.noteBucketByNoteId = {};
+    });
+
+    emitDiagnostic("legacy-note-index-cleared", {
+      legacyEntryCount,
     });
   }
 
@@ -222,29 +232,12 @@ export function createNoteNamespace(
     }
 
     await migrateLegacyGlobalNotesDoc();
+    clearLegacyNoteBucketIndex();
   }
 
   async function findNoteLocation(id: NoteId): Promise<NoteLocation | null> {
     const catalogDoc = catalog.doc();
     if (!catalogDoc) return null;
-
-    const indexedBucketKey = catalogDoc.noteBucketByNoteId?.[id];
-    if (indexedBucketKey) {
-      const handle = await getBucketHandle(indexedBucketKey);
-      const notesDoc = handle?.doc();
-      if (handle && notesDoc) {
-        const index = notesDoc.notes.findIndex((n) => n.id === id);
-        if (index !== -1) {
-          return { bucketKey: indexedBucketKey, handle, index };
-        }
-      }
-
-      // Repair stale index entry.
-      catalog.change((doc) => {
-        if (!doc.noteBucketByNoteId) return;
-        delete doc.noteBucketByNoteId[id];
-      });
-    }
 
     for (const [bucketKey, docId] of Object.entries(catalogDoc.notesBucketDocIds ?? {})) {
       const handle = await repo.find<NotesDocument>(docId as DocumentId);
@@ -253,13 +246,6 @@ export function createNoteNamespace(
 
       const index = notesDoc.notes.findIndex((n) => n.id === id);
       if (index === -1) continue;
-
-      catalog.change((doc) => {
-        if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
-          doc.noteBucketByNoteId = {};
-        }
-        doc.noteBucketByNoteId[id] = bucketKey;
-      });
 
       return { bucketKey, handle, index };
     }
@@ -358,13 +344,6 @@ export function createNoteNamespace(
       const bucketKey = noteBucketKeyForNote(note);
       const notesHandle = await getOrCreateBucketHandle(bucketKey);
       appendNotesWithoutDuplicates(notesHandle, [note]);
-
-      catalog.change((doc) => {
-        if (doc.noteBucketByNoteId === undefined || doc.noteBucketByNoteId === null) {
-          doc.noteBucketByNoteId = {};
-        }
-        doc.noteBucketByNoteId[id] = bucketKey;
-      });
 
       emitDiagnostic("create", {
         noteId: id,
@@ -478,10 +457,6 @@ export function createNoteNamespace(
       const bucketIsEmpty = (location.handle.doc()?.notes.length ?? 0) === 0;
 
       catalog.change((doc) => {
-        if (doc.noteBucketByNoteId !== undefined && doc.noteBucketByNoteId !== null) {
-          delete doc.noteBucketByNoteId[id];
-        }
-
         if (
           bucketIsEmpty &&
           doc.notesBucketDocIds !== undefined &&


### PR DESCRIPTION
## Summary

Reduce note-heavy sync pressure by removing the unbounded catalog note index from active use and by scoping Electron journal reads to one month at a time instead of eagerly loading every note.

## Task

- task-7f4b4312
- evcraddock/todu#363

## Changes

- stop maintaining `noteBucketByNoteId` during normal note operations
- clear legacy `noteBucketByNoteId` entries on startup while preserving note update/delete by scanning note buckets on demand
- scope the Electron journal view to month-sized `journal: true` queries with older/newer month navigation
- switch the standalone note list filter to use the server-side journal filter instead of client-side filtering
- add regression coverage for legacy note index cleanup and journal month filtering helpers
- update architecture docs to describe the legacy note index cleanup behavior

## Root cause

The main memory risk was a combination of two note-heavy paths:

1. `noteBucketByNoteId` lived in the root catalog and grew with total note count, which is a poor fit for an append-only Automerge document that every client/sync peer needs to materialize.
2. The Electron journal screen was calling `useNotes({})` and filtering journal entries client-side, which eagerly loaded unrelated task/project note payloads and their full bodies during normal UI usage.

This change removes the catalog-wide index from active use and narrows the default journal read path to a single month.

## Scope note

This task is scoped to the code-side fix and root-cause writeup. Production-style homelab validation and reverting the temporary `2Gi` mitigation are out of scope for this PR.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- `npx vitest run --config vitest.all.config.ts packages/engine/src/notes.integration.test.ts`
- `npm run test -- packages/electron/src/renderer/views/JournalList.test.ts`
- `TODU_RUN_SYNC_SERVER_TESTS=1 npx vitest run --config vitest.all.config.ts packages/engine/src/sync.integration.test.ts`
- `make pre-pr`

## Checklist

- [x] `make pre-pr` passes
- [x] Documentation updated (if needed)
- [x] No unrelated changes included
