### PR TITLE
feat: replace completedAt with updatedFrom/updatedTo task filters

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -309,17 +309,17 @@ todu --format json task list --from 2026-03-01 --to 2026-03-31
 todu --format json task list --project proj-123 --from 2026-03-01T00:00:00Z --to 2026-03-31T23:59:59Z
 ```
 
-Filter tasks by completion date range (for monthly review and reporting):
+Filter tasks by updated-at date range (for monthly review and reporting):
 
 ```bash
-todu --format json task list --status done --completed-from 2026-03-01 --completed-to 2026-03-31
+todu --format json task list --status done --updated-from 2026-03-01 --updated-to 2026-03-31
 ```
 
 Task date-range behavior notes:
 - `task list --from/--to` uses created-at timestamps, not due dates.
-- `task list --completed-from/--completed-to` uses the date the task was marked done.
+- `task list --updated-from/--updated-to` uses the `updatedAt` timestamp.
 - Both accept either `YYYY-MM-DD` or ISO-8601 date/datetime strings.
-- For monthly review, use `--completed-from`/`--completed-to` to find tasks finished during the target month regardless of when they were created.
+- For monthly review, use `--status done --updated-from/--updated-to` to find tasks completed during the target month.
 - Invalid task date input fails with a validation error.
 
 ## Validate connectivity

--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -51,7 +51,7 @@ describe("task commands", () => {
     expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);
   });
 
-  it("passes completion-date range filtering through on task list", async () => {
+  it("passes updated-at date range filtering through on task list", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "task.list") {
         return {
@@ -77,9 +77,9 @@ describe("task commands", () => {
         "list",
         "--status",
         "done",
-        "--completed-from",
+        "--updated-from",
         "2026-03-01",
-        "--completed-to",
+        "--updated-to",
         "2026-03-31",
       ],
       {
@@ -89,8 +89,8 @@ describe("task commands", () => {
 
     expect(invokeDaemonMock).toHaveBeenCalledWith("task.list", {
       filter: expect.objectContaining({
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
         status: "done",
       }),
       sort: undefined,

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -154,8 +154,8 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--label <label>", "filter by label")
     .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
     .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
-    .option("--completed-from <date>", "filter by completion date start (YYYY-MM-DD or ISO-8601)")
-    .option("--completed-to <date>", "filter by completion date end (YYYY-MM-DD or ISO-8601)")
+    .option("--updated-from <date>", "filter by updated-at start (YYYY-MM-DD or ISO-8601)")
+    .option("--updated-to <date>", "filter by updated-at end (YYYY-MM-DD or ISO-8601)")
     .option("--overdue", "show overdue tasks only")
     .option("--today", "show tasks due or scheduled today")
     .option("--sort <field>", "sort by field (priority, dueDate, createdAt, updatedAt, title)")
@@ -211,8 +211,8 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           label: opts.label,
           createdFrom: opts.from,
           createdTo: opts.to,
-          completedFrom: opts.completedFrom,
-          completedTo: opts.completedTo,
+          updatedFrom: opts.updatedFrom,
+          updatedTo: opts.updatedTo,
           overdue: opts.overdue,
           today: opts.today,
         },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -190,7 +190,6 @@ export interface Task {
   externalId?: string;
   sourceUrl?: string;
   templateId?: string;
-  completedAt?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -327,8 +326,8 @@ export interface TaskFilter {
   createdTo?: string;
   dueBefore?: string;
   dueAfter?: string;
-  completedFrom?: string;
-  completedTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
   overdue?: boolean;
   today?: boolean;
   timezone?: string;

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -1005,20 +1005,18 @@ describe("validateTaskFilter", () => {
     expect(error?.field).toBe("timezone");
   });
 
-  it("accepts completedFrom/completedTo bounds", () => {
-    expect(
-      validateTaskFilter({ completedFrom: "2026-03-01", completedTo: "2026-03-31" }),
-    ).toBeNull();
+  it("accepts updatedFrom/updatedTo bounds", () => {
+    expect(validateTaskFilter({ updatedFrom: "2026-03-01", updatedTo: "2026-03-31" })).toBeNull();
   });
 
-  it("rejects invalid completedFrom", () => {
-    const error = validateTaskFilter({ completedFrom: "not-a-date" });
-    expect(error?.field).toBe("completedFrom");
+  it("rejects invalid updatedFrom", () => {
+    const error = validateTaskFilter({ updatedFrom: "not-a-date" });
+    expect(error?.field).toBe("updatedFrom");
   });
 
-  it("rejects inverted completed date ranges", () => {
-    const error = validateTaskFilter({ completedFrom: "2026-04-01", completedTo: "2026-03-31" });
-    expect(error?.field).toBe("completedTo");
+  it("rejects inverted updated date ranges", () => {
+    const error = validateTaskFilter({ updatedFrom: "2026-04-01", updatedTo: "2026-03-31" });
+    expect(error?.field).toBe("updatedTo");
     expect(error?.message).toContain("on or after");
   });
 });

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -641,21 +641,21 @@ export function validateTaskFilter(filter: TaskFilter): ValidationError | null {
     }
   }
 
-  if (filter.completedFrom !== undefined) {
-    const completedFromError = validateCreatedRangeDate("completedFrom", filter.completedFrom);
-    if (completedFromError) return completedFromError;
+  if (filter.updatedFrom !== undefined) {
+    const updatedFromError = validateCreatedRangeDate("updatedFrom", filter.updatedFrom);
+    if (updatedFromError) return updatedFromError;
   }
 
-  if (filter.completedTo !== undefined) {
-    const completedToError = validateCreatedRangeDate("completedTo", filter.completedTo);
-    if (completedToError) return completedToError;
+  if (filter.updatedTo !== undefined) {
+    const updatedToError = validateCreatedRangeDate("updatedTo", filter.updatedTo);
+    if (updatedToError) return updatedToError;
   }
 
-  if (filter.completedFrom !== undefined && filter.completedTo !== undefined) {
-    const completedFrom = normalizeCreatedRangeDate("completedFrom", filter.completedFrom);
-    const completedTo = normalizeCreatedRangeDate("completedTo", filter.completedTo);
-    if (completedFrom > completedTo) {
-      return validationError("completedTo", "completedTo must be on or after completedFrom");
+  if (filter.updatedFrom !== undefined && filter.updatedTo !== undefined) {
+    const updatedFrom = normalizeCreatedRangeDate("updatedFrom", filter.updatedFrom);
+    const updatedTo = normalizeCreatedRangeDate("updatedTo", filter.updatedTo);
+    if (updatedFrom > updatedTo) {
+      return validationError("updatedTo", "updatedTo must be on or after updatedFrom");
     }
   }
 

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -108,16 +108,16 @@ const ListTasksParams = Type.Object({
     Type.String({ description: "Filter tasks due before date (YYYY-MM-DD)" }),
   ),
   dueAfter: Type.Optional(Type.String({ description: "Filter tasks due after date (YYYY-MM-DD)" })),
-  completedFrom: Type.Optional(
+  updatedFrom: Type.Optional(
     Type.String({
       description:
-        "Filter by completion date start (YYYY-MM-DD or ISO-8601). Use for monthly review.",
+        "Filter by updated-at start (YYYY-MM-DD or ISO-8601). Use with status=done for monthly review.",
     }),
   ),
-  completedTo: Type.Optional(
+  updatedTo: Type.Optional(
     Type.String({
       description:
-        "Filter by completion date end (YYYY-MM-DD or ISO-8601). Use for monthly review.",
+        "Filter by updated-at end (YYYY-MM-DD or ISO-8601). Use with status=done for monthly review.",
     }),
   ),
   overdue: Type.Optional(Type.Boolean({ description: "Filter overdue tasks" })),
@@ -318,7 +318,7 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     {
       name: "list_tasks",
       description:
-        "List tasks with optional filtering by status, priority, project, label, due date, or completion date. Use completedFrom/completedTo for monthly review. Supports sorting.",
+        "List tasks with optional filtering by status, priority, project, label, due date, or updated-at range. Use updatedFrom/updatedTo with status=done for monthly review. Supports sorting.",
       label: "List Tasks",
       parameters: ListTasksParams,
       execute: async (_toolCallId, params) => {

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -400,10 +400,10 @@ describe("task namespace", () => {
       expect(result.value[2].title).toBe("No due");
     });
 
-    it("filters by completedFrom/completedTo", async () => {
-      // Create task in January, complete in March
+    it("filters by updatedFrom/updatedTo", async () => {
+      // Create task in January, mark done in March
       const janTask = await todu.task.create({
-        title: "Jan created, Mar completed",
+        title: "Jan created, Mar done",
         projectId,
         createdAt: "2026-01-15T12:00:00.000Z",
       });
@@ -413,9 +413,9 @@ describe("task namespace", () => {
         updatedAt: "2026-03-15T12:00:00.000Z",
       });
 
-      // Create task in March, complete in April
+      // Create task in March, mark done in April
       const marTask = await todu.task.create({
-        title: "Mar created, Apr completed",
+        title: "Mar created, Apr done",
         projectId,
         createdAt: "2026-03-10T12:00:00.000Z",
       });
@@ -425,52 +425,42 @@ describe("task namespace", () => {
         updatedAt: "2026-04-05T12:00:00.000Z",
       });
 
-      // Query for tasks completed in March
+      // Query for done tasks updated in March
       const result = await todu.task.list({
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+        status: "done",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
       });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value).toHaveLength(1);
-      expect(result.value[0].title).toBe("Jan created, Mar completed");
+      expect(result.value[0].title).toBe("Jan created, Mar done");
     });
 
-    it("sets completedAt when task is created with done status", async () => {
-      const result = await todu.task.create({
-        title: "Born done",
+    it("excludes done tasks updated outside the window", async () => {
+      const task = await todu.task.create({
+        title: "Apr done",
         projectId,
+        createdAt: "2026-03-01T12:00:00.000Z",
+      });
+      if (!task.ok) throw new Error("create failed");
+      await todu.task.update(task.value.id, {
         status: "done",
+        updatedAt: "2026-04-05T12:00:00.000Z",
+      });
+
+      const result = await todu.task.list({
+        status: "done",
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
       });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.completedAt).toBeDefined();
+      expect(result.value).toHaveLength(0);
     });
 
-    it("sets completedAt on status transition to done", async () => {
-      const created = await todu.task.create({ title: "Pending", projectId });
-      if (!created.ok) throw new Error("create failed");
-      expect(created.value.completedAt).toBeUndefined();
-
-      const updated = await todu.task.update(created.value.id, { status: "done" });
-      expect(updated.ok).toBe(true);
-      if (!updated.ok) return;
-      expect(updated.value.completedAt).toBeDefined();
-    });
-
-    it("clears completedAt when moving away from done", async () => {
-      const created = await todu.task.create({ title: "Will reopen", projectId });
-      if (!created.ok) throw new Error("create failed");
-      await todu.task.update(created.value.id, { status: "done" });
-
-      const reopened = await todu.task.update(created.value.id, { status: "active" });
-      expect(reopened.ok).toBe(true);
-      if (!reopened.ok) return;
-      expect(reopened.value.completedAt).toBeUndefined();
-    });
-
-    it("existing creation-date filters still work alongside completion filters", async () => {
-      // Create in January, complete in March
+    it("existing creation-date filters still work alongside updatedAt filters", async () => {
+      // Create in January, mark done in March
       const task = await todu.task.create({
         title: "Cross-range",
         projectId,
@@ -491,14 +481,14 @@ describe("task namespace", () => {
       if (!byCreated.ok) return;
       expect(byCreated.value).toHaveLength(1);
 
-      // completedFrom in March should find it
-      const byCompleted = await todu.task.list({
-        completedFrom: "2026-03-01",
-        completedTo: "2026-03-31",
+      // updatedFrom in March should find it
+      const byUpdated = await todu.task.list({
+        updatedFrom: "2026-03-01",
+        updatedTo: "2026-03-31",
       });
-      expect(byCompleted.ok).toBe(true);
-      if (!byCompleted.ok) return;
-      expect(byCompleted.value).toHaveLength(1);
+      expect(byUpdated.ok).toBe(true);
+      if (!byUpdated.ok) return;
+      expect(byUpdated.value).toHaveLength(1);
     });
   });
 

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -85,15 +85,11 @@ export function createTaskNamespace(
     if (filter.createdTo !== undefined) {
       normalized.createdTo = normalizeRangeBoundary(filter.createdTo, "end", filter.timezone);
     }
-    if (filter.completedFrom !== undefined) {
-      normalized.completedFrom = normalizeRangeBoundary(
-        filter.completedFrom,
-        "start",
-        filter.timezone,
-      );
+    if (filter.updatedFrom !== undefined) {
+      normalized.updatedFrom = normalizeRangeBoundary(filter.updatedFrom, "start", filter.timezone);
     }
-    if (filter.completedTo !== undefined) {
-      normalized.completedTo = normalizeRangeBoundary(filter.completedTo, "end", filter.timezone);
+    if (filter.updatedTo !== undefined) {
+      normalized.updatedTo = normalizeRangeBoundary(filter.updatedTo, "end", filter.timezone);
     }
 
     return normalized;
@@ -236,7 +232,6 @@ export function createTaskNamespace(
       if (input.externalId !== undefined) task.externalId = input.externalId.trim();
       if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
       if (templateId !== undefined) task.templateId = templateId;
-      if (task.status === "done") task.completedAt = updatedAt;
 
       // Add to task list document
       const listHandle = await getOrCreateTaskListDoc(input.projectId);
@@ -308,15 +303,11 @@ export function createTaskNamespace(
       if (normalizedFilter?.createdTo) {
         filtered = filtered.filter((t) => t.createdAt <= normalizedFilter.createdTo!);
       }
-      if (normalizedFilter?.completedFrom) {
-        filtered = filtered.filter(
-          (t) => t.completedAt !== undefined && t.completedAt >= normalizedFilter.completedFrom!,
-        );
+      if (normalizedFilter?.updatedFrom) {
+        filtered = filtered.filter((t) => t.updatedAt >= normalizedFilter.updatedFrom!);
       }
-      if (normalizedFilter?.completedTo) {
-        filtered = filtered.filter(
-          (t) => t.completedAt !== undefined && t.completedAt <= normalizedFilter.completedTo!,
-        );
+      if (normalizedFilter?.updatedTo) {
+        filtered = filtered.filter((t) => t.updatedAt <= normalizedFilter.updatedTo!);
       }
       if (normalizedFilter?.dueBefore) {
         filtered = filtered.filter(
@@ -422,14 +413,7 @@ export function createTaskNamespace(
         if (input.scheduledDate !== undefined) task.scheduledDate = input.scheduledDate;
         if (input.externalId !== undefined) task.externalId = input.externalId.trim();
         if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
-        if (input.status !== undefined) {
-          if (input.status === "done") {
-            task.completedAt = updatedAt;
-          } else if (result.task.status === "done") {
-            // Moving away from done — clear completedAt
-            delete (task as unknown as Record<string, unknown>).completedAt;
-          }
-        }
+
         task.updatedAt = updatedAt;
       });
 
@@ -594,7 +578,6 @@ function cloneTask(t: Task): Task {
     externalId: t.externalId,
     sourceUrl: t.sourceUrl,
     templateId: t.templateId,
-    completedAt: t.completedAt,
     createdAt: t.createdAt,
     updatedAt: t.updatedAt,
   };


### PR DESCRIPTION
## Summary

Replace the `completedAt` field and completion-date filtering with `updatedFrom`/`updatedTo` filters on the existing `updatedAt` timestamp. This provides reliable date-range filtering for all tasks, including historical data that predates the `completedAt` field.

## Changes

- **`@todu/core`**: Remove `completedAt` from `Task`, replace `completedFrom`/`completedTo` with `updatedFrom`/`updatedTo` on `TaskFilter`
- **`@todu/core`**: Update validation for new filter fields
- **`@todu/engine`**: Remove `completedAt` lifecycle logic, filter on `updatedAt` instead
- **`@todu/cli`**: Replace `--completed-from`/`--completed-to` with `--updated-from`/`--updated-to`
- **`@todu/electron`**: Update tool schema and description
- **Docs**: Updated monthly review guidance to use `--status done --updated-from/--updated-to`
- **Tests**: Replaced completion-date tests with updatedAt range tests

## Monthly review workflow

```bash
todu --format json task list --status done --updated-from 2026-03-01 --updated-to 2026-03-31
```

Task: #task-45e2da11