### PR TITLE
fix: add timezone support to date range filters

### DIFF
--- a/packages/core/src/schedule.test.ts
+++ b/packages/core/src/schedule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  dateToTimezoneISO,
   generateScheduledTaskId,
   validateDateString,
   validateRRule,
@@ -237,5 +238,41 @@ describe("validateScheduleDefinition", () => {
     });
     expect(result).not.toBeNull();
     expect(result!.field).toBe("endDate");
+  });
+});
+
+describe("dateToTimezoneISO", () => {
+  it("converts start of day in UTC", () => {
+    const result = dateToTimezoneISO("2026-03-29", "start", "UTC");
+    expect(result).toBe("2026-03-29T00:00:00.000Z");
+  });
+
+  it("converts end of day in UTC", () => {
+    const result = dateToTimezoneISO("2026-03-29", "end", "UTC");
+    expect(result).toBe("2026-03-29T23:59:59.999Z");
+  });
+
+  it("converts start of day in America/Chicago (CST, UTC-6)", () => {
+    // March 29 2026 is in CDT (UTC-5), midnight CDT = 05:00 UTC
+    const result = dateToTimezoneISO("2026-03-29", "start", "America/Chicago");
+    expect(result).toBe("2026-03-29T05:00:00.000Z");
+  });
+
+  it("converts end of day in America/Chicago (CDT, UTC-5)", () => {
+    // 23:59:59.999 CDT = 04:59:59.999 UTC next day
+    const result = dateToTimezoneISO("2026-03-29", "end", "America/Chicago");
+    expect(result).toBe("2026-03-30T04:59:59.999Z");
+  });
+
+  it("converts start of day in Asia/Tokyo (UTC+9)", () => {
+    // Midnight JST = 15:00 UTC previous day
+    const result = dateToTimezoneISO("2026-03-29", "start", "Asia/Tokyo");
+    expect(result).toBe("2026-03-28T15:00:00.000Z");
+  });
+
+  it("converts end of day in Asia/Tokyo (UTC+9)", () => {
+    // 23:59:59.999 JST = 14:59:59.999 UTC same day
+    const result = dateToTimezoneISO("2026-03-29", "end", "Asia/Tokyo");
+    expect(result).toBe("2026-03-29T14:59:59.999Z");
   });
 });

--- a/packages/core/src/schedule.ts
+++ b/packages/core/src/schedule.ts
@@ -147,3 +147,44 @@ export function validateScheduleDefinition(schedule: {
 
   return null;
 }
+
+/**
+ * Convert a YYYY-MM-DD date string to a UTC ISO timestamp at the start or end
+ * of that day in the given IANA timezone.
+ */
+export function dateToTimezoneISO(date: string, bound: "start" | "end", timezone: string): string {
+  const [year, month, day] = date.split("-").map(Number);
+
+  // Build a reference UTC date near the target, then compute the timezone offset.
+  const refUtc = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+
+  // Use Intl to find the UTC offset for this timezone at the reference time.
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(refUtc);
+  const get = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((p) => p.type === type)!.value);
+
+  const localAtRef = new Date(
+    Date.UTC(get("year"), get("month") - 1, get("day"), get("hour"), get("minute"), get("second")),
+  );
+  const offsetMs = localAtRef.getTime() - refUtc.getTime();
+
+  // Target local time: start or end of the requested day.
+  const localTarget =
+    bound === "start"
+      ? Date.UTC(year, month - 1, day, 0, 0, 0, 0)
+      : Date.UTC(year, month - 1, day, 23, 59, 59, 999);
+
+  // Subtract offset to get UTC equivalent.
+  return new Date(localTarget - offsetMs).toISOString();
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -328,6 +328,7 @@ export interface TaskFilter {
   dueAfter?: string;
   overdue?: boolean;
   today?: boolean;
+  timezone?: string;
 }
 
 export const TASK_SORT_FIELDS = ["priority", "dueDate", "createdAt", "updatedAt", "title"] as const;
@@ -374,6 +375,7 @@ export interface NoteFilter {
   createdFrom?: string;
   createdTo?: string;
   journal?: boolean;
+  timezone?: string;
 }
 
 // ============================================================================

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -995,6 +995,15 @@ describe("validateTaskFilter", () => {
     expect(error?.field).toBe("createdTo");
     expect(error?.message).toContain("on or after");
   });
+
+  it("accepts valid timezone", () => {
+    expect(validateTaskFilter({ timezone: "America/Chicago" })).toBeNull();
+  });
+
+  it("rejects invalid timezone", () => {
+    const error = validateTaskFilter({ timezone: "Fake/Zone" });
+    expect(error?.field).toBe("timezone");
+  });
 });
 
 describe("validateNoteFilter", () => {
@@ -1030,5 +1039,14 @@ describe("validateNoteFilter", () => {
   it("rejects journal combined with entity filters", () => {
     const error = validateNoteFilter({ journal: true, entityType: "task", entityId: "task-123" });
     expect(error?.field).toBe("journal");
+  });
+
+  it("accepts valid timezone", () => {
+    expect(validateNoteFilter({ timezone: "America/Chicago" })).toBeNull();
+  });
+
+  it("rejects invalid timezone", () => {
+    const error = validateNoteFilter({ timezone: "Fake/Zone" });
+    expect(error?.field).toBe("timezone");
   });
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -645,6 +645,11 @@ export function validateTaskFilter(filter: TaskFilter): ValidationError | null {
     }
   }
 
+  if (filter.timezone !== undefined) {
+    const tzError = validateTimezone(filter.timezone);
+    if (tzError) return tzError;
+  }
+
   return null;
 }
 
@@ -673,6 +678,11 @@ export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
     if (createdFrom > createdTo) {
       return validationError("createdTo", "createdTo must be on or after createdFrom");
     }
+  }
+
+  if (filter.timezone !== undefined) {
+    const tzError = validateTimezone(filter.timezone);
+    if (tzError) return tzError;
   }
 
   return null;

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -5,6 +5,7 @@ import {
   type CreateNoteInput,
   createNoteId,
   createNotesDocument,
+  dateToTimezoneISO,
   err,
   type Note,
   type NoteFilter,
@@ -63,8 +64,15 @@ export function createNoteNamespace(
     return null;
   }
 
-  function normalizeRangeBoundary(value: string, bound: "start" | "end"): string {
+  function normalizeRangeBoundary(
+    value: string,
+    bound: "start" | "end",
+    timezone?: string,
+  ): string {
     if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      if (timezone) {
+        return dateToTimezoneISO(value, bound, timezone);
+      }
       const [year, month, day] = value.split("-").map(Number);
       const time =
         bound === "start"
@@ -81,10 +89,10 @@ export function createNoteNamespace(
 
     const normalized: NoteFilter = { ...filter };
     if (filter.createdFrom !== undefined) {
-      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start");
+      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start", filter.timezone);
     }
     if (filter.createdTo !== undefined) {
-      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end");
+      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end", filter.timezone);
     }
 
     return normalized;

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -6,6 +6,7 @@ import {
   createTaskDetailDocument,
   createTaskId,
   createTaskListDocument,
+  dateToTimezoneISO,
   err,
   notFound,
   ok,
@@ -54,8 +55,15 @@ export function createTaskNamespace(
   catalog: DocHandle<CatalogDocument>,
   repo: Repo,
 ): InternalTaskNamespace {
-  function normalizeRangeBoundary(value: string, bound: "start" | "end"): string {
+  function normalizeRangeBoundary(
+    value: string,
+    bound: "start" | "end",
+    timezone?: string,
+  ): string {
     if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      if (timezone) {
+        return dateToTimezoneISO(value, bound, timezone);
+      }
       const [year, month, day] = value.split("-").map(Number);
       const time =
         bound === "start"
@@ -72,10 +80,10 @@ export function createTaskNamespace(
 
     const normalized: TaskFilter = { ...filter };
     if (filter.createdFrom !== undefined) {
-      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start");
+      normalized.createdFrom = normalizeRangeBoundary(filter.createdFrom, "start", filter.timezone);
     }
     if (filter.createdTo !== undefined) {
-      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end");
+      normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end", filter.timezone);
     }
 
     return normalized;


### PR DESCRIPTION
## Summary

Add optional `timezone` field to `NoteFilter` and `TaskFilter` so date boundaries are calculated relative to the caller's timezone instead of always UTC.

## Changes

- **`@todu/core`**: Add `timezone?: string` to `NoteFilter` and `TaskFilter` types
- **`@todu/core`**: Add `dateToTimezoneISO` utility for timezone-aware date boundary conversion
- **`@todu/core`**: Add timezone validation to `validateTaskFilter` and `validateNoteFilter`
- **`@todu/engine`**: Update `normalizeRangeBoundary` in notes and tasks to use timezone when provided
- Omitting timezone preserves existing UTC behavior (backwards compatible)

## Note on RecurringFilter/HabitFilter

These filter types have no date range fields, so no timezone field is needed.

Task: #task-a49c1234