### PR TITLE
docs: add multi-user task assignment plan

### DIFF
--- a/docs/plans/multi-user-task-assignment-rollout.md
+++ b/docs/plans/multi-user-task-assignment-rollout.md
@@ -1,0 +1,638 @@
+# Multi-user Task Assignment Rollout Strategy
+
+## Status
+
+Proposed rollout plan for the assignment and actor model defined in `docs/plans/multi-user-task-assignment.md`.
+
+## Purpose
+
+This document describes how to roll out the actor-based assignment model across core todu and the known dependent packages without requiring a flag-day upgrade.
+
+Primary dependent surfaces today:
+
+- core todu repo
+- `todu-github-plugin`
+- `todu-forgejo-plugin`
+- `todu-pi-extensions`
+
+The goal is to minimize user disruption, preserve sync continuity, and allow each downstream package to move at its own pace.
+
+## Rollout goals
+
+The rollout should:
+
+- preserve existing local data through migration
+- preserve sync behavior for users who upgrade core before plugins
+- avoid a requirement that every plugin and UI package release simultaneously
+- keep old provider plugins working for at least one compatibility window
+- make failures obvious and recoverable
+- allow incremental testing and rollback at each stage
+
+## Rollout non-goals
+
+This rollout does not try to:
+
+- preserve the legacy string-based storage model indefinitely
+- guarantee zero implementation work in downstream packages
+- introduce permanent dual-write storage
+- keep the old sync-provider API forever
+
+## Scope
+
+This rollout covers:
+
+- core schema and migration strategy
+- runtime compatibility for sync-provider plugins
+- rollout sequencing across plugin and UI packages
+- verification strategy
+- rollback strategy
+
+This rollout does not fully specify the implementation details of each downstream repository. Those should be tracked as repo-specific tasks derived from this document.
+
+## Baseline assumptions
+
+- core storage will move forward to the actor-based model
+- compatibility should be handled at system boundaries, not by preserving two canonical storage models forever
+- the sync-provider boundary is the most important compatibility seam
+- `todu-pi-extensions` should be allowed to upgrade independently from sync providers
+- existing data is safe to migrate using the agreed normalization rules from the design note
+
+## Known impacted systems
+
+## 1. Core todu repo
+
+Impacted areas include:
+
+- core types and schema
+- engine task and note persistence
+- validation
+- migration
+- daemon plugin host/runtime
+- CLI and Electron baseline flows
+- sync-provider API documentation and validation
+
+## 2. `todu-github-plugin`
+
+Impacted areas include:
+
+- provider manifest `apiVersion`
+- assignee import/export handling
+- comment author import handling
+- support for structured external actor refs
+- optional trust-aware behavior assumptions
+
+## 3. `todu-forgejo-plugin`
+
+Impacted areas are roughly the same as the GitHub plugin.
+
+## 4. `todu-pi-extensions`
+
+Impacted areas include:
+
+- task display and editing
+- note display and editing
+- actor management UI/commands
+- project authorized assignee management
+- binding mapping and trust UI
+- approval-needed UI/commands
+
+## Rollout principles
+
+### 1. Migrate storage once
+
+Persisted data should migrate to the actor model once.
+
+Do not maintain two canonical persisted representations such as:
+
+- `Task.assignees: string[]`
+- and `Task.assigneeActorIds: ActorId[]`
+
+at the same time as equal sources of truth.
+
+### 2. Keep compatibility at boundaries
+
+Compatibility should live in:
+
+- runtime adapters
+- provider host shims
+- read-model adapters for old consumers
+
+not in long-lived duplicate storage.
+
+### 3. Additive first, removal later
+
+The first releases should add:
+
+- actor storage
+- migration
+- compatibility adapters
+- new provider contract support
+
+Only later releases should remove old behavior.
+
+### 4. Upgrade consumers independently
+
+Core, plugins, and `todu-pi-extensions` should be able to upgrade on separate schedules during the compatibility window.
+
+### 5. Fail soft when possible
+
+Examples:
+
+- unmapped outbound assignees should warn, not fail sync
+- pending imported-content approval should block agent use, not human visibility
+- old plugins should continue to sync through compatibility adapters where possible
+
+## Compatibility strategy
+
+## Storage compatibility
+
+### Canonical storage after migration
+
+After migration, the canonical model should be:
+
+- catalog `actors[]`
+- catalog `ownerActorId`
+- task `assigneeActorIds`
+- note `authorActorId`
+- project `authorizedAssigneeActorIds`
+
+### Legacy read compatibility
+
+Where older code still expects string values, the system should derive them from actors as needed.
+
+Examples:
+
+- legacy task-assignee string view derived from actor `displayName`
+- legacy note-author string view derived from actor `displayName`
+
+This compatibility should be exposed only where needed and should not become a permanent second storage model.
+
+## Sync-provider API compatibility
+
+This is the most important compatibility seam.
+
+### Current state
+
+Current provider API is version `2` and expects:
+
+- string assignees
+- string note/comment authors
+- direct `mapToTask(...)` and `mapFromTask(...)` methods
+
+### Target state
+
+Target provider API should use:
+
+- structured `ExternalActorRef`
+- normalized import payloads
+- normalized export payloads
+- runtime-owned actor resolution and approval computation
+
+### Rollout requirement
+
+During rollout, the host should support both:
+
+- provider API v2
+- provider API v3
+
+That means the host-side compatibility policy should change from:
+
+- exact single-version match only
+
+to something like:
+
+- supported API versions = `{2, 3}` during the transition window
+
+### Host responsibilities during the compatibility window
+
+For **v2 providers**:
+
+- convert pulled string assignees and authors into actors
+- create or reuse actor mappings during pull
+- derive approval state in runtime
+- convert local actor assignment back into string assignees on push
+- preserve existing comment push behavior where providers post as the integration account
+
+For **v3 providers**:
+
+- accept normalized import/export payloads directly
+- bypass legacy string conversion shims
+
+### Removal policy
+
+Do not remove v2 support until:
+
+- `todu-github-plugin` has shipped on v3
+- `todu-forgejo-plugin` has shipped on v3
+- compatibility coverage has been validated in end-to-end tests
+
+## UI compatibility
+
+`todu-pi-extensions` should move to the actor model, but it should not block core rollout.
+
+### Core requirement
+
+Core should expose enough compatibility behavior that old UI surfaces do not immediately break after migration.
+
+### Preferred UI rollout
+
+- old UI continues to work against compatibility-backed reads during a short window
+- new UI moves to actor concepts as soon as practical
+- actor management, mapping, and approval UX ship incrementally rather than as one giant release
+
+## Rollout phases
+
+## Phase 0: preparation and contract design
+
+### Deliverables
+
+- finalize design note
+- finalize rollout plan
+- define provider API v3 types
+- define compatibility policy for supported provider API versions
+- identify all core migration entry points and all downstream repos
+
+### Success criteria
+
+- design and rollout docs are approved
+- downstream repos have clear upgrade targets
+- compatibility window policy is explicit
+
+## Phase 1: core additive groundwork
+
+### Scope
+
+Add core structures without yet removing compatibility paths.
+
+### Core changes
+
+- add actor types
+- add catalog actor storage
+- add `ownerActorId`
+- add project `authorizedAssigneeActorIds`
+- add task `assigneeActorIds`
+- add note `authorActorId`
+- add approval metadata structures
+- add binding-scoped actor mapping and trust structures
+- add provider API v3 types alongside existing v2 types
+- update plugin host validation to support both v2 and v3 during transition
+
+### Important rule
+
+No downstream repo should be required to upgrade at this phase boundary.
+
+### Success criteria
+
+- core compiles with v2 and v3 provider support paths present
+- existing tests continue to pass
+- new actor-model tests exist for storage and validation behavior
+
+## Phase 2: migration implementation
+
+### Scope
+
+Implement and validate migration from legacy string identities to actors.
+
+### Migration behavior
+
+- create actors from task assignees and note authors using agreed normalization
+- map legacy `"user"` and missing note authors to `ownerActorId`
+- rewrite tasks and notes to actor ids
+- backfill project authorized assignee lists
+- make migration idempotent
+
+### Safety requirements
+
+- if migration fails, fail before partial destructive cleanup
+- avoid writing partially migrated mixed-state data that cannot be retried safely
+- migration should be resumable or repeatable without corruption
+
+### Success criteria
+
+- migrated datasets load cleanly
+- legacy datasets upgrade deterministically
+- actor ids remain stable across repeated startup attempts after successful migration
+
+## Phase 3: runtime compatibility shims
+
+### Scope
+
+Make old providers and old UI reads continue to work against migrated data.
+
+### Deliverables
+
+- v2 provider pull adapter: strings -> actors
+- v2 provider push adapter: actors -> strings
+- compatibility read helpers for any old internal consumers that still expect strings
+- warnings and diagnostics around unmapped assignees remain operational
+
+### Success criteria
+
+- core with migrated data can still sync through unmodified v2 providers
+- old provider behavior remains correct enough for one transition window
+- no actor information is silently lost in local storage even when external push degrades gracefully
+
+## Phase 4: `todu-pi-extensions` upgrade
+
+### Scope
+
+Upgrade the UI package to native actor concepts.
+
+### Deliverables
+
+- actor list and actor management flows
+- project authorized assignee editor
+- task multi-actor assignment UI and commands
+- binding mapping and trust management flows
+- approval-needed views and approval actions
+- stale unauthorized-assignee indicators
+- skipped-unmapped-assignee warning display
+
+### Success criteria
+
+- `todu-pi-extensions` works directly with actor-based core data
+- no dependency on legacy string-assignee assumptions remains in active UI flows
+
+## Phase 5: `todu-github-plugin` v3 upgrade
+
+### Scope
+
+Ship GitHub on the new provider contract.
+
+### Deliverables
+
+- manifest bump to provider API v3
+- `ExternalActorRef` support
+- normalized import payload support
+- normalized export payload support
+- GitHub-specific actor extraction using stable external ids and login data
+
+### Success criteria
+
+- GitHub sync works against core without v2 shims
+- pull creates or reuses actors correctly
+- push uses mapped actor refs correctly
+- approval and trust flows behave as expected for imported GitHub content
+
+## Phase 6: `todu-forgejo-plugin` v3 upgrade
+
+Same goals as GitHub, adapted for Forgejo specifics.
+
+## Phase 7: stabilization window
+
+### Scope
+
+Run with:
+
+- migrated core storage
+- updated UI package where available
+- both v2 and v3 provider support still enabled
+
+### Purpose
+
+This gives time to:
+
+- find migration bugs
+- validate plugin behavior
+- validate approval behavior in real usage
+- validate trust and mapping UX
+
+### Exit criteria
+
+- both known sync providers ship v3
+- no critical migration bugs remain open
+- no major compatibility regressions remain unresolved
+
+## Phase 8: legacy removal
+
+### Scope
+
+Remove temporary compatibility layers.
+
+### Removals
+
+- provider API v2 support
+- legacy string-assignee compatibility helpers no longer needed internally
+- obsolete migration-only code after sufficient release distance
+
+### Preconditions
+
+Do not begin this phase until:
+
+- both known provider plugins are on v3
+- the compatibility window has elapsed
+- migration success has been validated on representative datasets
+
+## Versioning and release strategy
+
+## Core release strategy
+
+Recommended release flow:
+
+### Release A
+
+- additive actor groundwork
+- migration
+- runtime compatibility shims
+- v2 + v3 provider host support
+
+This is the most important release.
+
+### Release B
+
+- `todu-pi-extensions` actor-native UI support
+- optional refinement to warnings, approval UX, and actor management
+
+### Release C
+
+- `todu-github-plugin` v3
+
+### Release D
+
+- `todu-forgejo-plugin` v3
+
+### Release E
+
+- removal of v2 provider support
+
+A single package may release multiple times within each broad stage. The important part is the compatibility ordering, not the exact number of version tags.
+
+## Compatibility window
+
+Recommended minimum:
+
+- keep v2 provider support for at least one full core release cycle after both known providers have shipped v3
+
+Conservative option:
+
+- two release cycles if early adopters reveal migration or plugin edge cases
+
+## Downtime minimization strategy
+
+## User-visible downtime
+
+Target: no planned sync downtime required.
+
+### How to achieve that
+
+- core should upgrade first with compatibility shims
+- old providers should keep working immediately after core upgrade
+- plugin upgrades can happen later without breaking already-upgraded core users
+
+## Local migration downtime
+
+A one-time local startup migration pause is acceptable if:
+
+- it is bounded
+- progress/errors are visible
+- it either completes fully or fails cleanly
+
+## External sync continuity
+
+Sync should remain operational throughout the transition except where:
+
+- a provider is explicitly broken by a regression
+- an unmapped assignee is intentionally omitted with warning
+- imported content requires approval before agent use
+
+## Verification strategy
+
+## Core verification
+
+Must include:
+
+- unit tests for actor schema and validation
+- migration tests for legacy tasks and notes
+- restart tests proving migrated data reloads correctly
+- tests for unauthorized stale assignee behavior
+- tests for approval-state persistence and reset on content changes
+- tests for binding mappings and trust behavior
+
+## Provider compatibility verification
+
+For **v2 compatibility mode**:
+
+- pull string assignees -> actors
+- pull string authors -> actors
+- push actor assignments -> string assignees
+- unmapped actor warnings behave correctly
+
+For **v3 mode**:
+
+- structured actor refs import correctly
+- structured actor refs export correctly
+- raw provider payloads remain optional and non-canonical
+
+## End-to-end verification matrix
+
+At minimum, verify these combinations:
+
+| Core | GitHub plugin | Forgejo plugin | UI | Expected result |
+| --- | --- | --- | --- | --- |
+| new | old v2 | old v2 | old | works through compatibility shims |
+| new | new v3 | old v2 | old | mixed provider compatibility works |
+| new | old v2 | new v3 | new | mixed provider compatibility works |
+| new | new v3 | new v3 | new | full target state works |
+
+Also verify:
+
+- migrated dataset with no integrations
+- migrated dataset with GitHub only
+- migrated dataset with Forgejo only
+- migrated dataset with both bindings present
+
+## Operational observability
+
+During rollout, add or preserve diagnostics for:
+
+- migration start, completion, and failure
+- number of actors created during migration
+- number of mappings auto-created during pull
+- skipped unmapped outbound assignees
+- pending approval counts for imported content
+- provider API version loaded per binding/provider
+
+## Rollback strategy
+
+## Core rollback
+
+Because storage migration moves the canonical schema forward, core rollback must be handled carefully.
+
+### Recommended policy
+
+- before first migrated startup, create a backup or snapshot of local data
+- if migration fails before commit, stay on old version or fix migration and retry
+- if migration succeeds and writes new schema, rolling back to an older core build may not be supported
+
+This should be documented clearly in release notes.
+
+## Plugin rollback
+
+Plugin rollback should be easy during the compatibility window.
+
+Examples:
+
+- new core + old v2 plugin should still work
+- new core + reverted `todu-pi-extensions` should continue to function via compatibility paths where supported
+
+## Rollback of v3 providers
+
+If a v3 provider release regresses:
+
+- revert the plugin to the last known good version
+- keep core on compatibility mode supporting both v2 and v3
+- do not rush legacy removal until both providers are stable
+
+## Task decomposition recommendation
+
+Recommended implementation task order inside the core repo:
+
+1. add actor types, storage fields, and validation scaffolding
+2. implement migration and migration tests
+3. implement runtime compatibility shims for provider v2
+4. add provider API v3 types and dual-version validation support
+5. update internal sync runtime to speak both contracts
+6. add approval metadata storage and enforcement plumbing
+7. add core CLI/Electron baseline support where applicable
+8. document compatibility and release notes
+
+Recommended downstream tasks:
+
+### `todu-pi-extensions`
+
+1. actor-aware task and note display
+2. project authorization editor
+3. actor management flows
+4. binding mapping and trust UI
+5. approval-needed views and commands
+
+### `todu-github-plugin`
+
+1. add v3 provider contract support
+2. migrate actor extraction and assignee export logic
+3. add v3 conformance tests
+
+### `todu-forgejo-plugin`
+
+1. add v3 provider contract support
+2. migrate actor extraction and assignee export logic
+3. add v3 conformance tests
+
+## Documentation requirements
+
+When implementation begins, update at least:
+
+- `docs/plans/multi-user-task-assignment.md`
+- `docs/plugin-sync-provider-api.md`
+- `docs/ARCHITECTURE.md` if compatibility or migration behavior becomes canonical architecture
+- any plugin author or UI docs impacted by new commands, settings, or trust/approval behavior
+
+## Exit condition
+
+This rollout is complete when:
+
+- actor-based storage is the only canonical storage model
+- both known sync providers use provider API v3
+- `todu-pi-extensions` is actor-native
+- approval metadata and trust behavior are working in practice
+- legacy provider v2 compatibility code has been removed

--- a/docs/plans/multi-user-task-assignment.md
+++ b/docs/plans/multi-user-task-assignment.md
@@ -1,0 +1,430 @@
+# Multi-user Task Assignment Model
+
+## Status
+
+Proposed design direction for `task-24a037dd`.
+
+See also:
+
+- `docs/plans/multi-user-task-assignment-rollout.md`
+
+## Summary
+
+This design keeps todu personal-first while supporting richer assignment, authorship, and integration sync.
+
+Core direction:
+
+- one catalog has one owner
+- the owner is also an actor in the catalog
+- actors are catalog-wide and may represent humans, bots, or service identities
+- tasks use multi-actor assignment
+- notes use single-actor authorship
+- projects control which actors may be assigned within that project
+- integrations map local actors to external identities per binding
+- imported content from unknown or untrusted actors requires explicit human approval before agent workflows may treat it as instructions
+
+## Goals
+
+This design should support:
+
+- a single owner using the same catalog on multiple machines
+- task assignment to humans and non-humans
+- note authorship as a first-class identity
+- plugin-first collaboration through systems like GitHub
+- graceful handling of partial or missing identity mappings
+- safe handling of imported prompt-like content
+
+## Non-goals
+
+This design does not try to add:
+
+- a native shared-catalog multi-user workspace model
+- multiple catalog owners
+- core authentication or account-management features
+- plugin-specific identity fields in the core actor model
+- project permissions beyond authorized assignee lists
+
+## Current state
+
+Today the model is string-based:
+
+- `Task.assignees: string[]`
+- `Note.author: string`
+- sync providers also exchange assignees and authors as strings
+- there is no first-class actor model in the catalog
+
+## Core design
+
+### Catalog ownership
+
+A catalog has exactly one owner.
+
+The owner is represented by a catalog-wide actor reference:
+
+```ts
+ownerActorId: ActorId
+```
+
+Ownership and assignment are separate concepts.
+
+### Actor model
+
+Actors are catalog-wide and reusable across projects and integrations.
+
+```ts
+interface Actor {
+  id: ActorId;
+  displayName: string;
+  archived?: boolean;
+}
+```
+
+Notes:
+
+- `displayName` is the editable human-facing label
+- no `kind` field in v1
+- no plugin-specific identity data in core
+- actors may represent people, bots, service accounts, or similar identities
+
+### Catalog storage
+
+The catalog document should store actors directly in v1.
+
+```ts
+actors: Actor[]
+ownerActorId: ActorId
+```
+
+A separate identity document is unnecessary unless the collection becomes large or contentious enough to justify splitting it out later.
+
+## Task and note model
+
+### Task assignment
+
+Task assignment answers:
+
+> who is working on this?
+
+It does not define a single execution owner.
+
+```ts
+assigneeActorIds: ActorId[]
+```
+
+Semantics:
+
+- empty list means no one is explicitly assigned
+- one actor is the common case
+- multiple actors are allowed
+- order has no semantic meaning
+- duplicates are not allowed
+- the catalog owner does not need to assign themselves before working on a task
+
+### Status interaction
+
+Status and assignment are independent.
+
+- `inprogress` means the catalog owner is actively working on the task
+- `waiting` means the catalog owner is waiting on someone or something else
+- a task may be `waiting` while still assigned to other actors
+
+### Note authorship
+
+Notes use actors too, but with single authorship.
+
+```ts
+authorActorId: ActorId
+```
+
+Rules:
+
+- every note has exactly one author
+- note authorship is separate from task assignment
+- notes do not get note-level assignee lists in v1
+
+## Project scoping
+
+Projects control who may be assigned within that project.
+
+```ts
+authorizedAssigneeActorIds: ActorId[]
+```
+
+Rules:
+
+- actors remain catalog-wide
+- the same actor may be authorized in many projects
+- task assignment may only use actors authorized for the task's project
+
+### Unauthorized existing assignees
+
+If an actor is removed from a project's authorized list:
+
+- existing task assignments remain
+- those assignees become stale or unauthorized for that project
+- new assignment edits must enforce project authorization
+- non-assignment edits like title or status changes should still work
+- UI should warn when removing an authorized actor who is still assigned on tasks
+
+## Integration model
+
+Collaboration is plugin-first and binding-scoped.
+
+A local actor may map to different external identities in different bindings.
+
+Current direction:
+
+- actor mappings live on `IntegrationBinding.options`
+- mappings are scoped per binding, not global per provider
+- mappings may also store trust metadata for imported content decisions
+
+Conceptual shape:
+
+```ts
+binding.options = {
+  actorMappings: [
+    {
+      actorId: "actor-erik",
+      externalAccountId: "12345",
+      externalLogin: "evcraddock",
+      trusted: true
+    }
+  ]
+}
+```
+
+## Sync behavior
+
+### Push behavior
+
+When pushing local tasks to an external system:
+
+- local tasks remain valid even if some assigned actors are not mapped in the binding
+- only mapped actors are included in outbound assignee data
+- unmapped actors are skipped
+- sync continues instead of failing the whole task push
+- sync surfaces a warning for skipped unmapped assignees
+
+For pushed notes/comments:
+
+- `authorActorId` remains the local source of truth
+- providers like GitHub will usually publish comments as the authenticated integration account
+- missing actor mappings should not block comment push
+
+### Pull behavior
+
+When pulling external tasks or comments into todu:
+
+- if an external author or assignee matches an existing binding mapping, reuse that actor
+- if no mapping exists, create a new local actor
+- persist the new mapping on that binding
+- pulled task assignees populate `assigneeActorIds`
+- pulled note/comment authors populate `authorActorId`
+- pulled task assignees should also be added to the project's `authorizedAssigneeActorIds` if missing
+- unknown external identities must never collapse to `ownerActorId`
+
+## Imported content trust and approval
+
+Imported content may contain prompt-injection or other unsafe instructions.
+
+Trust is evaluated per binding actor mapping.
+
+- mapped and trusted actor -> no explicit approval gate required
+- mapped but untrusted actor -> approval required
+- unknown actor -> approval required
+- auto-created mappings discovered during pull default to `trusted: false`
+
+Important nuance:
+
+- trusted means the explicit approval gate may be skipped
+- trusted does not mean imported content is universally safe or should be obeyed blindly
+
+### Approval model
+
+Approval is content-level, field-level, and revision-aware.
+
+```ts
+type ContentApprovalState = "notRequired" | "pendingApproval" | "approved";
+
+interface ImportedContentApproval {
+  state: ContentApprovalState;
+  sourceBindingId?: IntegrationBindingId;
+  sourceActorId?: ActorId;
+  sourceFingerprint?: string;
+  reviewedAt?: string;
+  reviewedByActorId?: ActorId;
+}
+```
+
+Rules:
+
+- applies to imported task descriptions and imported note/comment bodies
+- tracked separately per imported content field revision
+- local content defaults to `notRequired`
+- imported content from trusted mapped actors uses `notRequired`
+- imported content from unknown or untrusted actors uses `pendingApproval`
+- explicit human approval of the current revision sets `approved`
+- if imported content changes later, approval is re-evaluated using a fingerprint or equivalent revision signal
+- local edits do not auto-approve or auto-trust imported content
+- titles, labels, assignees, status, and similar structured fields are not part of this approval gate in v1
+
+### Approval storage
+
+Approval metadata should live next to the content it governs.
+
+- task description approval metadata belongs in `TaskDetailDocument`
+- note approval metadata belongs on each `Note`
+
+### Approval behavior
+
+If content is pending approval:
+
+- humans can still read it
+- humans can still manually work with it
+- sync continues normally
+- agent workflows must ignore it as trusted instructions until explicitly approved
+
+Approval must remain an explicit human action.
+
+## Sync-provider contract direction
+
+The provider boundary should move from string-based assignees and authors to normalized import/export payloads using structured external actor references.
+
+```ts
+interface ExternalActorRef {
+  externalAccountId?: string;
+  externalLogin?: string;
+  displayName?: string;
+  raw?: unknown;
+}
+
+interface ImportedTaskInput {
+  externalId: string;
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  labels?: string[];
+  assignees?: ExternalActorRef[];
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface ImportedCommentInput {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: ExternalActorRef;
+  createdAt: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface ExportedCommentInput {
+  localNoteId: NoteId;
+  body: string;
+  createdAt: string;
+  updatedAt?: string;
+  sourceUrl?: string;
+}
+
+interface ExportedTaskInput {
+  localTaskId: TaskId;
+  externalId?: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  labels: string[];
+  assignees: ExternalActorRef[];
+  sourceUrl?: string;
+  comments: ExportedCommentInput[];
+}
+```
+
+Direction:
+
+- providers do not consume or return local `ActorId`s
+- providers normalize provider-specific fields and extract external identity data
+- runtime resolves and creates local actors
+- runtime updates binding mappings
+- runtime computes approval state
+- runtime prepares outbound external actor refs from local `assigneeActorIds`
+
+This replaces the current tightly coupled `mapToTask(...)` and `mapFromTask(...)` style.
+
+## Migration
+
+Migration should unify legacy task assignees and note authors into the new actor model.
+
+Steps:
+
+1. Add catalog-wide `actors[]` and `ownerActorId`
+2. Scan all tasks for legacy `assignees: string[]`
+3. Scan all notes for legacy `author: string`
+4. Normalize names using `trim + lowercase`
+5. Create one actor per unique normalized name across the catalog
+6. Preserve a human-facing `displayName` from the first seen non-magic value
+7. Rewrite task assignees to `assigneeActorIds`
+8. Rewrite note authors to required `authorActorId`
+9. Backfill each project's `authorizedAssigneeActorIds` from assigned actors in that project plus `ownerActorId`
+
+Rules:
+
+- use one shared normalization rule for tasks and notes
+- legacy note author `"user"` maps to `ownerActorId`
+- missing or empty note authors map to `ownerActorId`
+- if legacy task assignees contain `"user"`, map that to `ownerActorId`
+- case-insensitive merging is considered safe for the known current data set
+- this is a migration rule, not necessarily a permanent future import rule
+
+Examples:
+
+- `"erik "` and `"erik"` become the same actor
+- `"Erik"` and `"erik"` become the same actor
+- note author `"user"` becomes `ownerActorId`
+- note with no author becomes `ownerActorId`
+
+## UX direction
+
+The same core workflows should exist in Electron and CLI.
+
+Electron should provide richer discovery. CLI should provide explicit command-driven control.
+
+### Electron surfaces
+
+- global actors list
+- project authorized assignee editor
+- task assignee picker
+- integration binding actor-mapping screen with trust controls
+- approval-needed list/filter plus detail badges or banners
+
+### CLI surfaces
+
+- `todu actor list|create|rename|archive|unarchive`
+- `todu project actors list|add|remove <project> ...`
+- `todu task assign add|remove|set <task> ...`
+- `todu integration actor-mapping list|set|trust|untrust <binding> ...`
+- `todu approval list|show|approve ...`
+
+### UX rules
+
+- actor management should stay lightweight
+- actor creation should be primarily project-driven, with inline creation while managing project authorization
+- archived actors remain visible in historical data and existing assignments, but are not offered for new assignment
+- binding mapping screens should show local actor, external identity, and trust state
+- approval-needed indicators should be visible but non-blocking for normal human work
+- skipped unmapped assignees should appear as binding-scoped warnings, with task-specific detail where possible
+
+## Implementation checklist
+
+1. Add actor types and catalog storage
+2. Add task assignment and note authorship schema changes
+3. Add project authorized assignee lists
+4. Add binding-scoped actor mappings and trust flags
+5. Add imported content approval metadata to task descriptions and notes
+6. Redesign sync-provider contracts around normalized import/export payloads
+7. Implement migration from legacy string assignees and authors
+8. Add CLI and Electron flows for actor management, assignment, mapping, trust, and approval


### PR DESCRIPTION
## Summary
- add the finalized multi-user task assignment design note
- add the rollout plan covering staged delivery and compatibility
- link the design and rollout docs for follow-on implementation work

## Testing
- not run (docs only)