### PR TITLE
feat: add trust and approval metadata

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,8 @@ daemon(A) <--> relay <--> daemon(B) <--> relay <--> daemon(C)
 - All clients/daemons for the same dataset should converge on the same catalog ID and referenced sub-document graph.
 - The catalog stores small shared metadata including projects, labels, actors, owner identity, habits, recurring templates, and references to heavier sub-documents.
 - Projects carry authorized-assignee actor ids, tasks carry actor assignment metadata, and notes carry actor authorship metadata as the assignment model evolves.
+- Integration bindings may also carry binding-scoped actor mappings and trust flags in `binding.options.actorMappings`.
+- Task descriptions and note bodies persist imported-content approval metadata beside the governed content so later runtime paths can recompute approval by binding, actor, and content fingerprint.
 - Legacy string assignees and note authors are migrated to actor ids during persistent catalog load before the catalog schema version is advanced.
 
 ### Notes storage partitioning

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -80,6 +80,12 @@ To keep the first version simple and avoid overlapping control planes:
 
 Provider-specific desired-state options may live in `binding.options`, but only as plain JSON configuration needed to express shared user intent. Do not use `binding.options` for plugin internals.
 
+For the actor-assignment rollout, binding-scoped actor mappings belong here as shared desired state:
+
+- `binding.options.actorMappings[].actorId`
+- external identity fields such as `externalAccountId`, `externalLogin`, and `displayName`
+- binding-scoped trust metadata such as `trusted`
+
 The following remain outside synced core entities:
 
 - credentials and tokens

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -10,6 +10,8 @@ For generic daemon worker plugins, see `docs/worker-plugin-api.md`.
 
 This document defines the provider execution contract. Shared integration binding desired state is a separate architecture concern owned by core and documented in `docs/architecture/integrations.md`.
 
+Core-owned imported-content approval metadata also remains outside provider-managed state. Task description approval metadata lives with `TaskDetailDocument`, note/comment approval metadata lives with `Note`, and later runtime work is responsible for deriving approval from binding identity, actor identity, and content fingerprint.
+
 ## Relationship to generic integration architecture
 
 Provider plugins should not own the canonical cross-device integration binding registry for projects and external targets.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_OWNER_ACTOR_ID,
   SCHEMA_VERSION,
 } from "./schema.js";
-import { createIntegrationBindingId, createProjectId } from "./types.js";
+import { createActorId, createIntegrationBindingId, createProjectId } from "./types.js";
 
 describe("schema", () => {
   it("exports schema version", () => {
@@ -76,9 +76,16 @@ describe("schema", () => {
 
   describe("createTaskDetailDocument", () => {
     it("creates a detail document", () => {
-      const doc = createTaskDetailDocument("task-123", "Some description");
+      const doc = createTaskDetailDocument("task-123", "Some description", {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-1"),
+        sourceActorId: createActorId("actor-1"),
+        sourceFingerprint: "sha1:abc",
+      });
       expect(doc.taskId).toBe("task-123");
       expect(doc.description).toBe("Some description");
+      expect(doc.descriptionApproval?.state).toBe("pendingApproval");
+      expect(doc.descriptionApproval?.sourceBindingId).toBe("ibind-1");
     });
   });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -5,6 +5,7 @@ import {
   type Habit,
   type HabitEntry,
   type HabitId,
+  type ImportedContentApproval,
   type IntegrationBinding,
   type IntegrationBindingId,
   type IntegrationBindingStatus,
@@ -109,6 +110,9 @@ export interface TaskDetailDocument {
 
   /** Full task description (markdown) */
   description: string;
+
+  /** Imported-content approval metadata for the description revision. */
+  descriptionApproval?: ImportedContentApproval;
 }
 
 /**
@@ -189,10 +193,15 @@ export function createTaskListDocument(projectId: ProjectId): TaskListDocument {
   };
 }
 
-export function createTaskDetailDocument(taskId: string, description: string): TaskDetailDocument {
+export function createTaskDetailDocument(
+  taskId: string,
+  description: string,
+  descriptionApproval?: ImportedContentApproval,
+): TaskDetailDocument {
   return {
     taskId,
     description,
+    ...(descriptionApproval !== undefined ? { descriptionApproval } : {}),
   };
 }
 

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -19,6 +19,7 @@ import {
   createRecurringId,
   createTaskId,
   err,
+  isContentApprovalState,
   isIntegrationBindingState,
   isNoteEntityType,
   isProjectStatus,
@@ -175,6 +176,19 @@ describe("type guards", () => {
     it("rejects invalid integration binding states", () => {
       expect(isIntegrationBindingState("pending")).toBe(false);
       expect(isIntegrationBindingState("")).toBe(false);
+    });
+  });
+
+  describe("isContentApprovalState", () => {
+    it("accepts valid content approval states", () => {
+      expect(isContentApprovalState("notRequired")).toBe(true);
+      expect(isContentApprovalState("pendingApproval")).toBe(true);
+      expect(isContentApprovalState("approved")).toBe(true);
+    });
+
+    it("rejects invalid content approval states", () => {
+      expect(isContentApprovalState("pending")).toBe(false);
+      expect(isContentApprovalState("")).toBe(false);
     });
   });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -163,6 +163,39 @@ export interface Actor {
 }
 
 // ============================================================================
+// Imported content approval + binding-scoped actor mapping metadata
+// ============================================================================
+
+export const CONTENT_APPROVAL_STATES = ["notRequired", "pendingApproval", "approved"] as const;
+export type ContentApprovalState = (typeof CONTENT_APPROVAL_STATES)[number];
+
+export function isContentApprovalState(value: string): value is ContentApprovalState {
+  return (CONTENT_APPROVAL_STATES as readonly string[]).includes(value);
+}
+
+export interface ImportedContentApproval {
+  state: ContentApprovalState;
+  sourceBindingId?: IntegrationBindingId;
+  sourceActorId?: ActorId;
+  sourceFingerprint?: string;
+  reviewedAt?: string;
+  reviewedByActorId?: ActorId;
+}
+
+export interface IntegrationBindingActorMapping {
+  actorId: ActorId;
+  externalAccountId?: string;
+  externalLogin?: string;
+  displayName?: string;
+  trusted?: boolean;
+}
+
+export interface IntegrationBindingOptions {
+  actorMappings?: IntegrationBindingActorMapping[];
+  [key: string]: unknown;
+}
+
+// ============================================================================
 // Integration binding entities — shared desired state for external integrations
 // ============================================================================
 
@@ -174,7 +207,7 @@ export interface IntegrationBinding {
   targetRef: string;
   strategy: SyncStrategy;
   enabled: boolean;
-  options?: Record<string, unknown>;
+  options?: IntegrationBindingOptions;
   createdAt: string;
   updatedAt: string;
 }
@@ -215,6 +248,7 @@ export interface Task {
 /** Task with description loaded from TaskDetailDocument */
 export interface TaskWithDetail extends Task {
   description?: string;
+  descriptionApproval?: ImportedContentApproval;
 }
 
 /** Task with description and comments, used as sync-provider push input */
@@ -250,6 +284,7 @@ export interface Note {
   /** @deprecated Compatibility field kept during actor-model rollout. */
   author: string;
   authorActorId?: ActorId;
+  contentApproval?: ImportedContentApproval;
   entityType?: NoteEntityType;
   entityId?: string;
   tags: string[];
@@ -282,7 +317,7 @@ export interface CreateIntegrationBindingInput {
   targetRef: string;
   strategy?: SyncStrategy;
   enabled?: boolean;
-  options?: Record<string, unknown>;
+  options?: IntegrationBindingOptions;
 }
 
 export interface UpdateIntegrationBindingInput {
@@ -292,7 +327,7 @@ export interface UpdateIntegrationBindingInput {
   targetRef?: string;
   strategy?: SyncStrategy;
   enabled?: boolean;
-  options?: Record<string, unknown>;
+  options?: IntegrationBindingOptions;
 }
 
 export interface IntegrationBindingFilter {
@@ -315,6 +350,7 @@ export interface CreateTaskInput {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
+  descriptionApproval?: ImportedContentApproval;
   labels?: string[];
   assigneeActorIds?: ActorId[];
   /** @deprecated Compatibility field kept during actor-model rollout. */
@@ -332,6 +368,7 @@ export interface UpdateTaskInput {
   status?: TaskStatus;
   priority?: TaskPriority;
   description?: string;
+  descriptionApproval?: ImportedContentApproval;
   labels?: string[];
   assigneeActorIds?: ActorId[];
   /** @deprecated Compatibility field kept during actor-model rollout. */
@@ -386,6 +423,7 @@ export interface CreateNoteInput {
   /** @deprecated Compatibility field kept during actor-model rollout. */
   author?: string;
   authorActorId?: ActorId;
+  contentApproval?: ImportedContentApproval;
   entityType?: NoteEntityType;
   entityId?: string;
   tags?: string[];
@@ -396,6 +434,7 @@ export interface UpdateNoteInput {
   content?: string;
   tags?: string[];
   authorActorId?: ActorId;
+  contentApproval?: ImportedContentApproval;
 }
 
 export interface NoteFilter {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -555,6 +555,14 @@ describe("validateImportedContentApproval", () => {
     });
     expect(error?.field).toBe("contentApproval");
   });
+
+  it("rejects null approval payloads safely", () => {
+    const error = validateImportedContentApproval(
+      "contentApproval",
+      null as unknown as { state: "approved" },
+    );
+    expect(error?.field).toBe("contentApproval");
+  });
 });
 
 describe("validateCreateTaskInput", () => {
@@ -702,6 +710,16 @@ describe("validateCreateTaskInput", () => {
       title: "Test",
       projectId,
       descriptionApproval: { state: "pendingApproval" },
+    });
+    expect(error?.field).toBe("descriptionApproval");
+  });
+
+  it("rejects null description approval payloads safely", () => {
+    const error = validateCreateTaskInput({
+      title: "Test",
+      projectId,
+      description: "Details",
+      descriptionApproval: null as unknown as { state: "pendingApproval" },
     });
     expect(error?.field).toBe("descriptionApproval");
   });
@@ -1092,6 +1110,14 @@ describe("validateCreateNoteInput", () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it("rejects null note content approval payloads safely", () => {
+    const error = validateCreateNoteInput({
+      content: "Thought",
+      contentApproval: null as unknown as { state: "pendingApproval" },
+    });
+    expect(error?.field).toBe("contentApproval");
   });
 
   it("accepts note with createdAt", () => {

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -19,6 +19,7 @@ import {
   validateCreateRecurringInput,
   validateCreateTaskInput,
   validateDescription,
+  validateImportedContentApproval,
   validateIntegrationBindingField,
   validateIntegrationBindingProjectUniqueness,
   validateISODate,
@@ -286,6 +287,28 @@ describe("validateCreateIntegrationBindingInput", () => {
     ).toBeNull();
   });
 
+  it("accepts actor mappings with trust metadata", () => {
+    expect(
+      validateCreateIntegrationBindingInput({
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+        options: {
+          actorMappings: [
+            {
+              actorId: createActorId("actor-1"),
+              externalAccountId: "12345",
+              externalLogin: "evcraddock",
+              displayName: "Erik",
+              trusted: true,
+            },
+          ],
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("rejects non-object options", () => {
     const error = validateCreateIntegrationBindingInput({
       provider: "github",
@@ -293,6 +316,19 @@ describe("validateCreateIntegrationBindingInput", () => {
       targetKind: "repository",
       targetRef: "owner/repo",
       options: ["bad"] as unknown as Record<string, unknown>,
+    });
+    expect(error?.field).toBe("options");
+  });
+
+  it("rejects invalid actor mappings", () => {
+    const error = validateCreateIntegrationBindingInput({
+      provider: "github",
+      projectId,
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      options: {
+        actorMappings: [{ actorId: "", trusted: "yes" }],
+      } as unknown as Record<string, unknown>,
     });
     expect(error?.field).toBe("options");
   });
@@ -372,6 +408,16 @@ describe("validateUpdateIntegrationBindingInput", () => {
       validateUpdateIntegrationBindingInput({
         options: {
           importClosedOnBootstrap: true,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts actor mapping option updates", () => {
+    expect(
+      validateUpdateIntegrationBindingInput({
+        options: {
+          actorMappings: [{ actorId: createActorId("actor-1"), trusted: false }],
         },
       }),
     ).toBeNull();
@@ -489,6 +535,28 @@ describe("validateISODate", () => {
   });
 });
 
+describe("validateImportedContentApproval", () => {
+  it("accepts approval metadata", () => {
+    expect(
+      validateImportedContentApproval("contentApproval", {
+        state: "approved",
+        sourceBindingId: createIntegrationBindingId("ibind-1"),
+        sourceActorId: createActorId("actor-1"),
+        sourceFingerprint: "sha1:abc",
+        reviewedAt: "2026-04-13T00:00:00Z",
+        reviewedByActorId: createActorId("actor-2"),
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects invalid approval state", () => {
+    const error = validateImportedContentApproval("contentApproval", {
+      state: "unknown" as "approved",
+    });
+    expect(error?.field).toBe("contentApproval");
+  });
+});
+
 describe("validateCreateTaskInput", () => {
   const projectId = createProjectId("proj-test");
 
@@ -503,6 +571,12 @@ describe("validateCreateTaskInput", () => {
         projectId,
         priority: "high",
         description: "Details here",
+        descriptionApproval: {
+          state: "pendingApproval",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-1"),
+          sourceFingerprint: "sha1:abc",
+        },
         labels: ["bug"],
         assignees: ["alice"],
         dueDate: "2026-04-01",
@@ -622,6 +696,15 @@ describe("validateCreateTaskInput", () => {
     });
     expect(error?.field).toBe("externalId");
   });
+
+  it("rejects description approval without description", () => {
+    const error = validateCreateTaskInput({
+      title: "Test",
+      projectId,
+      descriptionApproval: { state: "pendingApproval" },
+    });
+    expect(error?.field).toBe("descriptionApproval");
+  });
 });
 
 describe("validateUpdateTaskInput", () => {
@@ -684,6 +767,21 @@ describe("validateUpdateTaskInput", () => {
 
   it("accepts imported updatedAt in update", () => {
     expect(validateUpdateTaskInput({ updatedAt: "2021-04-18T09:15:00Z" })).toBeNull();
+  });
+
+  it("accepts description approval updates", () => {
+    expect(
+      validateUpdateTaskInput({
+        descriptionApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-1"),
+          sourceFingerprint: "sha1:abc",
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-2"),
+        },
+      }),
+    ).toBeNull();
   });
 
   it("rejects invalid updatedAt in update", () => {
@@ -982,6 +1080,20 @@ describe("validateCreateNoteInput", () => {
     ).toBeNull();
   });
 
+  it("accepts note content approval metadata", () => {
+    expect(
+      validateCreateNoteInput({
+        content: "Thought",
+        contentApproval: {
+          state: "pendingApproval",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-1"),
+          sourceFingerprint: "sha1:abc",
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("accepts note with createdAt", () => {
     expect(
       validateCreateNoteInput({
@@ -1041,8 +1153,24 @@ describe("validateUpdateNoteInput", () => {
     expect(validateUpdateNoteInput({ content: "New", tags: ["tag"] })).toBeNull();
   });
 
-  it("accepts empty update (no fields)", () => {
-    expect(validateUpdateNoteInput({})).toBeNull();
+  it("accepts content approval updates", () => {
+    expect(
+      validateUpdateNoteInput({
+        contentApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-1"),
+          sourceFingerprint: "sha1:abc",
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-2"),
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects empty update (no fields)", () => {
+    const error = validateUpdateNoteInput({});
+    expect(error?.field).toBe("input");
   });
 
   it("rejects empty content string", () => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -7,6 +7,7 @@ import type {
   CreateProjectInput,
   CreateRecurringInput,
   CreateTaskInput,
+  ImportedContentApproval,
   IntegrationBinding,
   IntegrationBindingId,
   NoteFilter,
@@ -23,6 +24,7 @@ import type {
   ValidationError,
 } from "./types.js";
 import {
+  isContentApprovalState,
   isIntegrationBindingState,
   isNoteEntityType,
   isProjectStatus,
@@ -102,6 +104,58 @@ function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
+export function validateImportedContentApproval(
+  field: string,
+  approval: ImportedContentApproval,
+): ValidationError | null {
+  if (!isContentApprovalState(approval.state)) {
+    return validationError(field, `Invalid content approval state: ${approval.state}`);
+  }
+
+  if (approval.sourceBindingId !== undefined) {
+    const sourceBindingId = approval.sourceBindingId.trim();
+    if (sourceBindingId.length === 0) {
+      return validationError(field, "sourceBindingId must be a non-empty string");
+    }
+    if (sourceBindingId.length > MAX_INTEGRATION_FIELD_LENGTH) {
+      return validationError(
+        field,
+        `sourceBindingId must be ${MAX_INTEGRATION_FIELD_LENGTH} characters or less`,
+      );
+    }
+  }
+
+  if (approval.sourceActorId !== undefined) {
+    const actorIdError = validateActorId("sourceActorId", approval.sourceActorId);
+    if (actorIdError) return validationError(field, actorIdError.message);
+  }
+
+  if (approval.sourceFingerprint !== undefined) {
+    const fingerprint = approval.sourceFingerprint.trim();
+    if (fingerprint.length === 0) {
+      return validationError(field, "sourceFingerprint must be a non-empty string");
+    }
+    if (fingerprint.length > MAX_DESCRIPTION_LENGTH) {
+      return validationError(
+        field,
+        `sourceFingerprint must be ${MAX_DESCRIPTION_LENGTH} characters or less`,
+      );
+    }
+  }
+
+  if (approval.reviewedAt !== undefined) {
+    const reviewedAtError = validateISODate("reviewedAt", approval.reviewedAt);
+    if (reviewedAtError) return validationError(field, reviewedAtError.message);
+  }
+
+  if (approval.reviewedByActorId !== undefined) {
+    const actorIdError = validateActorId("reviewedByActorId", approval.reviewedByActorId);
+    if (actorIdError) return validationError(field, actorIdError.message);
+  }
+
+  return null;
+}
+
 function validateIntegrationBindingOptions(options: unknown): ValidationError | null {
   if (options === undefined) {
     return null;
@@ -109,6 +163,49 @@ function validateIntegrationBindingOptions(options: unknown): ValidationError | 
 
   if (!isPlainJsonObject(options)) {
     return validationError("options", "options must be a JSON object");
+  }
+
+  if (options.actorMappings !== undefined) {
+    if (!Array.isArray(options.actorMappings)) {
+      return validationError("options", "actorMappings must be an array");
+    }
+
+    const seenActorIds = new Set<string>();
+    for (const mapping of options.actorMappings) {
+      if (!isPlainJsonObject(mapping)) {
+        return validationError("options", "actorMappings entries must be JSON objects");
+      }
+
+      if (typeof mapping.actorId !== "string") {
+        return validationError("options", "actorMappings.actorId is required");
+      }
+      const actorIdError = validateActorId("actorId", mapping.actorId);
+      if (actorIdError) return validationError("options", actorIdError.message);
+
+      const normalizedActorId = mapping.actorId.trim();
+      if (seenActorIds.has(normalizedActorId)) {
+        return validationError("options", "actorMappings actorIds must be unique");
+      }
+      seenActorIds.add(normalizedActorId);
+
+      for (const field of ["externalAccountId", "externalLogin", "displayName"] as const) {
+        const value = mapping[field];
+        if (value === undefined) continue;
+        if (typeof value !== "string" || value.trim().length === 0) {
+          return validationError("options", `${field} must be a non-empty string`);
+        }
+        if (value.trim().length > MAX_INTEGRATION_FIELD_LENGTH) {
+          return validationError(
+            "options",
+            `${field} must be ${MAX_INTEGRATION_FIELD_LENGTH} characters or less`,
+          );
+        }
+      }
+
+      if (mapping.trusted !== undefined && typeof mapping.trusted !== "boolean") {
+        return validationError("options", "trusted must be a boolean");
+      }
+    }
   }
 
   return null;
@@ -418,6 +515,17 @@ export function validateCreateTaskInput(input: CreateTaskInput): ValidationError
     if (descError) return descError;
   }
 
+  if (input.descriptionApproval !== undefined) {
+    if (input.description === undefined) {
+      return validationError("descriptionApproval", "descriptionApproval requires a description");
+    }
+    const approvalError = validateImportedContentApproval(
+      "descriptionApproval",
+      input.descriptionApproval,
+    );
+    if (approvalError) return approvalError;
+  }
+
   if (input.status !== undefined && !isTaskStatus(input.status)) {
     return validationError("status", `Invalid status: ${input.status}`);
   }
@@ -478,6 +586,7 @@ export function validateUpdateTaskInput(
     input.status === undefined &&
     input.priority === undefined &&
     input.description === undefined &&
+    input.descriptionApproval === undefined &&
     input.labels === undefined &&
     input.assigneeActorIds === undefined &&
     input.assignees === undefined &&
@@ -498,6 +607,14 @@ export function validateUpdateTaskInput(
   if (input.description !== undefined) {
     const descError = validateDescription(input.description);
     if (descError) return descError;
+  }
+
+  if (input.descriptionApproval !== undefined) {
+    const approvalError = validateImportedContentApproval(
+      "descriptionApproval",
+      input.descriptionApproval,
+    );
+    if (approvalError) return approvalError;
   }
 
   if (input.status !== undefined) {
@@ -629,6 +746,11 @@ export function validateCreateNoteInput(input: CreateNoteInput): ValidationError
   const contentError = validateNoteContent(input.content);
   if (contentError) return contentError;
 
+  if (input.contentApproval !== undefined) {
+    const approvalError = validateImportedContentApproval("contentApproval", input.contentApproval);
+    if (approvalError) return approvalError;
+  }
+
   if (input.entityType !== undefined && !isNoteEntityType(input.entityType)) {
     return validationError("entityType", `Invalid entity type: ${input.entityType}`);
   }
@@ -655,6 +777,15 @@ export function validateCreateNoteInput(input: CreateNoteInput): ValidationError
 }
 
 export function validateUpdateNoteInput(input: UpdateNoteInput): ValidationError | null {
+  if (
+    input.content === undefined &&
+    input.tags === undefined &&
+    input.authorActorId === undefined &&
+    input.contentApproval === undefined
+  ) {
+    return validationError("input", "At least one field must be provided");
+  }
+
   if (input.content !== undefined) {
     const contentError = validateNoteContent(input.content);
     if (contentError) return contentError;
@@ -663,6 +794,11 @@ export function validateUpdateNoteInput(input: UpdateNoteInput): ValidationError
   if (input.authorActorId !== undefined) {
     const actorIdError = validateActorId("authorActorId", input.authorActorId);
     if (actorIdError) return actorIdError;
+  }
+
+  if (input.contentApproval !== undefined) {
+    const approvalError = validateImportedContentApproval("contentApproval", input.contentApproval);
+    if (approvalError) return approvalError;
   }
 
   return null;

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -108,6 +108,10 @@ export function validateImportedContentApproval(
   field: string,
   approval: ImportedContentApproval,
 ): ValidationError | null {
+  if (typeof approval !== "object" || approval === null || Array.isArray(approval)) {
+    return validationError(field, `${field} must be a JSON object`);
+  }
+
   if (!isContentApprovalState(approval.state)) {
     return validationError(field, `Invalid content approval state: ${approval.state}`);
   }

--- a/packages/engine/src/integrations.integration.test.ts
+++ b/packages/engine/src/integrations.integration.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { IntegrationBindingId, ProjectId } from "@todu/core";
-import { createIntegrationBindingId } from "@todu/core";
+import { createActorId, createIntegrationBindingId } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTodu } from "./index.js";
 import type { Todu } from "./todu.js";
@@ -100,6 +100,59 @@ describe("integration namespace", () => {
       if (!disabled.ok) return;
       expect(disabled.value).toHaveLength(1);
       expect(disabled.value[0].id).toBe(bindingB.value.id);
+    });
+
+    it("persists actor mappings with trust metadata in binding options", async () => {
+      const created = await todu.integration.create({
+        provider: "github",
+        projectId,
+        targetKind: "repository",
+        targetRef: "owner/repo",
+        options: {
+          actorMappings: [
+            {
+              actorId: createActorId("actor-user"),
+              externalAccountId: "12345",
+              externalLogin: "evcraddock",
+              displayName: "Erik",
+              trusted: true,
+            },
+          ],
+        },
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      expect(created.value.options?.actorMappings).toEqual([
+        {
+          actorId: "actor-user",
+          externalAccountId: "12345",
+          externalLogin: "evcraddock",
+          displayName: "Erik",
+          trusted: true,
+        },
+      ]);
+
+      const fetched = await todu.integration.get(created.value.id);
+      expect(fetched.ok).toBe(true);
+      if (!fetched.ok) return;
+      expect(fetched.value.options?.actorMappings).toEqual(created.value.options?.actorMappings);
+
+      const returnedMappings = fetched.value.options?.actorMappings as Array<{ trusted?: boolean }>;
+      returnedMappings[0].trusted = false;
+
+      const fetchedAgain = await todu.integration.get(created.value.id);
+      expect(fetchedAgain.ok).toBe(true);
+      if (!fetchedAgain.ok) return;
+      expect(fetchedAgain.value.options?.actorMappings).toEqual([
+        {
+          actorId: "actor-user",
+          externalAccountId: "12345",
+          externalLogin: "evcraddock",
+          displayName: "Erik",
+          trusted: true,
+        },
+      ]);
     });
 
     it("gets, updates, and deletes a binding", async () => {

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -8,6 +8,7 @@ import {
   type CatalogDocument,
   createActorId,
   createEmptyCatalog,
+  createIntegrationBindingId,
   createNoteId,
   createNotesDocument,
   DEFAULT_OWNER_ACTOR_ID,
@@ -115,6 +116,10 @@ describe("note namespace", () => {
       expect(result.value.content).toBe("Today was productive");
       expect(result.value.author).toBe("user");
       expect(result.value.authorActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
+      expect(result.value.contentApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
       expect(result.value.entityType).toBeUndefined();
       expect(result.value.entityId).toBeUndefined();
       expect(result.value.tags).toEqual([]);
@@ -172,10 +177,21 @@ describe("note namespace", () => {
       const result = await todu.note.create({
         content: "Actor-authored note",
         authorActorId: createActorId("actor-user"),
+        contentApproval: {
+          state: "pendingApproval",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+        },
       });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.authorActorId).toBe("actor-user");
+      expect(result.value.contentApproval).toEqual({
+        state: "pendingApproval",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
     });
 
     it("rejects unknown author actor id", async () => {
@@ -486,7 +502,37 @@ describe("note namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.content).toBe("Updated");
+      expect(result.value.contentApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
       expect(result.value.id).toBe(created.value.id);
+    });
+
+    it("updates note approval metadata without changing content", async () => {
+      const created = await todu.note.create({ content: "Original" });
+      if (!created.ok) throw new Error("create failed");
+
+      const result = await todu.note.update(created.value.id, {
+        contentApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.content).toBe("Original");
+      expect(result.value.contentApproval).toEqual({
+        state: "approved",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        reviewedAt: "2026-04-13T00:00:00Z",
+        reviewedByActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
     });
 
     it("updates note tags", async () => {
@@ -503,6 +549,17 @@ describe("note namespace", () => {
       const created = await todu.note.create({ content: "Old", tags: ["a"] });
       if (!created.ok) throw new Error("create failed");
 
+      const approved = await todu.note.update(created.value.id, {
+        contentApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
+      });
+      if (!approved.ok) throw new Error("approval update failed");
+
       const result = await todu.note.update(created.value.id, {
         content: "New",
         tags: ["b", "c"],
@@ -511,6 +568,13 @@ describe("note namespace", () => {
       if (!result.ok) return;
       expect(result.value.content).toBe("New");
       expect(result.value.tags).toEqual(["b", "c"]);
+      expect(result.value.contentApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
+      expect(result.value.contentApproval?.sourceFingerprint).not.toBe(
+        approved.value.contentApproval?.sourceFingerprint,
+      );
     });
 
     it("updates note author actor id", async () => {
@@ -600,7 +664,17 @@ describe("note namespace", () => {
 
   describe("persistence", () => {
     it("notes survive close and reopen", async () => {
-      await todu.note.create({ content: "Persistent thought", tags: ["journal"] });
+      await todu.note.create({
+        content: "Persistent thought",
+        tags: ["journal"],
+        contentApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
+      });
       await todu.close();
       await new Promise((r) => setTimeout(r, 50));
 
@@ -611,6 +685,14 @@ describe("note namespace", () => {
       expect(result.value).toHaveLength(1);
       expect(result.value[0].content).toBe("Persistent thought");
       expect(result.value[0].tags).toEqual(["journal"]);
+      expect(result.value[0].contentApproval).toEqual({
+        state: "approved",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        reviewedAt: "2026-04-13T00:00:00Z",
+        reviewedByActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
     });
 
     it("stores notes in partitioned bucket documents", async () => {

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -7,6 +7,7 @@ import {
   createNotesDocument,
   dateToTimezoneISO,
   err,
+  type ImportedContentApproval,
   type Note,
   type NoteFilter,
   type NoteId,
@@ -23,6 +24,20 @@ import {
 import type { NoteNamespace } from "./todu.js";
 
 const NOTES_DIAGNOSTICS_ENV = "TODU_NOTES_DIAGNOSTICS";
+
+function createStoredNoteContentFingerprint(content: string): string {
+  return `sha1:${crypto.createHash("sha1").update(content).digest("hex")}`;
+}
+
+function normalizeStoredNoteContentApproval(
+  content: string,
+  approval?: ImportedContentApproval,
+): ImportedContentApproval {
+  return {
+    ...(approval ?? { state: "notRequired" }),
+    sourceFingerprint: createStoredNoteContentFingerprint(content),
+  };
+}
 
 interface NoteLocation {
   bucketKey: string;
@@ -96,6 +111,20 @@ export function createNoteNamespace(
     }
 
     return normalized;
+  }
+
+  function createContentFingerprint(content: string): string {
+    return `sha1:${crypto.createHash("sha1").update(content).digest("hex")}`;
+  }
+
+  function normalizeContentApproval(
+    content: string,
+    approval?: ImportedContentApproval,
+  ): ImportedContentApproval {
+    return {
+      ...(approval ?? { state: "notRequired" }),
+      sourceFingerprint: createContentFingerprint(content),
+    };
   }
 
   function isJournalBucketKey(bucketKey: string): boolean {
@@ -366,12 +395,14 @@ export function createNoteNamespace(
         : new Date().toISOString();
       const id = createNoteId(`note-${crypto.randomUUID().slice(0, 8)}`);
 
+      const content = input.content.trim();
       const note: Note = {
         id,
-        content: input.content.trim(),
+        content,
         author: input.author ?? "user",
         tags: input.tags ?? [],
         createdAt,
+        contentApproval: normalizeContentApproval(content, input.contentApproval),
       };
       if (authorActorId !== undefined) note.authorActorId = authorActorId;
       if (input.entityType !== undefined) note.entityType = input.entityType;
@@ -469,7 +500,12 @@ export function createNoteNamespace(
 
       location.handle.change((doc) => {
         const note = doc.notes[location.index];
-        if (input.content !== undefined) note.content = input.content.trim();
+        if (input.content !== undefined) {
+          note.content = input.content.trim();
+          note.contentApproval = normalizeContentApproval(note.content, input.contentApproval);
+        } else if (input.contentApproval !== undefined) {
+          note.contentApproval = normalizeContentApproval(note.content, input.contentApproval);
+        }
         if (input.authorActorId !== undefined) note.authorActorId = input.authorActorId;
         if (input.tags !== undefined) {
           // Clear and repopulate tags array for Automerge compatibility
@@ -529,6 +565,7 @@ function toStorageNote(n: Note): Note {
     author: n.author,
     tags: [...n.tags],
     createdAt: n.createdAt,
+    contentApproval: normalizeStoredNoteContentApproval(n.content, n.contentApproval),
   };
 
   if (n.authorActorId !== undefined) note.authorActorId = n.authorActorId;

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
-import { createActorId, createProjectId, createTaskId, DEFAULT_OWNER_ACTOR_ID } from "@todu/core";
+import {
+  createActorId,
+  createIntegrationBindingId,
+  createProjectId,
+  createTaskId,
+  DEFAULT_OWNER_ACTOR_ID,
+} from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
@@ -293,6 +299,11 @@ describe("task namespace", () => {
         projectId,
         priority: "high",
         description: "Detailed description",
+        descriptionApproval: {
+          state: "pendingApproval",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+        },
         labels: ["bug", "urgent"],
         dueDate: "2026-04-01",
         scheduledDate: "2026-03-30",
@@ -302,6 +313,12 @@ describe("task namespace", () => {
 
       expect(result.value.priority).toBe("high");
       expect(result.value.description).toBe("Detailed description");
+      expect(result.value.descriptionApproval).toEqual({
+        state: "pendingApproval",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
       expect(result.value.labels).toEqual(["bug", "urgent"]);
       expect(result.value.dueDate).toBe("2026-04-01");
       expect(result.value.scheduledDate).toBe("2026-03-30");
@@ -846,6 +863,57 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.description).toBe("New desc");
+      expect(result.value.descriptionApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
+    });
+
+    it("updates description approval metadata without changing the description", async () => {
+      const result = await todu.task.update(taskId, {
+        descriptionApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.description).toBe("Original desc");
+      expect(result.value.descriptionApproval).toEqual({
+        state: "approved",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        reviewedAt: "2026-04-13T00:00:00Z",
+        reviewedByActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
+    });
+
+    it("resets description approval when the description revision changes locally", async () => {
+      const approved = await todu.task.update(taskId, {
+        descriptionApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
+      });
+      if (!approved.ok) throw new Error("approval update failed");
+
+      const result = await todu.task.update(taskId, { description: "Locally edited" });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.descriptionApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
+      expect(result.value.descriptionApproval?.sourceFingerprint).not.toBe(
+        approved.value.descriptionApproval?.sourceFingerprint,
+      );
     });
 
     it("adds description to task that had none", async () => {
@@ -958,6 +1026,10 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value.description).toBe("Original desc");
+      expect(result.value.descriptionApproval).toEqual({
+        state: "notRequired",
+        sourceFingerprint: expect.any(String),
+      });
     });
   });
 
@@ -1092,6 +1164,13 @@ describe("task namespace", () => {
         title: "Persistent",
         projectId,
         description: "Survives restart",
+        descriptionApproval: {
+          state: "approved",
+          sourceBindingId: createIntegrationBindingId("ibind-1"),
+          sourceActorId: createActorId("actor-user"),
+          reviewedAt: "2026-04-13T00:00:00Z",
+          reviewedByActorId: createActorId("actor-user"),
+        },
       });
       await todu.close();
       await new Promise((r) => setTimeout(r, 50));
@@ -1108,6 +1187,14 @@ describe("task namespace", () => {
       expect(detail.ok).toBe(true);
       if (!detail.ok) return;
       expect(detail.value.description).toBe("Survives restart");
+      expect(detail.value.descriptionApproval).toEqual({
+        state: "approved",
+        sourceBindingId: "ibind-1",
+        sourceActorId: "actor-user",
+        reviewedAt: "2026-04-13T00:00:00Z",
+        reviewedByActorId: "actor-user",
+        sourceFingerprint: expect.any(String),
+      });
     });
   });
 });

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -8,6 +8,7 @@ import {
   createTaskListDocument,
   dateToTimezoneISO,
   err,
+  type ImportedContentApproval,
   notFound,
   ok,
   type ProjectId,
@@ -94,6 +95,20 @@ export function createTaskNamespace(
     }
 
     return normalized;
+  }
+
+  function createContentFingerprint(content: string): string {
+    return `sha1:${crypto.createHash("sha1").update(content).digest("hex")}`;
+  }
+
+  function normalizeContentApproval(
+    content: string,
+    approval?: ImportedContentApproval,
+  ): ImportedContentApproval {
+    return {
+      ...(approval ?? { state: "notRequired" }),
+      sourceFingerprint: createContentFingerprint(content),
+    };
   }
 
   function findMissingActorId(actorIds: readonly string[]): string | null {
@@ -280,12 +295,17 @@ export function createTaskNamespace(
 
       // Create detail document if description provided
       const description = input.description?.trim();
+      let descriptionApproval: ImportedContentApproval | undefined;
       if (description) {
+        descriptionApproval = normalizeContentApproval(description, input.descriptionApproval);
         const detailHandle = repo.create<TaskDetailDocument>();
-        const template = createTaskDetailDocument(id, description);
+        const template = createTaskDetailDocument(id, description, descriptionApproval);
         detailHandle.change((doc) => {
           doc.taskId = template.taskId;
           doc.description = template.description;
+          if (template.descriptionApproval !== undefined) {
+            doc.descriptionApproval = template.descriptionApproval;
+          }
         });
 
         listHandle.change((doc) => {
@@ -293,7 +313,7 @@ export function createTaskNamespace(
         });
       }
 
-      return ok({ ...task, description });
+      return ok({ ...task, description, descriptionApproval });
     },
 
     async list(filter?: TaskFilter, sort?: TaskSortOptions): Promise<Result<Task[]>> {
@@ -411,16 +431,21 @@ export function createTaskNamespace(
       const listDoc = result.listHandle.doc();
       const detailDocId = listDoc?.detailDocIds[id];
       let description: string | undefined;
+      let descriptionApproval: ImportedContentApproval | undefined;
 
       if (detailDocId) {
         const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
         const detailDoc = detailHandle.doc();
         if (detailDoc) {
           description = detailDoc.description;
+          descriptionApproval = normalizeContentApproval(
+            detailDoc.description,
+            detailDoc.descriptionApproval,
+          );
         }
       }
 
-      return ok({ ...result.task, description });
+      return ok({ ...result.task, description, descriptionApproval });
     },
 
     async update(id: TaskId, input: UpdateTaskInput): Promise<Result<TaskWithDetail>> {
@@ -477,43 +502,61 @@ export function createTaskNamespace(
 
       // Update description in detail document if changed
       let description: string | undefined;
-      if (input.description !== undefined) {
-        const listDoc = result.listHandle.doc();
-        const detailDocId = listDoc?.detailDocIds[id];
+      let descriptionApproval: ImportedContentApproval | undefined;
+      const listDoc = result.listHandle.doc();
+      const detailDocId = listDoc?.detailDocIds[id];
 
-        if (detailDocId) {
-          // Update existing detail doc
-          const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
+      if (detailDocId) {
+        const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
+
+        if (input.description !== undefined || input.descriptionApproval !== undefined) {
           detailHandle.change((doc) => {
-            doc.description = input.description!.trim();
+            const nextDescription =
+              input.description !== undefined ? input.description.trim() : doc.description;
+            doc.description = nextDescription;
+            doc.descriptionApproval = normalizeContentApproval(
+              nextDescription,
+              input.descriptionApproval,
+            );
           });
-          description = input.description.trim();
-        } else if (input.description.trim()) {
-          // Create new detail doc
-          const detailHandle = repo.create<TaskDetailDocument>();
-          const template = createTaskDetailDocument(id, input.description.trim());
-          detailHandle.change((doc) => {
-            doc.taskId = template.taskId;
-            doc.description = template.description;
-          });
-          result.listHandle.change((doc) => {
-            doc.detailDocIds[id] = detailHandle.documentId;
-          });
-          description = input.description.trim();
         }
-      } else {
-        // Load existing description
-        const listDoc = result.listHandle.doc();
-        const detailDocId = listDoc?.detailDocIds[id];
-        if (detailDocId) {
-          const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
-          description = detailHandle.doc()?.description;
+
+        const detailDoc = detailHandle.doc();
+        description = detailDoc?.description;
+        if (detailDoc?.description !== undefined) {
+          descriptionApproval = normalizeContentApproval(
+            detailDoc.description,
+            detailDoc.descriptionApproval,
+          );
         }
+      } else if (input.description?.trim()) {
+        const descriptionText = input.description.trim();
+        descriptionApproval = normalizeContentApproval(descriptionText, input.descriptionApproval);
+        const detailHandle = repo.create<TaskDetailDocument>();
+        const template = createTaskDetailDocument(id, descriptionText, descriptionApproval);
+        detailHandle.change((doc) => {
+          doc.taskId = template.taskId;
+          doc.description = template.description;
+          if (template.descriptionApproval !== undefined) {
+            doc.descriptionApproval = template.descriptionApproval;
+          }
+        });
+        result.listHandle.change((doc) => {
+          doc.detailDocIds[id] = detailHandle.documentId;
+        });
+        description = descriptionText;
+      } else if (input.descriptionApproval !== undefined) {
+        return err(
+          validationError(
+            "descriptionApproval",
+            "Cannot update description approval without an existing description",
+          ),
+        );
       }
 
       // Read back updated task
       const updated = result.listHandle.doc()!.tasks[result.index];
-      return ok({ ...cloneTask(updated), description });
+      return ok({ ...cloneTask(updated), description, descriptionApproval });
     },
 
     async delete(id: TaskId): Promise<Result<void>> {
@@ -587,12 +630,20 @@ export function createTaskNamespace(
 
       // Load description for return value
       let description: string | undefined;
+      let descriptionApproval: ImportedContentApproval | undefined;
       if (detailDocId) {
         const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
-        description = detailHandle.doc()?.description;
+        const detailDoc = detailHandle.doc();
+        description = detailDoc?.description;
+        if (detailDoc?.description !== undefined) {
+          descriptionApproval = normalizeContentApproval(
+            detailDoc.description,
+            detailDoc.descriptionApproval,
+          );
+        }
       }
 
-      return ok({ ...taskData, description });
+      return ok({ ...taskData, description, descriptionApproval });
     },
 
     async search(query: string): Promise<Result<Task[]>> {


### PR DESCRIPTION
## Summary
- add core actor-mapping trust metadata on integration binding options
- add imported-content approval storage for task descriptions and note bodies
- add validation, persistence behavior, and regression coverage for approval metadata

## Testing
- make pre-pr