### PR TITLE
fix: pin Bun in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   NODE_VERSION: "24"
-  BUN_VERSION: "latest"
+  BUN_VERSION: "1.3.11"
 
 jobs:
   # ===========================================================================


### PR DESCRIPTION
## Summary
- pin the release workflow to Bun 1.3.11 instead of `latest`
- stop macOS release packaging from drifting with Bun upgrades
- preserve the last known-good toolchain for the embedded standalone CLI binary used in Electron packaging

## Why
The `v0.16.1` release failed only in the macOS build. The fatal error was the macOS codesign step rejecting the bundled `cli/todu` binary with:

```text
invalid or unsupported format for signature
```

The previous successful release used Bun 1.3.11, while the failed release picked up Bun 1.3.12 through `BUN_VERSION: latest`.

## Testing
- pre-commit checks
- push hook test run
