### PR TITLE
fix: skip today in current streak when not yet checked in

### DIFF
--- a/packages/engine/src/habits.integration.test.ts
+++ b/packages/engine/src/habits.integration.test.ts
@@ -3,8 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import type { HabitId, ProjectId } from "@todu/core";
 import { createProjectId } from "@todu/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTodu } from "./index.js";
+import * as schedule from "./schedule.js";
 import { clearProcessors } from "./scheduling.js";
 import type { Todu } from "./todu.js";
 
@@ -464,6 +465,40 @@ describe("habits", () => {
       expect(streak.value.current).toBe(1);
       expect(streak.value.completedToday).toBe(true);
       expect(streak.value.totalCheckins).toBe(1);
+    });
+
+    it("preserves streak when today is scheduled but not yet checked in", async () => {
+      const create = await todu.habit.create({
+        projectId,
+        title: "Daily",
+        schedule: "FREQ=DAILY",
+        timezone: "UTC",
+        startDate: "2020-01-01",
+      });
+      expect(create.ok).toBe(true);
+      if (!create.ok) return;
+
+      // Check in "today"
+      await todu.habit.check(create.value.id);
+
+      // Now pretend tomorrow is "today" so the real today becomes a past checked day
+      // and tomorrow is the new unchecked scheduled day
+      const tomorrow = new Date();
+      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+      const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+      const spy = vi.spyOn(schedule, "todayInTimezone").mockReturnValue(tomorrowStr);
+
+      try {
+        const streak = await todu.habit.streak(create.value.id);
+        expect(streak.ok).toBe(true);
+        if (!streak.ok) return;
+
+        // Current streak should be 1 (yesterday's real check-in), not 0
+        expect(streak.value.current).toBe(1);
+        expect(streak.value.completedToday).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 

--- a/packages/engine/src/habits.ts
+++ b/packages/engine/src/habits.ts
@@ -344,6 +344,8 @@ export function createHabitNamespace(
         if (isScheduled) {
           if (entries[checkDate]?.completed) {
             current++;
+          } else if (checkDate === today) {
+            // Today is not over yet — skip without breaking the streak
           } else {
             break;
           }


### PR DESCRIPTION
## Summary

Fixes the habit streak calculation that resets `current` to 0 when today's check-in is not yet completed, even though the day is not over.

## Changes

- **packages/engine/src/habits.ts**: When counting backwards through scheduled dates for the current streak, skip today if it's not yet completed instead of breaking the streak.
- **packages/engine/src/habits.integration.test.ts**: Added test that mocks `todayInTimezone` to simulate querying streak on a day where yesterday was checked but today is not yet — verifies `current` reflects the past streak.

## Acceptance criteria

- [x] `current` streak does not reset to 0 for an unchecked today when the day is still in progress
- [x] `current` streak only breaks when a past scheduled day was missed
- [x] existing streak tests updated to cover the "today not yet checked" case

Task: #task-55ea7fea