### PR TITLE
fix: pass Bun version to setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: npm ci
@@ -149,6 +151,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: npm ci
@@ -197,6 +201,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- pass the pinned Bun version into `oven-sh/setup-bun`
- make the release workflow actually use the configured Bun version in all build jobs
- prevent silent Bun version drift in release builds

## Why
The first fix only changed `BUN_VERSION`, but `setup-bun` was still installing Bun 1.3.12 because the action only honors the explicit `bun-version` input.

## Testing
- pre-commit checks
- push hook test run
