### PR TITLE
feat: add actor model scaffolding

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,6 +80,8 @@ daemon(A) <--> relay <--> daemon(B) <--> relay <--> daemon(C)
 
 - Dataset is rooted by a catalog document ID.
 - All clients/daemons for the same dataset should converge on the same catalog ID and referenced sub-document graph.
+- The catalog stores small shared metadata including projects, labels, actors, owner identity, habits, recurring templates, and references to heavier sub-documents.
+- Projects carry authorized-assignee actor ids, tasks carry actor assignment metadata, and notes carry actor authorship metadata as the assignment model evolves.
 
 ### Notes storage partitioning
 

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -6,6 +6,7 @@ import {
   createNotesDocument,
   createTaskDetailDocument,
   createTaskListDocument,
+  DEFAULT_OWNER_ACTOR_ID,
   SCHEMA_VERSION,
 } from "./schema.js";
 import { createIntegrationBindingId, createProjectId } from "./types.js";
@@ -29,6 +30,12 @@ describe("schema", () => {
     it("creates a catalog with empty labels", () => {
       const catalog = createEmptyCatalog();
       expect(catalog.labels).toEqual([]);
+    });
+
+    it("creates a catalog with the default owner actor", () => {
+      const catalog = createEmptyCatalog();
+      expect(catalog.actors).toEqual([{ id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" }]);
+      expect(catalog.ownerActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
     });
 
     it("creates a catalog with empty taskListDocIds", () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,17 +1,20 @@
-import type {
-  Habit,
-  HabitEntry,
-  HabitId,
-  IntegrationBinding,
-  IntegrationBindingId,
-  IntegrationBindingStatus,
-  Label,
-  Note,
-  Project,
-  ProjectId,
-  RecurringTemplate,
-  Settings,
-  Task,
+import {
+  type Actor,
+  type ActorId,
+  createActorId,
+  type Habit,
+  type HabitEntry,
+  type HabitId,
+  type IntegrationBinding,
+  type IntegrationBindingId,
+  type IntegrationBindingStatus,
+  type Label,
+  type Note,
+  type Project,
+  type ProjectId,
+  type RecurringTemplate,
+  type Settings,
+  type Task,
 } from "./types.js";
 
 // ============================================================================
@@ -32,6 +35,12 @@ export interface CatalogDocument {
 
   /** All labels */
   labels: Label[];
+
+  /** Catalog-wide actors used for assignment and authorship. */
+  actors: Actor[];
+
+  /** Catalog owner actor, when established. */
+  ownerActorId?: ActorId;
 
   /**
    * Map of projectId → Automerge document ID for that project's task list.
@@ -146,6 +155,7 @@ export interface HabitLogDocument {
 // ============================================================================
 
 export const SCHEMA_VERSION = 1;
+export const DEFAULT_OWNER_ACTOR_ID = createActorId("actor-user");
 
 // ============================================================================
 // Factory functions
@@ -156,6 +166,8 @@ export function createEmptyCatalog(): CatalogDocument {
     version: SCHEMA_VERSION,
     projects: [],
     labels: [],
+    actors: [{ id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" }],
+    ownerActorId: DEFAULT_OWNER_ACTOR_ID,
     taskListDocIds: {},
     notesBucketDocIds: {},
     noteBucketByNoteId: {},

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type {
+  ActorId,
   HabitId,
   IntegrationBindingId,
   LabelId,
@@ -9,6 +10,7 @@ import type {
   TaskId,
 } from "./types.js";
 import {
+  createActorId,
   createHabitId,
   createIntegrationBindingId,
   createLabelId,
@@ -40,6 +42,11 @@ describe("branded IDs", () => {
   it("creates a branded ProjectId", () => {
     const id = createProjectId("project-456");
     expect(id).toBe("project-456" as ProjectId);
+  });
+
+  it("creates a branded ActorId", () => {
+    const id = createActorId("actor-123");
+    expect(id).toBe("actor-123" as ActorId);
   });
 
   it("creates a branded LabelId", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,7 @@
 
 export type TaskId = string & { readonly __brand: "TaskId" };
 export type ProjectId = string & { readonly __brand: "ProjectId" };
+export type ActorId = string & { readonly __brand: "ActorId" };
 export type LabelId = string & { readonly __brand: "LabelId" };
 export type NoteId = string & { readonly __brand: "NoteId" };
 export type HabitId = string & { readonly __brand: "HabitId" };
@@ -16,6 +17,10 @@ export function createTaskId(id: string): TaskId {
 
 export function createProjectId(id: string): ProjectId {
   return id as ProjectId;
+}
+
+export function createActorId(id: string): ActorId {
+  return id as ActorId;
 }
 
 export function createLabelId(id: string): LabelId {
@@ -136,6 +141,7 @@ export interface Project {
   description?: string;
   status: ProjectStatus;
   priority: TaskPriority;
+  authorizedAssigneeActorIds: ActorId[];
   createdAt: string;
   updatedAt: string;
 }
@@ -144,6 +150,16 @@ export interface ProjectFilter {
   status?: ProjectStatus | ProjectStatus[];
   priority?: TaskPriority;
   search?: string;
+}
+
+// ============================================================================
+// Actor entity — stored in catalog document
+// ============================================================================
+
+export interface Actor {
+  id: ActorId;
+  displayName: string;
+  archived?: boolean;
 }
 
 // ============================================================================
@@ -184,6 +200,8 @@ export interface Task {
   priority: TaskPriority;
   projectId: ProjectId;
   labels: string[];
+  assigneeActorIds: ActorId[];
+  /** @deprecated Compatibility field kept during actor-model rollout. */
   assignees: string[];
   dueDate?: string;
   scheduledDate?: string;
@@ -229,7 +247,9 @@ export function isNoteEntityType(value: string): value is NoteEntityType {
 export interface Note {
   id: NoteId;
   content: string;
+  /** @deprecated Compatibility field kept during actor-model rollout. */
   author: string;
+  authorActorId?: ActorId;
   entityType?: NoteEntityType;
   entityId?: string;
   tags: string[];
@@ -244,6 +264,7 @@ export interface CreateProjectInput {
   name: string;
   description?: string;
   priority?: TaskPriority;
+  authorizedAssigneeActorIds?: ActorId[];
 }
 
 export interface UpdateProjectInput {
@@ -251,6 +272,7 @@ export interface UpdateProjectInput {
   description?: string;
   status?: ProjectStatus;
   priority?: TaskPriority;
+  authorizedAssigneeActorIds?: ActorId[];
 }
 
 export interface CreateIntegrationBindingInput {
@@ -294,6 +316,8 @@ export interface CreateTaskInput {
   priority?: TaskPriority;
   description?: string;
   labels?: string[];
+  assigneeActorIds?: ActorId[];
+  /** @deprecated Compatibility field kept during actor-model rollout. */
   assignees?: string[];
   dueDate?: string;
   scheduledDate?: string;
@@ -309,6 +333,8 @@ export interface UpdateTaskInput {
   priority?: TaskPriority;
   description?: string;
   labels?: string[];
+  assigneeActorIds?: ActorId[];
+  /** @deprecated Compatibility field kept during actor-model rollout. */
   assignees?: string[];
   dueDate?: string;
   scheduledDate?: string;
@@ -357,7 +383,9 @@ export interface UpdateLabelInput {
 
 export interface CreateNoteInput {
   content: string;
+  /** @deprecated Compatibility field kept during actor-model rollout. */
   author?: string;
+  authorActorId?: ActorId;
   entityType?: NoteEntityType;
   entityId?: string;
   tags?: string[];
@@ -367,6 +395,7 @@ export interface CreateNoteInput {
 export interface UpdateNoteInput {
   content?: string;
   tags?: string[];
+  authorActorId?: ActorId;
 }
 
 export interface NoteFilter {
@@ -374,6 +403,7 @@ export interface NoteFilter {
   entityId?: string;
   tag?: string;
   author?: string;
+  authorActorId?: ActorId;
   createdFrom?: string;
   createdTo?: string;
   journal?: boolean;

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createIntegrationBindingId, createProjectId } from "./types.js";
+import { createActorId, createIntegrationBindingId, createProjectId } from "./types.js";
 import {
+  MAX_ACTOR_ID_LENGTH,
   MAX_ASSIGNEE_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   MAX_INTEGRATION_FIELD_LENGTH,
@@ -8,6 +9,7 @@ import {
   MAX_NOTE_CONTENT_LENGTH,
   MAX_PROJECT_NAME_LENGTH,
   MAX_TASK_TITLE_LENGTH,
+  validateActorIds,
   validateAssignees,
   validateCreateHabitInput,
   validateCreateIntegrationBindingInput,
@@ -95,9 +97,26 @@ describe("validateCreateProjectInput", () => {
     expect(validateCreateProjectInput(input)).toBeNull();
   });
 
+  it("accepts valid authorized assignee actor ids", () => {
+    expect(
+      validateCreateProjectInput({
+        name: "Test",
+        authorizedAssigneeActorIds: [createActorId("actor-1"), createActorId("actor-2")],
+      }),
+    ).toBeNull();
+  });
+
   it("rejects empty name", () => {
     const error = validateCreateProjectInput({ name: "" });
     expect(error?.field).toBe("name");
+  });
+
+  it("rejects duplicate authorized assignee actor ids", () => {
+    const error = validateCreateProjectInput({
+      name: "Test",
+      authorizedAssigneeActorIds: [createActorId("actor-1"), createActorId("actor-1")],
+    });
+    expect(error?.field).toBe("authorizedAssigneeActorIds");
   });
 
   it("rejects invalid priority", () => {
@@ -128,6 +147,14 @@ describe("validateUpdateProjectInput", () => {
 
   it("accepts valid priority update", () => {
     expect(validateUpdateProjectInput({ priority: "low" })).toBeNull();
+  });
+
+  it("accepts authorized assignee actor id update", () => {
+    expect(
+      validateUpdateProjectInput({
+        authorizedAssigneeActorIds: [createActorId("actor-1")],
+      }),
+    ).toBeNull();
   });
 
   it("accepts multiple field updates", () => {
@@ -490,6 +517,16 @@ describe("validateCreateTaskInput", () => {
     ).toBeNull();
   });
 
+  it("accepts valid input with assignee actor ids", () => {
+    expect(
+      validateCreateTaskInput({
+        title: "Test",
+        projectId,
+        assigneeActorIds: [createActorId("actor-1"), createActorId("actor-2")],
+      }),
+    ).toBeNull();
+  });
+
   it("accepts valid sync linkage fields in create", () => {
     expect(
       validateCreateTaskInput({
@@ -534,6 +571,15 @@ describe("validateCreateTaskInput", () => {
   it("rejects empty assignee string in create", () => {
     const error = validateCreateTaskInput({ title: "Test", projectId, assignees: [""] });
     expect(error?.field).toBe("assignees");
+  });
+
+  it("rejects duplicate assignee actor ids in create", () => {
+    const error = validateCreateTaskInput({
+      title: "Test",
+      projectId,
+      assigneeActorIds: [createActorId("actor-1"), createActorId("actor-1")],
+    });
+    expect(error?.field).toBe("assigneeActorIds");
   });
 
   it("rejects empty title", () => {
@@ -619,6 +665,14 @@ describe("validateUpdateTaskInput", () => {
     expect(validateUpdateTaskInput({ assignees: ["alice", "bob"] })).toBeNull();
   });
 
+  it("accepts valid assignee actor id update", () => {
+    expect(
+      validateUpdateTaskInput({
+        assigneeActorIds: [createActorId("actor-1"), createActorId("actor-2")],
+      }),
+    ).toBeNull();
+  });
+
   it("accepts valid sync linkage updates", () => {
     expect(
       validateUpdateTaskInput({
@@ -672,6 +726,32 @@ describe("validateAssignees", () => {
     const error = validateAssignees(["a".repeat(MAX_ASSIGNEE_LENGTH + 1)]);
     expect(error?.field).toBe("assignees");
     expect(error?.message).toContain(`${MAX_ASSIGNEE_LENGTH}`);
+  });
+});
+
+describe("validateActorIds", () => {
+  it("accepts empty actor id array", () => {
+    expect(validateActorIds("assigneeActorIds", [])).toBeNull();
+  });
+
+  it("accepts valid actor ids", () => {
+    expect(validateActorIds("assigneeActorIds", ["actor-1", "actor-2"])).toBeNull();
+  });
+
+  it("rejects empty actor id", () => {
+    const error = validateActorIds("assigneeActorIds", [""]);
+    expect(error?.field).toBe("assigneeActorIds");
+  });
+
+  it("rejects duplicate actor ids", () => {
+    const error = validateActorIds("assigneeActorIds", ["actor-1", "actor-1"]);
+    expect(error?.field).toBe("assigneeActorIds");
+  });
+
+  it("rejects too-long actor id", () => {
+    const error = validateActorIds("assigneeActorIds", ["a".repeat(MAX_ACTOR_ID_LENGTH + 1)]);
+    expect(error?.field).toBe("assigneeActorIds");
+    expect(error?.message).toContain(`${MAX_ACTOR_ID_LENGTH}`);
   });
 });
 
@@ -896,6 +976,12 @@ describe("validateCreateNoteInput", () => {
     expect(validateCreateNoteInput({ content: "Thought", tags: ["idea", "design"] })).toBeNull();
   });
 
+  it("accepts note with author actor id", () => {
+    expect(
+      validateCreateNoteInput({ content: "Thought", authorActorId: createActorId("actor-1") }),
+    ).toBeNull();
+  });
+
   it("accepts note with createdAt", () => {
     expect(
       validateCreateNoteInput({
@@ -941,6 +1027,10 @@ describe("validateCreateNoteInput", () => {
 describe("validateUpdateNoteInput", () => {
   it("accepts content update", () => {
     expect(validateUpdateNoteInput({ content: "Updated content" })).toBeNull();
+  });
+
+  it("accepts author actor id update", () => {
+    expect(validateUpdateNoteInput({ authorActorId: createActorId("actor-1") })).toBeNull();
   });
 
   it("accepts tags update", () => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -45,6 +45,7 @@ export const MAX_LABEL_NAME_LENGTH = 50;
 export const MAX_NOTE_CONTENT_LENGTH = 10000;
 export const MAX_INTEGRATION_FIELD_LENGTH = 255;
 export const MAX_ASSIGNEE_LENGTH = 100;
+export const MAX_ACTOR_ID_LENGTH = 100;
 export const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
 // ============================================================================
@@ -144,6 +145,33 @@ export function validateAssignees(assignees: string[]): ValidationError | null {
   return null;
 }
 
+export function validateActorId(field: string, actorId: string): ValidationError | null {
+  if (typeof actorId !== "string" || actorId.trim().length === 0) {
+    return validationError(field, "Actor ID must be a non-empty string");
+  }
+  if (actorId.trim().length > MAX_ACTOR_ID_LENGTH) {
+    return validationError(field, `Actor ID must be ${MAX_ACTOR_ID_LENGTH} characters or less`);
+  }
+  return null;
+}
+
+export function validateActorIds(field: string, actorIds: string[]): ValidationError | null {
+  const seen = new Set<string>();
+
+  for (const actorId of actorIds) {
+    const actorIdError = validateActorId(field, actorId);
+    if (actorIdError) return actorIdError;
+
+    const normalized = actorId.trim();
+    if (seen.has(normalized)) {
+      return validationError(field, "Actor IDs must be unique");
+    }
+    seen.add(normalized);
+  }
+
+  return null;
+}
+
 // ============================================================================
 // Input validators
 // ============================================================================
@@ -161,6 +189,14 @@ export function validateCreateProjectInput(input: CreateProjectInput): Validatio
     return validationError("priority", `Invalid priority: ${input.priority}`);
   }
 
+  if (input.authorizedAssigneeActorIds !== undefined) {
+    const actorIdsError = validateActorIds(
+      "authorizedAssigneeActorIds",
+      input.authorizedAssigneeActorIds,
+    );
+    if (actorIdsError) return actorIdsError;
+  }
+
   return null;
 }
 
@@ -170,7 +206,8 @@ export function validateUpdateProjectInput(input: UpdateProjectInput): Validatio
     input.name === undefined &&
     input.description === undefined &&
     input.status === undefined &&
-    input.priority === undefined
+    input.priority === undefined &&
+    input.authorizedAssigneeActorIds === undefined
   ) {
     return validationError("input", "At least one field must be provided");
   }
@@ -191,6 +228,14 @@ export function validateUpdateProjectInput(input: UpdateProjectInput): Validatio
 
   if (input.priority !== undefined && !isTaskPriority(input.priority)) {
     return validationError("priority", `Invalid priority: ${input.priority}`);
+  }
+
+  if (input.authorizedAssigneeActorIds !== undefined) {
+    const actorIdsError = validateActorIds(
+      "authorizedAssigneeActorIds",
+      input.authorizedAssigneeActorIds,
+    );
+    if (actorIdsError) return actorIdsError;
   }
 
   return null;
@@ -381,6 +426,11 @@ export function validateCreateTaskInput(input: CreateTaskInput): ValidationError
     return validationError("priority", `Invalid priority: ${input.priority}`);
   }
 
+  if (input.assigneeActorIds !== undefined) {
+    const actorIdsError = validateActorIds("assigneeActorIds", input.assigneeActorIds);
+    if (actorIdsError) return actorIdsError;
+  }
+
   if (input.assignees !== undefined) {
     const assigneesError = validateAssignees(input.assignees);
     if (assigneesError) return assigneesError;
@@ -429,6 +479,7 @@ export function validateUpdateTaskInput(
     input.priority === undefined &&
     input.description === undefined &&
     input.labels === undefined &&
+    input.assigneeActorIds === undefined &&
     input.assignees === undefined &&
     input.dueDate === undefined &&
     input.scheduledDate === undefined &&
@@ -463,6 +514,11 @@ export function validateUpdateTaskInput(
 
   if (input.priority !== undefined && !isTaskPriority(input.priority)) {
     return validationError("priority", `Invalid priority: ${input.priority}`);
+  }
+
+  if (input.assigneeActorIds !== undefined) {
+    const actorIdsError = validateActorIds("assigneeActorIds", input.assigneeActorIds);
+    if (actorIdsError) return actorIdsError;
   }
 
   if (input.assignees !== undefined) {
@@ -582,6 +638,11 @@ export function validateCreateNoteInput(input: CreateNoteInput): ValidationError
     if (createdAtError) return createdAtError;
   }
 
+  if (input.authorActorId !== undefined) {
+    const actorIdError = validateActorId("authorActorId", input.authorActorId);
+    if (actorIdError) return actorIdError;
+  }
+
   // If entityType is set, entityId must also be set (and vice versa)
   if (input.entityType !== undefined && !input.entityId) {
     return validationError("entityId", "Entity ID is required when entity type is specified");
@@ -597,6 +658,11 @@ export function validateUpdateNoteInput(input: UpdateNoteInput): ValidationError
   if (input.content !== undefined) {
     const contentError = validateNoteContent(input.content);
     if (contentError) return contentError;
+  }
+
+  if (input.authorActorId !== undefined) {
+    const actorIdError = validateActorId("authorActorId", input.authorActorId);
+    if (actorIdError) return actorIdError;
   }
 
   return null;
@@ -670,6 +736,11 @@ export function validateTaskFilter(filter: TaskFilter): ValidationError | null {
 export function validateNoteFilter(filter: NoteFilter): ValidationError | null {
   if (filter.entityType !== undefined && !isNoteEntityType(filter.entityType)) {
     return validationError("entityType", `Invalid entity type: ${filter.entityType}`);
+  }
+
+  if (filter.authorActorId !== undefined) {
+    const actorIdError = validateActorId("authorActorId", filter.authorActorId);
+    if (actorIdError) return actorIdError;
   }
 
   if (filter.journal && (filter.entityType !== undefined || filter.entityId !== undefined)) {

--- a/packages/engine/src/index.integration.test.ts
+++ b/packages/engine/src/index.integration.test.ts
@@ -184,6 +184,8 @@ describe("createTodu", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const migratedCatalog = await readCatalogDocument(tmpDir);
+    expect(migratedCatalog.actors).toEqual([{ id: "actor-user", displayName: "user" }]);
+    expect(migratedCatalog.ownerActorId).toBe("actor-user");
     expect(migratedCatalog.taskListDocIds).toEqual({});
     expect(migratedCatalog.notesBucketDocIds).toEqual({});
     expect(migratedCatalog.noteBucketByNoteId).toEqual({});

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -6,9 +6,11 @@ import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type CatalogDocument,
+  createActorId,
   createEmptyCatalog,
   createNoteId,
   createNotesDocument,
+  DEFAULT_OWNER_ACTOR_ID,
   type Note,
   type ProjectId,
 } from "@todu/core";
@@ -62,6 +64,7 @@ describe("note namespace", () => {
       if (!result.ok) return;
       expect(result.value.content).toBe("Today was productive");
       expect(result.value.author).toBe("user");
+      expect(result.value.authorActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
       expect(result.value.entityType).toBeUndefined();
       expect(result.value.entityId).toBeUndefined();
       expect(result.value.tags).toEqual([]);
@@ -113,6 +116,27 @@ describe("note namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.author).toBe("agent");
+    });
+
+    it("creates a note with author actor id", async () => {
+      const result = await todu.note.create({
+        content: "Actor-authored note",
+        authorActorId: createActorId("actor-user"),
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.authorActorId).toBe("actor-user");
+    });
+
+    it("rejects unknown author actor id", async () => {
+      const result = await todu.note.create({
+        content: "Actor-authored note",
+        authorActorId: createActorId("actor-missing"),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("actor");
     });
 
     it("creates a journal note with an explicit historical timestamp", async () => {
@@ -387,6 +411,31 @@ describe("note namespace", () => {
       if (!result.ok) return;
       expect(result.value.content).toBe("New");
       expect(result.value.tags).toEqual(["b", "c"]);
+    });
+
+    it("updates note author actor id", async () => {
+      const created = await todu.note.create({ content: "Original" });
+      if (!created.ok) throw new Error("create failed");
+
+      const result = await todu.note.update(created.value.id, {
+        authorActorId: createActorId("actor-user"),
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.authorActorId).toBe("actor-user");
+    });
+
+    it("rejects unknown note author actor id updates", async () => {
+      const created = await todu.note.create({ content: "Original" });
+      if (!created.ok) throw new Error("create failed");
+
+      const result = await todu.note.update(created.value.id, {
+        authorActorId: createActorId("actor-missing"),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("actor");
     });
 
     it("returns NotFound for nonexistent note", async () => {

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -116,6 +116,28 @@ export function createNoteNamespace(
     return true;
   }
 
+  function findActorIdByDisplayName(displayName: string): Note["authorActorId"] {
+    const catalogDoc = catalog.doc();
+    return catalogDoc?.actors.find((actor) => actor.displayName === displayName)?.id;
+  }
+
+  function actorExists(actorId: string): boolean {
+    const catalogDoc = catalog.doc();
+    return catalogDoc?.actors.some((actor) => actor.id === actorId) ?? false;
+  }
+
+  function resolveAuthorActorId(input: CreateNoteInput): Note["authorActorId"] {
+    if (input.authorActorId !== undefined) {
+      return input.authorActorId;
+    }
+
+    if (input.author === undefined || input.author === "user") {
+      return catalog.doc()?.ownerActorId;
+    }
+
+    return findActorIdByDisplayName(input.author);
+  }
+
   async function getBucketHandle(bucketKey: string): Promise<DocHandle<NotesDocument> | null> {
     const catalogDoc = catalog.doc();
     const docId = catalogDoc?.notesBucketDocIds?.[bucketKey];
@@ -334,6 +356,11 @@ export function createNoteNamespace(
         }
       }
 
+      const authorActorId = resolveAuthorActorId(input);
+      if (authorActorId !== undefined && !actorExists(authorActorId)) {
+        return err(notFound("actor", authorActorId));
+      }
+
       const createdAt = input.createdAt
         ? new Date(input.createdAt).toISOString()
         : new Date().toISOString();
@@ -346,6 +373,7 @@ export function createNoteNamespace(
         tags: input.tags ?? [],
         createdAt,
       };
+      if (authorActorId !== undefined) note.authorActorId = authorActorId;
       if (input.entityType !== undefined) note.entityType = input.entityType;
       if (input.entityId !== undefined) note.entityId = input.entityId;
 
@@ -398,6 +426,10 @@ export function createNoteNamespace(
         const author = normalizedFilter.author;
         notes = notes.filter((n) => n.author === author);
       }
+      if (normalizedFilter?.authorActorId) {
+        const authorActorId = normalizedFilter.authorActorId;
+        notes = notes.filter((n) => n.authorActorId === authorActorId);
+      }
       if (normalizedFilter?.journal) {
         notes = notes.filter((n) => n.entityType === undefined && n.entityId === undefined);
       }
@@ -431,9 +463,14 @@ export function createNoteNamespace(
       const location = await findNoteLocation(id);
       if (!location) return err(notFound("note", id));
 
+      if (input.authorActorId !== undefined && !actorExists(input.authorActorId)) {
+        return err(notFound("actor", input.authorActorId));
+      }
+
       location.handle.change((doc) => {
         const note = doc.notes[location.index];
         if (input.content !== undefined) note.content = input.content.trim();
+        if (input.authorActorId !== undefined) note.authorActorId = input.authorActorId;
         if (input.tags !== undefined) {
           // Clear and repopulate tags array for Automerge compatibility
           while (note.tags.length > 0) note.tags.pop();
@@ -494,6 +531,7 @@ function toStorageNote(n: Note): Note {
     createdAt: n.createdAt,
   };
 
+  if (n.authorActorId !== undefined) note.authorActorId = n.authorActorId;
   if (n.entityType !== undefined) note.entityType = n.entityType;
   if (n.entityId !== undefined) note.entityId = n.entityId;
 

--- a/packages/engine/src/projects.integration.test.ts
+++ b/packages/engine/src/projects.integration.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ProjectId } from "@todu/core";
-import { createProjectId } from "@todu/core";
+import { createActorId, createProjectId, DEFAULT_OWNER_ACTOR_ID } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
@@ -35,6 +35,7 @@ describe("project namespace", () => {
       expect(result.value).not.toHaveProperty("syncStrategy");
       expect(result.value).not.toHaveProperty("systemId");
       expect(result.value).not.toHaveProperty("externalId");
+      expect(result.value.authorizedAssigneeActorIds).toEqual([DEFAULT_OWNER_ACTOR_ID]);
       expect(result.value.id).toMatch(/^proj-/);
       expect(result.value.createdAt).toBeTruthy();
       expect(result.value.updatedAt).toBeTruthy();
@@ -52,6 +53,17 @@ describe("project namespace", () => {
       expect(result.value.name).toBe("Full Project");
       expect(result.value.description).toBe("A detailed description");
       expect(result.value.priority).toBe("high");
+    });
+
+    it("creates a project with authorized assignee actor ids", async () => {
+      const result = await todu.project.create({
+        name: "Assigned Project",
+        authorizedAssigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.authorizedAssigneeActorIds).toEqual(["actor-user"]);
     });
 
     it("trims whitespace from name", async () => {
@@ -76,6 +88,17 @@ describe("project namespace", () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.error.type).toBe("validation");
+    });
+
+    it("returns not found for unknown authorized actor ids", async () => {
+      const result = await todu.project.create({
+        name: "Assigned Project",
+        authorizedAssigneeActorIds: [createActorId("actor-missing")],
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("actor");
     });
   });
 
@@ -210,6 +233,15 @@ describe("project namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.description).toBe("New desc");
+    });
+
+    it("updates authorized assignee actor ids", async () => {
+      const result = await todu.project.update(projectId, {
+        authorizedAssigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.authorizedAssigneeActorIds).toEqual(["actor-user"]);
     });
 
     it("updates multiple fields at once", async () => {

--- a/packages/engine/src/projects.ts
+++ b/packages/engine/src/projects.ts
@@ -22,10 +22,29 @@ import type { ProjectNamespace } from "./todu.js";
 // ============================================================================
 
 export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): ProjectNamespace {
+  function findMissingAuthorizedActorId(
+    actorIds: Project["authorizedAssigneeActorIds"],
+  ): Project["authorizedAssigneeActorIds"][number] | null {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc) return actorIds[0] ?? null;
+
+    const catalogActorIds = new Set<string>(catalogDoc.actors.map((actor) => actor.id));
+    return actorIds.find((actorId) => !catalogActorIds.has(actorId)) ?? null;
+  }
+
   return {
     async create(input: CreateProjectInput): Promise<Result<Project>> {
       const validationErr = validateCreateProjectInput(input);
       if (validationErr) return err(validationErr);
+
+      const catalogDoc = catalog.doc();
+      const authorizedAssigneeActorIds =
+        input.authorizedAssigneeActorIds ??
+        (catalogDoc?.ownerActorId ? [catalogDoc.ownerActorId] : []);
+      const missingActorId = findMissingAuthorizedActorId(authorizedAssigneeActorIds);
+      if (missingActorId) {
+        return err(notFound("actor", missingActorId));
+      }
 
       const now = new Date().toISOString();
       const id = createProjectId(`proj-${crypto.randomUUID().slice(0, 8)}`);
@@ -35,6 +54,7 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
         name: input.name.trim(),
         status: "active",
         priority: input.priority ?? "medium",
+        authorizedAssigneeActorIds,
         createdAt: now,
         updatedAt: now,
       };
@@ -91,6 +111,13 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
       const index = doc.projects.findIndex((p) => p.id === id);
       if (index === -1) return err(notFound("project", id));
 
+      const nextAuthorizedAssigneeActorIds =
+        input.authorizedAssigneeActorIds ?? doc.projects[index].authorizedAssigneeActorIds;
+      const missingActorId = findMissingAuthorizedActorId(nextAuthorizedAssigneeActorIds);
+      if (missingActorId) {
+        return err(notFound("actor", missingActorId));
+      }
+
       const now = new Date().toISOString();
 
       catalog.change((doc) => {
@@ -99,6 +126,13 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
         if (input.description !== undefined) project.description = input.description.trim();
         if (input.status !== undefined) project.status = input.status;
         if (input.priority !== undefined) project.priority = input.priority;
+        if (input.authorizedAssigneeActorIds !== undefined) {
+          project.authorizedAssigneeActorIds.splice(
+            0,
+            project.authorizedAssigneeActorIds.length,
+            ...input.authorizedAssigneeActorIds,
+          );
+        }
         project.updatedAt = now;
       });
 
@@ -134,6 +168,7 @@ function cloneProject(p: Project): Project {
     description: p.description,
     status: p.status,
     priority: p.priority,
+    authorizedAssigneeActorIds: [...(p.authorizedAssigneeActorIds ?? [])],
     createdAt: p.createdAt,
     updatedAt: p.updatedAt,
   };

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -361,6 +361,8 @@ function createBootstrapCatalog(repo: Repo, markerPath: string): DocHandle<Catal
     doc.version = empty.version;
     doc.projects = empty.projects;
     doc.labels = empty.labels;
+    doc.actors = empty.actors;
+    doc.ownerActorId = empty.ownerActorId;
     doc.recurringTemplates = empty.recurringTemplates;
     doc.habits = empty.habits;
     doc.habitLogDocIds = empty.habitLogDocIds;
@@ -391,6 +393,8 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
   // Check for missing fields
   if (!Array.isArray(doc.projects)) needsMigration = true;
   if (!Array.isArray(doc.labels)) needsMigration = true;
+  if (!Array.isArray(doc.actors)) needsMigration = true;
+  if (doc.ownerActorId === undefined || doc.ownerActorId === null) needsMigration = true;
   if (!Array.isArray(doc.recurringTemplates)) needsMigration = true;
   if (!Array.isArray(doc.habits)) needsMigration = true;
   if (doc.taskListDocIds === undefined || doc.taskListDocIds === null) needsMigration = true;
@@ -402,12 +406,19 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
     needsMigration = true;
   if (doc.settings === undefined || doc.settings === null) needsMigration = true;
   if (doc.version === undefined || doc.version === null) needsMigration = true;
+  if (doc.projects?.some((project) => project.authorizedAssigneeActorIds === undefined)) {
+    needsMigration = true;
+  }
 
   if (!needsMigration) return;
 
   handle.change((d) => {
     if (!Array.isArray(d.projects)) d.projects = defaults.projects;
     if (!Array.isArray(d.labels)) d.labels = defaults.labels;
+    if (!Array.isArray(d.actors)) d.actors = defaults.actors;
+    if (d.ownerActorId === undefined || d.ownerActorId === null) {
+      d.ownerActorId = defaults.ownerActorId;
+    }
     if (!Array.isArray(d.recurringTemplates)) d.recurringTemplates = defaults.recurringTemplates;
     if (!Array.isArray(d.habits)) d.habits = defaults.habits;
     if (d.taskListDocIds === undefined || d.taskListDocIds === null)
@@ -422,5 +433,13 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
       d.integrationStatusDocIds = defaults.integrationStatusDocIds;
     if (d.settings === undefined || d.settings === null) d.settings = defaults.settings;
     if (d.version === undefined || d.version === null) d.version = SCHEMA_VERSION;
+    for (const project of d.projects) {
+      if (
+        project.authorizedAssigneeActorIds === undefined ||
+        project.authorizedAssigneeActorIds === null
+      ) {
+        project.authorizedAssigneeActorIds = d.ownerActorId ? [d.ownerActorId] : [];
+      }
+    }
   });
 }

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
-import { createProjectId, createTaskId } from "@todu/core";
+import { createActorId, createProjectId, createTaskId } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
@@ -32,13 +32,14 @@ async function removeTaskArrays(
     await taskListHandle.whenReady();
     taskListHandle.change((doc) => {
       const legacyTask = doc.tasks.find((task) => task.id === taskId) as
-        | (Task & { labels?: string[]; assignees?: string[] })
+        | (Task & { labels?: string[]; assigneeActorIds?: string[]; assignees?: string[] })
         | undefined;
       if (!legacyTask) {
         throw new Error(`task not found: ${taskId}`);
       }
 
       delete legacyTask.labels;
+      delete legacyTask.assigneeActorIds;
       delete legacyTask.assignees;
     });
     await repo.flush();
@@ -79,6 +80,7 @@ describe("task namespace", () => {
       expect(result.value.priority).toBe("medium");
       expect(result.value.projectId).toBe(projectId);
       expect(result.value.labels).toEqual([]);
+      expect(result.value.assigneeActorIds).toEqual([]);
       expect(result.value.assignees).toEqual([]);
       expect(result.value.id).toMatch(/^task-/);
     });
@@ -93,6 +95,45 @@ describe("task namespace", () => {
       if (!result.ok) return;
 
       expect(result.value.assignees).toEqual(["alice", "bob"]);
+    });
+
+    it("creates a task with assignee actor ids", async () => {
+      await todu.project.update(projectId, {
+        authorizedAssigneeActorIds: [createActorId("actor-user")],
+      });
+      const result = await todu.task.create({
+        title: "Actor-assigned task",
+        projectId,
+        assigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.assigneeActorIds).toEqual(["actor-user"]);
+    });
+
+    it("rejects unknown assignee actor ids", async () => {
+      const result = await todu.task.create({
+        title: "Actor-assigned task",
+        projectId,
+        assigneeActorIds: [createActorId("actor-missing")],
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("actor");
+    });
+
+    it("rejects unauthorized assignee actor ids", async () => {
+      const result = await todu.task.create({
+        title: "Actor-assigned task",
+        projectId,
+        assigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("validation");
+      expect(result.error.field).toBe("assigneeActorIds");
     });
 
     it("creates a task with all optional fields", async () => {
@@ -218,6 +259,7 @@ describe("task namespace", () => {
       expect(result.value).toHaveLength(1);
       expect(result.value[0].title).toBe("Legacy task");
       expect(result.value[0].labels).toEqual([]);
+      expect(result.value[0].assigneeActorIds).toEqual([]);
       expect(result.value[0].assignees).toEqual([]);
     });
 
@@ -582,6 +624,28 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.assignees).toEqual(["alice", "bob"]);
+    });
+
+    it("updates assignee actor ids", async () => {
+      await todu.project.update(projectId, {
+        authorizedAssigneeActorIds: [createActorId("actor-user")],
+      });
+      const result = await todu.task.update(taskId, {
+        assigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.assigneeActorIds).toEqual(["actor-user"]);
+    });
+
+    it("rejects unauthorized assignee actor id updates", async () => {
+      const result = await todu.task.update(taskId, {
+        assigneeActorIds: [createActorId("actor-user")],
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("validation");
+      expect(result.error.field).toBe("assigneeActorIds");
     });
 
     it("updates sync linkage fields", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -21,6 +21,7 @@ import {
   type TaskSortOptions,
   type TaskWithDetail,
   type UpdateTaskInput,
+  type ValidationError,
   validateCreateTaskInput,
   validateTaskFilter,
   validateUpdateTaskInput,
@@ -95,6 +96,28 @@ export function createTaskNamespace(
     return normalized;
   }
 
+  function findMissingActorId(actorIds: readonly string[]): string | null {
+    const catalogDoc = catalog.doc();
+    if (!catalogDoc) return actorIds[0] ?? null;
+
+    const catalogActorIds = new Set<string>(catalogDoc.actors.map((actor) => actor.id));
+    return actorIds.find((actorId) => !catalogActorIds.has(actorId)) ?? null;
+  }
+
+  function validateAuthorizedAssigneeActorIds(
+    project: { authorizedAssigneeActorIds: string[] },
+    assigneeActorIds: readonly string[],
+  ): ValidationError | null {
+    const authorized = new Set(project.authorizedAssigneeActorIds);
+    const unauthorizedActorId = assigneeActorIds.find((actorId) => !authorized.has(actorId));
+    if (!unauthorizedActorId) return null;
+
+    return validationError(
+      "assigneeActorIds",
+      `Actor is not authorized for project assignment: ${unauthorizedActorId}`,
+    );
+  }
+
   function migrateTaskListDoc(handle: DocHandle<TaskListDocument>): void {
     const doc = handle.doc();
     if (!doc) return;
@@ -104,6 +127,7 @@ export function createTaskNamespace(
       doc.detailDocIds === undefined ||
       doc.detailDocIds === null ||
       tasks.some((task) => task.labels === undefined || task.labels === null) ||
+      tasks.some((task) => task.assigneeActorIds === undefined || task.assigneeActorIds === null) ||
       tasks.some((task) => task.assignees === undefined || task.assignees === null);
 
     if (!needsMigration) return;
@@ -115,6 +139,9 @@ export function createTaskNamespace(
       for (const task of d.tasks) {
         if (task.labels === undefined || task.labels === null) {
           task.labels = [];
+        }
+        if (task.assigneeActorIds === undefined || task.assigneeActorIds === null) {
+          task.assigneeActorIds = [];
         }
         if (task.assignees === undefined || task.assignees === null) {
           task.assignees = [];
@@ -202,6 +229,17 @@ export function createTaskNamespace(
       const project = catalogDoc.projects.find((p) => p.id === input.projectId);
       if (!project) return err(notFound("project", input.projectId));
 
+      if (input.assigneeActorIds !== undefined) {
+        const missingActorId = findMissingActorId(input.assigneeActorIds);
+        if (missingActorId) return err(notFound("actor", missingActorId));
+
+        const authorizationError = validateAuthorizedAssigneeActorIds(
+          project,
+          input.assigneeActorIds,
+        );
+        if (authorizationError) return err(authorizationError);
+      }
+
       const now = new Date().toISOString();
       const createdAt = input.createdAt
         ? normalizeTaskTimestamp(input.createdAt)
@@ -222,6 +260,7 @@ export function createTaskNamespace(
         priority: input.priority ?? "medium",
         projectId: input.projectId,
         labels: input.labels ?? [],
+        assigneeActorIds: input.assigneeActorIds ?? [],
         assignees: input.assignees ?? [],
         createdAt,
         updatedAt,
@@ -391,6 +430,22 @@ export function createTaskNamespace(
       const validationErr = validateUpdateTaskInput(input, result.task.status);
       if (validationErr) return err(validationErr);
 
+      const catalogDoc = catalog.doc();
+      if (!catalogDoc) return err(notFound("project", result.task.projectId));
+      const project = catalogDoc.projects.find((p) => p.id === result.task.projectId);
+      if (!project) return err(notFound("project", result.task.projectId));
+
+      if (input.assigneeActorIds !== undefined) {
+        const missingActorId = findMissingActorId(input.assigneeActorIds);
+        if (missingActorId) return err(notFound("actor", missingActorId));
+
+        const authorizationError = validateAuthorizedAssigneeActorIds(
+          project,
+          input.assigneeActorIds,
+        );
+        if (authorizationError) return err(authorizationError);
+      }
+
       const updatedAt = input.updatedAt
         ? normalizeTaskTimestamp(input.updatedAt)
         : new Date().toISOString();
@@ -404,6 +459,9 @@ export function createTaskNamespace(
         if (input.labels !== undefined) {
           // Replace labels array entirely
           task.labels.splice(0, task.labels.length, ...input.labels);
+        }
+        if (input.assigneeActorIds !== undefined) {
+          task.assigneeActorIds.splice(0, task.assigneeActorIds.length, ...input.assigneeActorIds);
         }
         if (input.assignees !== undefined) {
           // Replace assignees array entirely
@@ -572,6 +630,7 @@ function cloneTask(t: Task): Task {
     priority: t.priority,
     projectId: t.projectId,
     labels: [...(t.labels ?? [])],
+    assigneeActorIds: [...(t.assigneeActorIds ?? [])],
     assignees: [...(t.assignees ?? [])],
     dueDate: t.dueDate,
     scheduledDate: t.scheduledDate,


### PR DESCRIPTION
## Summary
- add actor IDs plus actor-backed project, task, and note scaffolding in core
- keep legacy assignee/author fields in place during the rollout window
- add validation, engine defaults/migrations, tests, and architecture doc updates

## Verification
- make pre-pr
- npx vitest run --config vitest.all.config.ts packages/engine/src/index.integration.test.ts packages/engine/src/projects.integration.test.ts packages/engine/src/tasks.integration.test.ts packages/engine/src/notes.integration.test.ts
- npm run test -- packages/core/src/types.test.ts packages/core/src/schema.test.ts packages/core/src/validation.test.ts

Task: #task-90623e7d