### PR TITLE
feat: migrate legacy actor identities

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,7 @@ daemon(A) <--> relay <--> daemon(B) <--> relay <--> daemon(C)
 - All clients/daemons for the same dataset should converge on the same catalog ID and referenced sub-document graph.
 - The catalog stores small shared metadata including projects, labels, actors, owner identity, habits, recurring templates, and references to heavier sub-documents.
 - Projects carry authorized-assignee actor ids, tasks carry actor assignment metadata, and notes carry actor authorship metadata as the assignment model evolves.
+- Legacy string assignees and note authors are migrated to actor ids during persistent catalog load before the catalog schema version is advanced.
 
 ### Notes storage partitioning
 

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -13,7 +13,7 @@ import { createIntegrationBindingId, createProjectId } from "./types.js";
 
 describe("schema", () => {
   it("exports schema version", () => {
-    expect(SCHEMA_VERSION).toBe(1);
+    expect(SCHEMA_VERSION).toBe(2);
   });
 
   describe("createEmptyCatalog", () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -154,7 +154,7 @@ export interface HabitLogDocument {
 // Schema version
 // ============================================================================
 
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 export const DEFAULT_OWNER_ACTOR_ID = createActorId("actor-user");
 
 // ============================================================================

--- a/packages/engine/src/index.integration.test.ts
+++ b/packages/engine/src/index.integration.test.ts
@@ -192,6 +192,6 @@ describe("createTodu", () => {
     expect(migratedCatalog.integrationStatusDocIds).toEqual({});
     expect(migratedCatalog.recurringTemplates).toEqual([]);
     expect(migratedCatalog.habits).toEqual([]);
-    expect(migratedCatalog.settings.schemaVersion).toBe(1);
+    expect(migratedCatalog.settings.schemaVersion).toBe(2);
   });
 });

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -37,6 +37,56 @@ async function readCatalogDocument(storagePath: string): Promise<CatalogDocument
   }
 }
 
+async function seedLegacyNoteIdentityData(
+  storagePath: string,
+  legacyAuthorsByNoteId: Record<string, string | null | undefined>,
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim() as DocumentId;
+
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    catalogHandle.change((doc) => {
+      doc.version = 1;
+      doc.settings.schemaVersion = 1;
+      doc.actors.splice(0, doc.actors.length, {
+        id: DEFAULT_OWNER_ACTOR_ID,
+        displayName: "user",
+      });
+      doc.ownerActorId = DEFAULT_OWNER_ACTOR_ID;
+    });
+
+    const bucketDocIds = Object.values(catalogHandle.doc()?.notesBucketDocIds ?? {});
+    for (const docId of bucketDocIds) {
+      const notesHandle = await repo.find(docId as DocumentId);
+      await notesHandle.whenReady();
+      notesHandle.change((doc) => {
+        for (const note of doc.notes as Array<Note & { author?: string; authorActorId?: string }>) {
+          if (!(note.id in legacyAuthorsByNoteId)) continue;
+          delete note.authorActorId;
+          const legacyAuthor = legacyAuthorsByNoteId[note.id];
+          if (legacyAuthor === undefined) {
+            delete note.author;
+          } else if (legacyAuthor === null) {
+            note.author = "";
+          } else {
+            note.author = legacyAuthor;
+          }
+        }
+      });
+    }
+
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
 describe("note namespace", () => {
   let tmpDir: string;
   let todu: Todu;
@@ -206,6 +256,56 @@ describe("note namespace", () => {
       expect(result.value).toHaveLength(2);
       expect(result.value[0].content).toBe("Second");
       expect(result.value[1].content).toBe("First");
+    });
+
+    it("migrates legacy note authors into actor ids and reuses normalized actors across restarts", async () => {
+      const first = await todu.note.create({ content: "First note" });
+      const second = await todu.note.create({ content: "Second note" });
+      const third = await todu.note.create({ content: "Third note" });
+      if (!first.ok || !second.ok || !third.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedLegacyNoteIdentityData(tmpDir, {
+        [first.value.id]: " Alice ",
+        [second.value.id]: "",
+        [third.value.id]: undefined,
+      });
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.note.list();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const migratedFirst = result.value.find((note) => note.id === first.value.id);
+      const migratedSecond = result.value.find((note) => note.id === second.value.id);
+      const migratedThird = result.value.find((note) => note.id === third.value.id);
+      expect(migratedFirst?.authorActorId).toEqual(expect.any(String));
+      expect(migratedFirst?.authorActorId).not.toBe(DEFAULT_OWNER_ACTOR_ID);
+      expect(migratedSecond?.authorActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
+      expect(migratedThird?.authorActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const catalog = await readCatalogDocument(tmpDir);
+      expect(catalog.version).toBe(2);
+      expect(catalog.settings.schemaVersion).toBe(2);
+      expect(catalog.actors).toEqual([
+        { id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" },
+        { id: migratedFirst?.authorActorId, displayName: "Alice" },
+      ]);
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const afterRestart = await todu.note.list();
+      expect(afterRestart.ok).toBe(true);
+      if (!afterRestart.ok) return;
+      expect(afterRestart.value.find((note) => note.id === first.value.id)?.authorActorId).toBe(
+        migratedFirst?.authorActorId,
+      );
     });
 
     it("filters by entityType", async () => {

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -659,7 +659,13 @@ async function migrateLegacyTaskAssignments(
           task.assignees = [];
         }
 
-        if (task.assigneeActorIds.length === 0 && task.assignees.length > 0) {
+        const hasMissingActorReferences = task.assigneeActorIds.some(
+          (actorId) => !registry.actorIds.has(actorId),
+        );
+        if (
+          task.assignees.length > 0 &&
+          (task.assigneeActorIds.length === 0 || hasMissingActorReferences)
+        ) {
           const migratedActorIds = migrateLegacyAssigneeActorIds(registry, task.assignees);
           task.assigneeActorIds.splice(0, task.assigneeActorIds.length, ...migratedActorIds);
         }
@@ -756,7 +762,11 @@ async function migrateLegacyNotes(
     await handle.whenReady();
     handle.change((doc) => {
       for (const note of doc.notes as MutableLegacyNote[]) {
-        if (note.authorActorId === undefined || note.authorActorId === null) {
+        const hasMissingAuthorActor =
+          note.authorActorId === undefined ||
+          note.authorActorId === null ||
+          !registry.actorIds.has(note.authorActorId);
+        if (hasMissingAuthorActor) {
           note.authorActorId = createActorId(resolveLegacyActorId(registry, note.author));
         }
         if (note.author === undefined || note.author === null || note.author.trim() === "") {

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -1,13 +1,21 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DocHandle, DocumentId } from "@automerge/automerge-repo/slim";
 import { Repo } from "@automerge/automerge-repo/slim";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
+  type Actor,
   CATALOG_DOC_KEY,
   type CatalogDocument,
+  createActorId,
   createEmptyCatalog,
+  createNotesDocument,
+  DEFAULT_OWNER_ACTOR_ID,
+  type Note,
+  type NotesDocument,
   SCHEMA_VERSION,
+  type TaskListDocument,
 } from "@todu/core";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 
@@ -21,6 +29,137 @@ const SYNC_THROTTLE_MS = 100;
 const SYNC_DELIVERY_MS = 20;
 /** Catalog load timeout for startup and join checks */
 const CATALOG_LOAD_TIMEOUT_MS = 10_000;
+
+type MutableLegacyTask = TaskListDocument["tasks"][number] & {
+  labels?: string[];
+  assigneeActorIds?: string[];
+  assignees?: string[];
+};
+
+type MutableLegacyNote = Note & {
+  author?: string;
+  authorActorId?: string;
+};
+
+interface LegacyActorRegistry {
+  ownerActorId: string;
+  actorIds: Set<string>;
+  normalizedNameToActorId: Map<string, string>;
+  newActors: Actor[];
+}
+
+function normalizeLegacyActorName(name: string | null | undefined): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.toLowerCase();
+}
+
+function createStableLegacyActorId(normalizedName: string, existingActorIds: Set<string>): string {
+  const hash = crypto.createHash("sha1").update(normalizedName).digest("hex");
+  let candidate = `actor-legacy-${hash}`;
+  let suffix = 1;
+
+  while (existingActorIds.has(candidate)) {
+    candidate = `actor-legacy-${hash}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function noteBucketKeyForNote(note: Note): string {
+  if (note.entityType && note.entityId) {
+    return `entity:${note.entityType}:${note.entityId}`;
+  }
+
+  return `journal:${note.createdAt.slice(0, 7)}`;
+}
+
+function cloneNote(note: MutableLegacyNote): Note {
+  const cloned: Note = {
+    id: note.id,
+    content: note.content,
+    author: note.author ?? "user",
+    tags: [...(note.tags ?? [])],
+    createdAt: note.createdAt,
+  };
+
+  if (note.authorActorId !== undefined) {
+    cloned.authorActorId = createActorId(note.authorActorId);
+  }
+  if (note.entityType !== undefined) cloned.entityType = note.entityType;
+  if (note.entityId !== undefined) cloned.entityId = note.entityId;
+
+  return cloned;
+}
+
+function buildLegacyActorRegistry(doc: CatalogDocument): LegacyActorRegistry {
+  const ownerActorId = doc.ownerActorId ?? DEFAULT_OWNER_ACTOR_ID;
+  const actorIds = new Set<string>();
+  const normalizedNameToActorId = new Map<string, string>();
+
+  for (const actor of doc.actors ?? []) {
+    actorIds.add(actor.id);
+    const normalizedName = normalizeLegacyActorName(actor.displayName);
+    if (normalizedName && !normalizedNameToActorId.has(normalizedName)) {
+      normalizedNameToActorId.set(normalizedName, actor.id);
+    }
+  }
+
+  actorIds.add(ownerActorId);
+  normalizedNameToActorId.set("user", ownerActorId);
+
+  return {
+    ownerActorId,
+    actorIds,
+    normalizedNameToActorId,
+    newActors: [],
+  };
+}
+
+function resolveLegacyActorId(
+  registry: LegacyActorRegistry,
+  rawName: string | null | undefined,
+): string {
+  const normalizedName = normalizeLegacyActorName(rawName);
+  if (!normalizedName || normalizedName === "user") {
+    return registry.ownerActorId;
+  }
+
+  const existingActorId = registry.normalizedNameToActorId.get(normalizedName);
+  if (existingActorId) {
+    return existingActorId;
+  }
+
+  const actorId = createStableLegacyActorId(normalizedName, registry.actorIds);
+  const displayName = rawName?.trim() || normalizedName;
+  registry.actorIds.add(actorId);
+  registry.normalizedNameToActorId.set(normalizedName, actorId);
+  registry.newActors.push({ id: createActorId(actorId), displayName });
+  return actorId;
+}
+
+function migrateLegacyAssigneeActorIds(
+  registry: LegacyActorRegistry,
+  legacyAssignees: readonly string[] | null | undefined,
+): string[] {
+  const actorIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const assignee of legacyAssignees ?? []) {
+    const actorId = resolveLegacyActorId(registry, assignee);
+    if (!seen.has(actorId)) {
+      seen.add(actorId);
+      actorIds.push(actorId);
+    }
+  }
+
+  return actorIds;
+}
 
 /**
  * Wait for pending sync messages to be generated and delivered.
@@ -343,6 +482,7 @@ async function loadCatalogById(
       signal: AbortSignal.timeout(CATALOG_LOAD_TIMEOUT_MS),
     });
     migrateCatalog(handle);
+    await migrateLegacyIdentityModel(handle, repo);
     return handle;
   } catch {
     throw new Error(
@@ -406,6 +546,9 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
     needsMigration = true;
   if (doc.settings === undefined || doc.settings === null) needsMigration = true;
   if (doc.version === undefined || doc.version === null) needsMigration = true;
+  if (doc.settings?.schemaVersion === undefined || doc.settings?.schemaVersion === null) {
+    needsMigration = true;
+  }
   if (doc.projects?.some((project) => project.authorizedAssigneeActorIds === undefined)) {
     needsMigration = true;
   }
@@ -431,8 +574,12 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
       d.noteBucketByNoteId = defaults.noteBucketByNoteId;
     if (d.integrationStatusDocIds === undefined || d.integrationStatusDocIds === null)
       d.integrationStatusDocIds = defaults.integrationStatusDocIds;
-    if (d.settings === undefined || d.settings === null) d.settings = defaults.settings;
-    if (d.version === undefined || d.version === null) d.version = SCHEMA_VERSION;
+    if (d.settings === undefined || d.settings === null) {
+      d.settings = { schemaVersion: d.version ?? 1 };
+    } else if (d.settings.schemaVersion === undefined || d.settings.schemaVersion === null) {
+      d.settings.schemaVersion = d.version ?? 1;
+    }
+    if (d.version === undefined || d.version === null) d.version = 1;
     for (const project of d.projects) {
       if (
         project.authorizedAssigneeActorIds === undefined ||
@@ -442,4 +589,186 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
       }
     }
   });
+}
+
+async function migrateLegacyIdentityModel(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+): Promise<void> {
+  const catalogDoc = catalog.doc();
+  if (!catalogDoc) return;
+
+  const currentSchemaVersion = catalogDoc.settings?.schemaVersion ?? catalogDoc.version ?? 1;
+  if (currentSchemaVersion >= SCHEMA_VERSION) return;
+
+  const registry = buildLegacyActorRegistry(catalogDoc);
+  const projectAssignedActorIds = await migrateLegacyTaskAssignments(catalog, repo, registry);
+  await migrateLegacyNotes(catalog, repo, registry);
+
+  catalog.change((doc) => {
+    if (registry.newActors.length > 0) {
+      doc.actors.push(...registry.newActors);
+    }
+
+    for (const project of doc.projects) {
+      const nextAuthorizedActorIds = new Set<string>(project.authorizedAssigneeActorIds ?? []);
+      nextAuthorizedActorIds.add(registry.ownerActorId);
+      for (const actorId of projectAssignedActorIds.get(project.id) ?? []) {
+        nextAuthorizedActorIds.add(actorId);
+      }
+
+      const nextAuthorized = [...nextAuthorizedActorIds];
+      if (!arraysEqual(project.authorizedAssigneeActorIds ?? [], nextAuthorized)) {
+        project.authorizedAssigneeActorIds.splice(
+          0,
+          project.authorizedAssigneeActorIds.length,
+          ...nextAuthorized.map((actorId) => createActorId(actorId)),
+        );
+      }
+    }
+
+    doc.version = SCHEMA_VERSION;
+    doc.settings.schemaVersion = SCHEMA_VERSION;
+  });
+}
+
+async function migrateLegacyTaskAssignments(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+  registry: LegacyActorRegistry,
+): Promise<Map<string, Set<string>>> {
+  const projectAssignedActorIds = new Map<string, Set<string>>();
+  const catalogDoc = catalog.doc();
+  if (!catalogDoc) return projectAssignedActorIds;
+
+  for (const [projectId, docId] of Object.entries(catalogDoc.taskListDocIds ?? {})) {
+    const handle = await repo.find<TaskListDocument>(docId as DocumentId);
+    await handle.whenReady();
+    const taskListDoc = handle.doc();
+    if (!taskListDoc) continue;
+
+    handle.change((doc) => {
+      for (const task of doc.tasks as MutableLegacyTask[]) {
+        if (task.labels === undefined || task.labels === null) {
+          task.labels = [];
+        }
+        if (task.assigneeActorIds === undefined || task.assigneeActorIds === null) {
+          task.assigneeActorIds = [];
+        }
+        if (task.assignees === undefined || task.assignees === null) {
+          task.assignees = [];
+        }
+
+        if (task.assigneeActorIds.length === 0 && task.assignees.length > 0) {
+          const migratedActorIds = migrateLegacyAssigneeActorIds(registry, task.assignees);
+          task.assigneeActorIds.splice(0, task.assigneeActorIds.length, ...migratedActorIds);
+        }
+
+        let assigned = projectAssignedActorIds.get(projectId);
+        if (!assigned) {
+          assigned = new Set<string>();
+          projectAssignedActorIds.set(projectId, assigned);
+        }
+        for (const actorId of task.assigneeActorIds) {
+          assigned.add(actorId);
+        }
+      }
+    });
+  }
+
+  return projectAssignedActorIds;
+}
+
+async function migrateLegacyNotes(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+  registry: LegacyActorRegistry,
+): Promise<void> {
+  const catalogDoc = catalog.doc();
+  if (!catalogDoc) return;
+
+  if (catalogDoc.notesBucketDocIds === undefined || catalogDoc.notesBucketDocIds === null) {
+    catalog.change((doc) => {
+      doc.notesBucketDocIds = {};
+    });
+  }
+  if (catalogDoc.noteBucketByNoteId === undefined || catalogDoc.noteBucketByNoteId === null) {
+    catalog.change((doc) => {
+      doc.noteBucketByNoteId = {};
+    });
+  }
+
+  if (catalogDoc.notesDocId) {
+    const legacyHandle = await repo.find<NotesDocument>(catalogDoc.notesDocId as DocumentId);
+    await legacyHandle.whenReady();
+    const legacyNotes = (legacyHandle.doc()?.notes ?? []).map((note) => cloneNote(note));
+
+    const notesByBucket = new Map<string, Note[]>();
+    for (const note of legacyNotes) {
+      const bucketKey = noteBucketKeyForNote(note);
+      const bucketNotes = notesByBucket.get(bucketKey);
+      if (bucketNotes) {
+        bucketNotes.push(note);
+      } else {
+        notesByBucket.set(bucketKey, [note]);
+      }
+    }
+
+    for (const [bucketKey, notes] of notesByBucket) {
+      const existingBucketId = catalog.doc()?.notesBucketDocIds?.[bucketKey];
+      const bucketHandle = existingBucketId
+        ? await repo.find<NotesDocument>(existingBucketId as DocumentId)
+        : repo.create<NotesDocument>();
+      await bucketHandle.whenReady();
+      if (!existingBucketId) {
+        const empty = createNotesDocument();
+        bucketHandle.change((doc) => {
+          doc.notes = empty.notes;
+        });
+        catalog.change((doc) => {
+          doc.notesBucketDocIds[bucketKey] = bucketHandle.documentId;
+        });
+      }
+
+      bucketHandle.change((doc) => {
+        const existingIds = new Set(doc.notes.map((note) => note.id));
+        for (const note of notes) {
+          if (!existingIds.has(note.id)) {
+            doc.notes.push(note);
+            existingIds.add(note.id);
+          }
+        }
+      });
+    }
+
+    catalog.change((doc) => {
+      delete doc.notesDocId;
+      doc.noteBucketByNoteId = {};
+    });
+
+    legacyHandle.change((doc) => {
+      doc.notes.splice(0, doc.notes.length);
+    });
+  }
+
+  for (const docId of Object.values(catalog.doc()?.notesBucketDocIds ?? {})) {
+    const handle = await repo.find<NotesDocument>(docId as DocumentId);
+    await handle.whenReady();
+    handle.change((doc) => {
+      for (const note of doc.notes as MutableLegacyNote[]) {
+        if (note.authorActorId === undefined || note.authorActorId === null) {
+          note.authorActorId = createActorId(resolveLegacyActorId(registry, note.author));
+        }
+        if (note.author === undefined || note.author === null || note.author.trim() === "") {
+          note.author = "user";
+        }
+      }
+    });
+  }
+
+  if (Object.keys(catalog.doc()?.noteBucketByNoteId ?? {}).length > 0) {
+    catalog.change((doc) => {
+      doc.noteBucketByNoteId = {};
+    });
+  }
 }

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -4,10 +4,28 @@ import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
-import { createActorId, createProjectId, createTaskId } from "@todu/core";
+import { createActorId, createProjectId, createTaskId, DEFAULT_OWNER_ACTOR_ID } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
+
+async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    const catalogDoc = catalogHandle.doc();
+    if (!catalogDoc) throw new Error("catalog document not available");
+    return JSON.parse(JSON.stringify(catalogDoc)) as CatalogDocument;
+  } finally {
+    await repo.shutdown();
+  }
+}
 
 async function removeTaskArrays(
   storagePath: string,
@@ -42,6 +60,86 @@ async function removeTaskArrays(
       delete legacyTask.assigneeActorIds;
       delete legacyTask.assignees;
     });
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
+async function addCatalogActor(
+  storagePath: string,
+  actorId: string,
+  displayName: string,
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    catalogHandle.change((doc) => {
+      if (doc.actors.some((actor) => actor.id === actorId)) return;
+      doc.actors.push({ id: createActorId(actorId), displayName });
+    });
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
+async function seedLegacyTaskIdentityData(
+  storagePath: string,
+  projectId: ProjectId,
+  legacyAssigneesByTaskId: Record<string, string[]>,
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    catalogHandle.change((doc) => {
+      doc.version = 1;
+      doc.settings.schemaVersion = 1;
+      doc.actors.splice(0, doc.actors.length, {
+        id: DEFAULT_OWNER_ACTOR_ID,
+        displayName: "user",
+      });
+      doc.ownerActorId = DEFAULT_OWNER_ACTOR_ID;
+
+      const project = doc.projects.find((entry) => entry.id === projectId);
+      if (!project) throw new Error(`project not found: ${projectId}`);
+      project.authorizedAssigneeActorIds.splice(
+        0,
+        project.authorizedAssigneeActorIds.length,
+        DEFAULT_OWNER_ACTOR_ID,
+      );
+    });
+
+    const taskListDocId = catalogHandle.doc()?.taskListDocIds[projectId];
+    if (!taskListDocId) {
+      throw new Error(`task list not found for project ${projectId}`);
+    }
+
+    const taskListHandle = await repo.find<TaskListDocument>(taskListDocId);
+    await taskListHandle.whenReady();
+    taskListHandle.change((doc) => {
+      for (const task of doc.tasks as Array<
+        Task & { assigneeActorIds?: string[]; assignees?: string[] }
+      >) {
+        const legacyAssignees = legacyAssigneesByTaskId[task.id];
+        if (!legacyAssignees) continue;
+        delete task.assigneeActorIds;
+        task.assignees = [...legacyAssignees];
+      }
+    });
+
     await repo.flush();
   } finally {
     await repo.shutdown();
@@ -125,10 +223,15 @@ describe("task namespace", () => {
     });
 
     it("rejects unauthorized assignee actor ids", async () => {
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      await addCatalogActor(tmpDir, "actor-other", "Other");
+      todu = await createTodu({ storagePath: tmpDir });
+
       const result = await todu.task.create({
         title: "Actor-assigned task",
         projectId,
-        assigneeActorIds: [createActorId("actor-user")],
+        assigneeActorIds: [createActorId("actor-other")],
       });
       expect(result.ok).toBe(false);
       if (result.ok) return;
@@ -261,6 +364,65 @@ describe("task namespace", () => {
       expect(result.value[0].labels).toEqual([]);
       expect(result.value[0].assigneeActorIds).toEqual([]);
       expect(result.value[0].assignees).toEqual([]);
+    });
+
+    it("migrates legacy assignees into actor ids and backfills project authorization", async () => {
+      const first = await todu.task.create({ title: "First legacy", projectId });
+      const second = await todu.task.create({ title: "Second legacy", projectId });
+      if (!first.ok || !second.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedLegacyTaskIdentityData(tmpDir, projectId, {
+        [first.value.id]: [" Alice ", "user", "alice"],
+        [second.value.id]: ["BOB"],
+      });
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.task.list({ projectId });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const firstTask = result.value.find((task) => task.id === first.value.id);
+      const secondTask = result.value.find((task) => task.id === second.value.id);
+      expect(firstTask?.assigneeActorIds).toHaveLength(2);
+      expect(firstTask?.assigneeActorIds[0]).toEqual(expect.any(String));
+      expect(firstTask?.assigneeActorIds[0]).not.toBe(DEFAULT_OWNER_ACTOR_ID);
+      expect(firstTask?.assigneeActorIds[1]).toBe(DEFAULT_OWNER_ACTOR_ID);
+      expect(secondTask?.assigneeActorIds).toEqual([expect.any(String)]);
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const catalog = await readCatalogDocument(tmpDir);
+      expect(catalog.version).toBe(2);
+      expect(catalog.settings.schemaVersion).toBe(2);
+      expect(catalog.actors).toEqual([
+        { id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" },
+        { id: firstTask?.assigneeActorIds[0], displayName: "Alice" },
+        { id: secondTask?.assigneeActorIds[0], displayName: "BOB" },
+      ]);
+
+      const project = catalog.projects.find((entry) => entry.id === projectId);
+      expect(project?.authorizedAssigneeActorIds).toEqual([
+        DEFAULT_OWNER_ACTOR_ID,
+        firstTask?.assigneeActorIds[0],
+        secondTask?.assigneeActorIds[0],
+      ]);
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const afterRestart = await todu.task.list({ projectId });
+      expect(afterRestart.ok).toBe(true);
+      if (!afterRestart.ok) return;
+      expect(
+        afterRestart.value.find((task) => task.id === first.value.id)?.assigneeActorIds,
+      ).toEqual(firstTask?.assigneeActorIds);
+      expect(
+        afterRestart.value.find((task) => task.id === second.value.id)?.assigneeActorIds,
+      ).toEqual(secondTask?.assigneeActorIds);
     });
 
     it("filters by status", async () => {
@@ -639,8 +801,13 @@ describe("task namespace", () => {
     });
 
     it("rejects unauthorized assignee actor id updates", async () => {
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+      await addCatalogActor(tmpDir, "actor-other", "Other");
+      todu = await createTodu({ storagePath: tmpDir });
+
       const result = await todu.task.update(taskId, {
-        assigneeActorIds: [createActorId("actor-user")],
+        assigneeActorIds: [createActorId("actor-other")],
       });
       expect(result.ok).toBe(false);
       if (result.ok) return;

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -146,6 +146,54 @@ async function seedLegacyTaskIdentityData(
   }
 }
 
+async function seedPartiallyMigratedTaskIdentityData(
+  storagePath: string,
+  projectId: ProjectId,
+  taskId: TaskId,
+  assigneeActorIds: string[],
+  assignees: string[],
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    catalogHandle.change((doc) => {
+      doc.version = 1;
+      doc.settings.schemaVersion = 1;
+      doc.actors.splice(0, doc.actors.length, {
+        id: DEFAULT_OWNER_ACTOR_ID,
+        displayName: "user",
+      });
+      doc.ownerActorId = DEFAULT_OWNER_ACTOR_ID;
+    });
+
+    const taskListDocId = catalogHandle.doc()?.taskListDocIds[projectId];
+    if (!taskListDocId) {
+      throw new Error(`task list not found for project ${projectId}`);
+    }
+
+    const taskListHandle = await repo.find<TaskListDocument>(taskListDocId);
+    await taskListHandle.whenReady();
+    taskListHandle.change((doc) => {
+      const task = doc.tasks.find((entry) => entry.id === taskId) as
+        | (Task & { assigneeActorIds?: string[]; assignees?: string[] })
+        | undefined;
+      if (!task) throw new Error(`task not found: ${taskId}`);
+      task.assigneeActorIds = [...assigneeActorIds];
+      task.assignees = [...assignees];
+    });
+
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
 describe("task namespace", () => {
   let tmpDir: string;
   let todu: Todu;
@@ -423,6 +471,42 @@ describe("task namespace", () => {
       expect(
         afterRestart.value.find((task) => task.id === second.value.id)?.assigneeActorIds,
       ).toEqual(secondTask?.assigneeActorIds);
+    });
+
+    it("repairs partially migrated task assignees on retry", async () => {
+      const created = await todu.task.create({ title: "Retry legacy", projectId });
+      if (!created.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedPartiallyMigratedTaskIdentityData(
+        tmpDir,
+        projectId,
+        created.value.id,
+        ["actor-legacy-broken"],
+        ["Alice"],
+      );
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.task.list({ projectId });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const repairedTask = result.value.find((task) => task.id === created.value.id);
+      expect(repairedTask?.assigneeActorIds).toEqual([expect.any(String)]);
+      expect(repairedTask?.assigneeActorIds?.[0]).not.toBe("actor-legacy-broken");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const catalog = await readCatalogDocument(tmpDir);
+      expect(catalog.version).toBe(2);
+      expect(catalog.actors).toContainEqual({
+        id: repairedTask?.assigneeActorIds?.[0],
+        displayName: "Alice",
+      });
     });
 
     it("filters by status", async () => {


### PR DESCRIPTION
## Summary
- add a one-time load migration from legacy task assignee strings and note author strings to actor ids
- backfill catalog actors and project authorized assignee lists during migration
- add migration and restart coverage for legacy identity data

## Testing
- make pre-pr