### PR TITLE
feat: add sync provider v3 contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,7 +227,7 @@ Baseline worker lifecycle states are:
 - Generic worker plugins use `WorkerPluginRegistration` from `@todu/core` and export `workerPlugin`.
 - Sync provider plugins use `SyncProviderRegistration` from `@todu/core` and export `syncProvider`.
 - Plugin load paths validate registrations at load time before worker registration.
-- Compatibility baseline for sync providers is API-version based (current provider API version: `2`).
+- Compatibility baseline for sync providers is API-version based (latest provider API version: `3`; host-supported rollout window versions: `2` and `3`).
 - Daemon plugin module paths resolve from `TODU_DAEMON_PLUGIN_PATHS` first, then legacy `TODUAI_DAEMON_PLUGIN_PATHS`, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -6,7 +6,7 @@ For generic daemon worker plugins, see `docs/worker-plugin-api.md`.
 
 ## Purpose
 
-`SyncProvider` is the runtime contract for plugins that synchronize todu data with external systems (for example, GitHub or Forgejo issue trackers).
+`SyncProvider` is the runtime contract for plugins that synchronize todu data with external systems such as GitHub or Forgejo.
 
 This document defines the provider execution contract. Shared integration binding desired state is a separate architecture concern owned by core and documented in `docs/architecture/integrations.md`.
 
@@ -29,10 +29,12 @@ Use local provider configuration for secrets and host-local runtime settings, no
 
 Compatibility is API-version based.
 
-- Host-supported provider API version: `SYNC_PROVIDER_API_VERSION` (currently `2`).
+- Latest provider API version: `SYNC_PROVIDER_API_VERSION` (currently `3`).
+- Host-supported provider API versions during the rollout window: `SYNC_PROVIDER_SUPPORTED_API_VERSIONS` (currently `2` and `3`).
 - Every provider manifest must declare `apiVersion`.
-- Providers are loadable only when `manifest.apiVersion` matches the host-supported API version.
-- Version mismatches must fail at load time.
+- Providers are loadable only when `manifest.apiVersion` is included in the host-supported version set.
+- Unsupported versions must fail closed at load time.
+- Provider API v2 remains a transition contract and will be removed after the compatibility window closes.
 
 Use `validateSyncProviderRegistration(...)` during plugin load to enforce this gate.
 
@@ -52,10 +54,36 @@ Rules:
 - `version` must be non-empty.
 - `apiVersion` must be a positive integer and API-compatible with host runtime.
 
-## Provider Lifecycle Contract
+## API v2 contract
+
+API v2 is the legacy string-based provider contract.
 
 ```ts
-interface SyncProvider {
+interface ExternalTask {
+  externalId: string;
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  labels?: string[];
+  assignees?: string[];
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface ExternalComment {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: string;
+  createdAt: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface SyncProviderV2 {
   readonly name: string;
   readonly version: string;
   initialize(config: SyncProviderConfig): Promise<void>;
@@ -69,7 +97,84 @@ interface SyncProvider {
 
 `TaskPushPayload` extends `TaskWithDetail` with `comments: Note[]`, providing each task's description and attached comments during push.
 
-Expected lifecycle:
+Use v2 only for compatibility with the existing runtime shim path.
+
+## API v3 contract
+
+API v3 replaces direct `mapToTask(...)` and `mapFromTask(...)` coupling with normalized import/export payloads and structured external actor references.
+
+```ts
+interface ExternalActorRef {
+  externalAccountId?: string;
+  externalLogin?: string;
+  displayName?: string;
+  raw?: unknown;
+}
+
+interface ImportedTaskInput {
+  externalId: string;
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  labels?: string[];
+  assignees?: ExternalActorRef[];
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface ImportedCommentInput {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: ExternalActorRef;
+  createdAt: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+interface ExportedCommentInput {
+  localNoteId: NoteId;
+  body: string;
+  createdAt: string;
+  updatedAt?: string;
+  sourceUrl?: string;
+}
+
+interface ExportedTaskInput {
+  localTaskId: TaskId;
+  externalId?: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  labels: string[];
+  assignees: ExternalActorRef[];
+  sourceUrl?: string;
+  comments: ExportedCommentInput[];
+}
+
+interface SyncProviderV3 {
+  readonly name: string;
+  readonly version: string;
+  initialize(config: SyncProviderConfig): Promise<void>;
+  shutdown(): Promise<void>;
+  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResultV3>;
+  push(binding: IntegrationBinding, tasks: ExportedTaskInput[], project: Project): Promise<SyncProviderPushResult>;
+}
+```
+
+### v3 boundary rules
+
+- Providers must not consume or emit local `ActorId` values.
+- Providers own external identity extraction only.
+- The host/runtime owns local actor resolution, mapping persistence, and imported-content approval computation.
+- `binding.options.actorMappings` is shared desired state, not provider-local runtime bookkeeping.
+- Provider-local secrets, cursors, caches, and linkage internals remain outside synced core entities.
+
+## Expected lifecycle
 
 1. Load plugin module.
 2. Validate registration and compatibility.
@@ -77,9 +182,11 @@ Expected lifecycle:
 4. For each applicable integration binding, call `pull(...)` and `push(...)` according to the binding strategy.
 5. Call `shutdown()` during daemon stop/unload.
 
-## Task Pull Contract
+## Task and comment sync semantics
 
-`SyncProviderPullResult.tasks` accepts `ExternalTask[]`. The runtime reconciles pulled tasks within the binding's project by `externalId`:
+### v2 pull behavior
+
+`SyncProviderPullResult.tasks` accepts `ExternalTask[]`. The runtime reconciles pulled tasks within the binding's project by `externalId`.
 
 - Each pulled item is mapped through `mapToTask(external, project)`.
 - When no local task with the same `externalId` exists, the runtime creates a new task in the bound project.
@@ -88,21 +195,25 @@ Expected lifecycle:
 
 The runtime persists the pulled task's core fields, including mapped status, priority, labels, assignees, `externalId`, and `sourceUrl`. Task descriptions come from `ExternalTask.description`.
 
-Imported timestamp semantics:
+### v3 pull behavior
 
-- Newly created local tasks preserve external `createdAt` when provided.
-- Newly created local tasks preserve external `updatedAt` when provided.
-- If only one external task timestamp is provided, the runtime uses that timestamp for both local `createdAt` and `updatedAt` so imported history remains deterministic.
-- For later pull updates of already-linked tasks, local `createdAt` remains unchanged and local `updatedAt` follows the imported external timestamp used for the update decision.
-- Invalid external task timestamps fail the pull safely instead of being written into local task state.
+`SyncProviderPullResultV3.tasks` accepts `ImportedTaskInput[]` and `comments` accepts `ImportedCommentInput[]`.
 
-## Comment Sync Contract
+In v3:
 
-The sync-provider runtime supports comment/note mirroring through pull and push paths.
+- providers return normalized external identity data with `ExternalActorRef`
+- providers do not translate directly into local tasks or notes
+- the host/runtime is responsible for actor creation/reuse, binding mapping updates, and approval-state computation
+
+Imported timestamp semantics stay the same across v2 and v3:
+
+- newly created local tasks preserve external `createdAt` when provided
+- newly created local tasks preserve external `updatedAt` when provided
+- if only one external task timestamp is provided, the runtime uses that timestamp for both local `createdAt` and `updatedAt`
+- later pull updates preserve local `createdAt` and use external update timestamps for conflict resolution
+- invalid timestamps fail the pull safely instead of being written into local task state
 
 ### Push path
-
-Each `TaskPushPayload` in `push(...)` includes a `comments: Note[]` array containing the task's attached notes (entity type `task`). Providers can use these to detect local comment creates, edits, and deletes by comparing with external state.
 
 `push(...)` must return a `SyncProviderPushResult`:
 
@@ -133,29 +244,17 @@ The runtime applies returned `taskLinks` first, writing back task linkage for pu
 
 The runtime then applies each returned comment link idempotently by attaching the canonical `sync:externalId:<externalCommentId>` tag to the referenced local note. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error.
 
-### Pull path
+### Comment pull path
 
-`SyncProviderPullResult.comments` accepts `ExternalComment[]`. The runtime reconciles pulled comments with local notes using a snapshot model:
+For v2, pulled comments are `ExternalComment[]` with string `author` values.
 
-- Comments with an `externalId` not present locally are created as new notes with a `sync:externalId:<value>` tag.
-- Comments matching an existing local note (by external ID tag) are updated if the external `updatedAt` is newer than the local `createdAt` (last-write-wins).
-- Local synced notes whose external IDs are absent from the pull result are deleted.
+For v3, pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalActorRef`.
 
-### ExternalComment
+In both cases, the runtime reconciles pulled comments with local notes using a snapshot model:
 
-```ts
-interface ExternalComment {
-  externalId: string;
-  externalTaskId: string;
-  body: string;
-  author?: string;
-  createdAt: string;
-  updatedAt?: string;
-  raw?: unknown;
-}
-```
-
-The `externalTaskId` must match a todu task ID for the comment to be applied. The `createdAt` timestamp is required; `updatedAt` is used for conflict resolution when present (falls back to `createdAt`).
+- comments with an `externalId` not present locally are created as new notes with a `sync:externalId:<value>` tag
+- comments matching an existing local note are updated if the external `updatedAt` is newer than the local `createdAt`
+- local synced notes whose external IDs are absent from the pull result are deleted
 
 ## Load-Time Enforcement
 
@@ -167,10 +266,10 @@ validateSyncProviderRegistration(registration)
 
 Validation enforces:
 
-- manifest shape and non-empty identity fields,
-- required provider lifecycle methods,
-- provider/manifest identity consistency (`name` + `version`),
-- API-version compatibility.
+- manifest shape and non-empty identity fields
+- required provider lifecycle methods for the declared API version
+- provider/manifest identity consistency (`name` + `version`)
+- API-version compatibility against the host-supported version set
 
 Validation errors use structured codes:
 
@@ -197,21 +296,21 @@ Runtime behavior:
 
 Per-plugin scheduler config can be provided via `daemon.plugins.config.<pluginName>` in config file, `TODU_DAEMON_PLUGIN_CONFIG`, or legacy `TODUAI_DAEMON_PLUGIN_CONFIG` (JSON object). Supported fields:
 
-- `intervalSeconds`: steady-state cycle interval.
-- `retryInitialSeconds` / `retryMaxSeconds`: retry backoff controls.
-- `enabled`: optional execution toggle for the local provider worker.
-- `settings`: provider-specific object passed to `initialize(...)`.
+- `intervalSeconds`: steady-state cycle interval
+- `retryInitialSeconds` / `retryMaxSeconds`: retry backoff controls
+- `enabled`: optional execution toggle for the local provider worker
+- `settings`: provider-specific object passed to `initialize(...)`
 
-Binding desired state is no longer configured through local plugin config. The daemon host now enumerates shared integration bindings from core state, filters by provider name and `enabled` state, and executes provider work according to each binding's `strategy`, `projectId`, `targetKind`, `targetRef`, and optional `options` object.
+Binding desired state is no longer configured through local plugin config. The daemon host enumerates shared integration bindings from core state, filters by provider name and `enabled` state, and executes provider work according to each binding's `strategy`, `projectId`, `targetKind`, `targetRef`, and optional `options` object.
 
 Architecture note: the generic integration direction in `docs/architecture/integrations.md` moves project-to-external integration binding desired state into synced core data. In that model, local provider config remains the place for secrets, credentials, retry tuning, and other host-local runtime settings. `binding.options` is for provider-specific desired-state configuration only and must not be used for secrets or runtime internals.
 
 Retry policy:
 
-- Pull/push cycle failures are logged and retried with exponential backoff.
-- Delay formula is `retryInitialSeconds * 2^attempt`, capped by `retryMaxSeconds`.
-- Retry state resets after a successful cycle.
-- Daemon shutdown stops further scheduling and calls provider `shutdown()`.
+- pull/push cycle failures are logged and retried with exponential backoff
+- delay formula is `retryInitialSeconds * 2^attempt`, capped by `retryMaxSeconds`
+- retry state resets after a successful cycle
+- daemon shutdown stops further scheduling and calls provider `shutdown()`
 
 ## Conflict Resolution Baseline
 

--- a/packages/core/src/sync-provider.test.ts
+++ b/packages/core/src/sync-provider.test.ts
@@ -1,24 +1,37 @@
 import { describe, expect, it } from "vitest";
 import {
+  type AnySyncProviderRegistration,
   isSyncProviderApiVersionCompatible,
+  isSyncProviderRegistrationV2,
+  isSyncProviderRegistrationV3,
   SYNC_PROVIDER_API_VERSION,
-  type SyncProviderRegistration,
+  SYNC_PROVIDER_API_VERSION_V2,
+  SYNC_PROVIDER_API_VERSION_V3,
   validateSyncProviderRegistration,
 } from "./sync-provider.js";
 
 describe("isSyncProviderApiVersionCompatible", () => {
-  it("accepts matching API version", () => {
+  it("accepts supported v2 API version", () => {
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V2)).toBe(true);
+  });
+
+  it("accepts supported v3 API version", () => {
     expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION)).toBe(true);
   });
 
-  it("rejects mismatched API version", () => {
-    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION + 1)).toBe(false);
+  it("rejects unsupported API version", () => {
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3 + 1)).toBe(false);
+  });
+
+  it("supports explicit supported version lists", () => {
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [2, 3])).toBe(true);
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [2])).toBe(false);
   });
 });
 
 describe("validateSyncProviderRegistration", () => {
-  it("accepts a valid provider registration", () => {
-    const registration = createValidRegistration();
+  it("accepts a valid v2 provider registration", () => {
+    const registration = createValidV2Registration();
 
     const result = validateSyncProviderRegistration(registration);
 
@@ -27,16 +40,35 @@ describe("validateSyncProviderRegistration", () => {
       throw new Error("Expected valid sync provider registration");
     }
 
+    expect(isSyncProviderRegistrationV2(result.value)).toBe(true);
     expect(result.value.manifest).toEqual({
       name: "github",
       version: "1.2.3",
-      apiVersion: SYNC_PROVIDER_API_VERSION,
+      apiVersion: SYNC_PROVIDER_API_VERSION_V2,
     });
   });
 
-  it("rejects provider with incompatible API version", () => {
-    const registration = createValidRegistration();
-    registration.manifest.apiVersion = SYNC_PROVIDER_API_VERSION + 1;
+  it("accepts a valid v3 provider registration", () => {
+    const registration = createValidV3Registration();
+
+    const result = validateSyncProviderRegistration(registration);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected valid v3 sync provider registration");
+    }
+
+    expect(isSyncProviderRegistrationV3(result.value)).toBe(true);
+    expect(result.value.manifest).toEqual({
+      name: "github",
+      version: "1.2.3",
+      apiVersion: SYNC_PROVIDER_API_VERSION_V3,
+    });
+  });
+
+  it("rejects provider with unsupported API version", () => {
+    const registration = createValidV3Registration();
+    registration.manifest.apiVersion = (SYNC_PROVIDER_API_VERSION_V3 + 1) as never;
 
     const result = validateSyncProviderRegistration(registration);
 
@@ -48,14 +80,36 @@ describe("validateSyncProviderRegistration", () => {
     expect(result.error).toMatchObject({
       code: "API_VERSION_MISMATCH",
       details: {
-        providerApiVersion: SYNC_PROVIDER_API_VERSION + 1,
-        supportedApiVersion: SYNC_PROVIDER_API_VERSION,
+        providerApiVersion: SYNC_PROVIDER_API_VERSION_V3 + 1,
+        supportedApiVersions: [SYNC_PROVIDER_API_VERSION_V2, SYNC_PROVIDER_API_VERSION_V3],
       },
     });
   });
 
-  it("rejects provider missing required lifecycle methods", () => {
-    const registration = createValidRegistration();
+  it("supports explicit single-version host policy overrides", () => {
+    const registration = createValidV3Registration();
+
+    const result = validateSyncProviderRegistration(registration, {
+      supportedApiVersion: SYNC_PROVIDER_API_VERSION_V2,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected registration to fail when host only allows v2");
+    }
+
+    expect(result.error).toMatchObject({
+      code: "API_VERSION_MISMATCH",
+      details: {
+        providerApiVersion: SYNC_PROVIDER_API_VERSION_V3,
+        supportedApiVersion: SYNC_PROVIDER_API_VERSION_V2,
+        supportedApiVersions: [SYNC_PROVIDER_API_VERSION_V2],
+      },
+    });
+  });
+
+  it("rejects v2 provider missing required lifecycle methods", () => {
+    const registration = createValidV2Registration();
     registration.provider.shutdown = undefined as unknown as () => Promise<void>;
 
     const result = validateSyncProviderRegistration(registration);
@@ -69,12 +123,33 @@ describe("validateSyncProviderRegistration", () => {
       code: "INVALID_PROVIDER",
       details: {
         method: "shutdown",
+        apiVersion: SYNC_PROVIDER_API_VERSION_V2,
+      },
+    });
+  });
+
+  it("rejects v3 provider missing required lifecycle methods", () => {
+    const registration = createValidV3Registration();
+    registration.provider.pull = undefined as unknown as typeof registration.provider.pull;
+
+    const result = validateSyncProviderRegistration(registration);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected v3 registration to fail for missing provider method");
+    }
+
+    expect(result.error).toMatchObject({
+      code: "INVALID_PROVIDER",
+      details: {
+        method: "pull",
+        apiVersion: SYNC_PROVIDER_API_VERSION_V3,
       },
     });
   });
 
   it("rejects provider/manifest identity mismatch", () => {
-    const registration = createValidRegistration();
+    const registration = createValidV2Registration();
     registration.provider.version = "9.9.9";
 
     const result = validateSyncProviderRegistration(registration);
@@ -94,8 +169,8 @@ describe("validateSyncProviderRegistration", () => {
   });
 
   it("rejects invalid manifest apiVersion values", () => {
-    const registration = createValidRegistration();
-    registration.manifest.apiVersion = 0;
+    const registration = createValidV2Registration();
+    registration.manifest.apiVersion = 0 as never;
 
     const result = validateSyncProviderRegistration(registration);
 
@@ -114,7 +189,7 @@ describe("validateSyncProviderRegistration", () => {
   });
 
   it("rejects non-string manifest name without throwing", () => {
-    const registration = createValidRegistration();
+    const registration = createValidV2Registration();
     (registration.manifest as unknown as Record<string, unknown>).name = 42;
 
     const result = validateSyncProviderRegistration(registration);
@@ -133,12 +208,12 @@ describe("validateSyncProviderRegistration", () => {
   });
 });
 
-function createValidRegistration(): SyncProviderRegistration {
+function createValidV2Registration(): AnySyncProviderRegistration {
   return {
     manifest: {
       name: "github",
       version: "1.2.3",
-      apiVersion: SYNC_PROVIDER_API_VERSION,
+      apiVersion: SYNC_PROVIDER_API_VERSION_V2,
     },
     provider: {
       name: "github",
@@ -164,6 +239,7 @@ function createValidRegistration(): SyncProviderRegistration {
           priority: "medium",
           projectId: "project-1" as never,
           labels: [],
+          assigneeActorIds: [],
           assignees: [],
           createdAt: new Date(0).toISOString(),
           updatedAt: new Date(0).toISOString(),
@@ -173,6 +249,34 @@ function createValidRegistration(): SyncProviderRegistration {
         return {
           externalId: "ext-1",
           title: "Example",
+        };
+      },
+    },
+  };
+}
+
+function createValidV3Registration(): AnySyncProviderRegistration {
+  return {
+    manifest: {
+      name: "github",
+      version: "1.2.3",
+      apiVersion: SYNC_PROVIDER_API_VERSION_V3,
+    },
+    provider: {
+      name: "github",
+      version: "1.2.3",
+      async initialize() {},
+      async shutdown() {},
+      async pull() {
+        return {
+          tasks: [],
+          comments: [],
+        };
+      },
+      async push() {
+        return {
+          commentLinks: [],
+          taskLinks: [],
         };
       },
     },

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -7,10 +7,18 @@ import {
   type Result,
   type Task,
   type TaskId,
+  type TaskPriority,
   type TaskPushPayload,
+  type TaskStatus,
 } from "./types.js";
 
-export const SYNC_PROVIDER_API_VERSION = 2 as const;
+export const SYNC_PROVIDER_API_VERSION_V2 = 2 as const;
+export const SYNC_PROVIDER_API_VERSION_V3 = 3 as const;
+export const SYNC_PROVIDER_API_VERSION = SYNC_PROVIDER_API_VERSION_V3;
+export const SYNC_PROVIDER_SUPPORTED_API_VERSIONS = [
+  SYNC_PROVIDER_API_VERSION_V2,
+  SYNC_PROVIDER_API_VERSION_V3,
+] as const;
 
 export const SYNC_CONFLICT_RESOLUTION_POLICIES = ["last-write-wins"] as const;
 export type SyncConflictResolutionPolicy = (typeof SYNC_CONFLICT_RESOLUTION_POLICIES)[number];
@@ -45,6 +53,58 @@ export interface ExternalComment {
   raw?: unknown;
 }
 
+export interface ExternalActorRef {
+  externalAccountId?: string;
+  externalLogin?: string;
+  displayName?: string;
+  raw?: unknown;
+}
+
+export interface ImportedTaskInput {
+  externalId: string;
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  labels?: string[];
+  assignees?: ExternalActorRef[];
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+export interface ImportedCommentInput {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: ExternalActorRef;
+  createdAt: string;
+  updatedAt?: string;
+  raw?: unknown;
+}
+
+export interface ExportedCommentInput {
+  localNoteId: NoteId;
+  body: string;
+  createdAt: string;
+  updatedAt?: string;
+  sourceUrl?: string;
+}
+
+export interface ExportedTaskInput {
+  localTaskId: TaskId;
+  externalId?: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  labels: string[];
+  assignees: ExternalActorRef[];
+  sourceUrl?: string;
+  comments: ExportedCommentInput[];
+}
+
 export interface SyncProviderConfig {
   settings: Record<string, unknown>;
 }
@@ -52,6 +112,11 @@ export interface SyncProviderConfig {
 export interface SyncProviderPullResult {
   tasks: ExternalTask[];
   comments?: ExternalComment[];
+}
+
+export interface SyncProviderPullResultV3 {
+  tasks: ImportedTaskInput[];
+  comments?: ImportedCommentInput[];
 }
 
 export interface SyncProviderPushCommentLink {
@@ -75,7 +140,7 @@ export interface SyncProviderPushResult {
   taskLinks: SyncProviderPushTaskLink[];
 }
 
-export interface SyncProvider {
+export interface SyncProviderV2 {
   readonly name: string;
   readonly version: string;
   initialize(config: SyncProviderConfig): Promise<void>;
@@ -90,10 +155,39 @@ export interface SyncProvider {
   mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
 }
 
-export interface SyncProviderRegistration {
-  manifest: SyncProviderManifest;
-  provider: SyncProvider;
+export interface SyncProviderV3 {
+  readonly name: string;
+  readonly version: string;
+  initialize(config: SyncProviderConfig): Promise<void>;
+  shutdown(): Promise<void>;
+  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResultV3>;
+  push(
+    binding: IntegrationBinding,
+    tasks: ExportedTaskInput[],
+    project: Project,
+  ): Promise<SyncProviderPushResult>;
 }
+
+export type SyncProvider = SyncProviderV2;
+export type AnySyncProvider = SyncProviderV2 | SyncProviderV3;
+
+export interface SyncProviderRegistrationV2 {
+  manifest: SyncProviderManifest & {
+    apiVersion: typeof SYNC_PROVIDER_API_VERSION_V2;
+  };
+  provider: SyncProviderV2;
+}
+
+export interface SyncProviderRegistrationV3 {
+  manifest: SyncProviderManifest & {
+    apiVersion: typeof SYNC_PROVIDER_API_VERSION_V3;
+  };
+  provider: SyncProviderV3;
+}
+
+export type AnySyncProviderRegistration = SyncProviderRegistrationV2 | SyncProviderRegistrationV3;
+export type SyncProviderRegistration = AnySyncProviderRegistration;
+export type LegacySyncProviderRegistration = SyncProviderRegistrationV2;
 
 export const SYNC_PROVIDER_VALIDATION_ERROR_CODES = [
   "INVALID_MANIFEST",
@@ -112,9 +206,10 @@ export interface SyncProviderValidationError {
 
 export interface ValidateSyncProviderRegistrationOptions {
   supportedApiVersion?: number;
+  supportedApiVersions?: readonly number[];
 }
 
-const REQUIRED_SYNC_PROVIDER_METHODS = [
+const REQUIRED_SYNC_PROVIDER_V2_METHODS = [
   "initialize",
   "shutdown",
   "pull",
@@ -123,18 +218,40 @@ const REQUIRED_SYNC_PROVIDER_METHODS = [
   "mapFromTask",
 ] as const;
 
+const REQUIRED_SYNC_PROVIDER_V3_METHODS = ["initialize", "shutdown", "pull", "push"] as const;
+
 export function isSyncProviderApiVersionCompatible(
   providerApiVersion: number,
-  supportedApiVersion: number = SYNC_PROVIDER_API_VERSION,
+  supportedApiVersions: readonly number[] | number = SYNC_PROVIDER_SUPPORTED_API_VERSIONS,
 ): boolean {
-  return Number.isInteger(providerApiVersion) && providerApiVersion === supportedApiVersion;
+  if (!Number.isInteger(providerApiVersion)) {
+    return false;
+  }
+
+  const normalizedSupportedApiVersions = Array.isArray(supportedApiVersions)
+    ? supportedApiVersions
+    : [supportedApiVersions];
+
+  return normalizedSupportedApiVersions.includes(providerApiVersion);
+}
+
+export function isSyncProviderRegistrationV2(
+  registration: AnySyncProviderRegistration,
+): registration is SyncProviderRegistrationV2 {
+  return registration.manifest.apiVersion === SYNC_PROVIDER_API_VERSION_V2;
+}
+
+export function isSyncProviderRegistrationV3(
+  registration: AnySyncProviderRegistration,
+): registration is SyncProviderRegistrationV3 {
+  return registration.manifest.apiVersion === SYNC_PROVIDER_API_VERSION_V3;
 }
 
 export function validateSyncProviderRegistration(
-  registration: SyncProviderRegistration,
+  registration: AnySyncProviderRegistration,
   options: ValidateSyncProviderRegistrationOptions = {},
-): Result<SyncProviderRegistration, SyncProviderValidationError> {
-  const supportedApiVersion = options.supportedApiVersion ?? SYNC_PROVIDER_API_VERSION;
+): Result<AnySyncProviderRegistration, SyncProviderValidationError> {
+  const supportedApiVersions = resolveSupportedApiVersions(options);
 
   const manifestCandidate = registration.manifest as unknown;
   if (!manifestCandidate || typeof manifestCandidate !== "object") {
@@ -187,15 +304,23 @@ export function validateSyncProviderRegistration(
     );
   }
 
-  if (!isSyncProviderApiVersionCompatible(manifestApiVersion, supportedApiVersion)) {
+  if (!isSyncProviderApiVersionCompatible(manifestApiVersion, supportedApiVersions)) {
     return err(
       createSyncProviderValidationError(
         "API_VERSION_MISMATCH",
-        `Sync provider API version mismatch: provider=${manifestApiVersion} host=${supportedApiVersion}`,
-        {
-          providerApiVersion: manifestApiVersion,
-          supportedApiVersion,
-        },
+        `Sync provider API version mismatch: provider=${manifestApiVersion} host=${supportedApiVersions.join(",")}`,
+        createApiVersionMismatchDetails(manifestApiVersion, supportedApiVersions),
+      ),
+    );
+  }
+
+  const requiredMethods = getRequiredSyncProviderMethods(manifestApiVersion);
+  if (!requiredMethods) {
+    return err(
+      createSyncProviderValidationError(
+        "API_VERSION_MISMATCH",
+        `Sync provider API version is recognized as compatible but has no validator: provider=${manifestApiVersion}`,
+        createApiVersionMismatchDetails(manifestApiVersion, supportedApiVersions),
       ),
     );
   }
@@ -250,7 +375,7 @@ export function validateSyncProviderRegistration(
     );
   }
 
-  for (const method of REQUIRED_SYNC_PROVIDER_METHODS) {
+  for (const method of requiredMethods) {
     if (typeof providerRecord[method] !== "function") {
       return err(
         createSyncProviderValidationError(
@@ -258,20 +383,74 @@ export function validateSyncProviderRegistration(
           `Sync provider is missing required method: ${method}`,
           {
             method,
+            apiVersion: manifestApiVersion,
           },
         ),
       );
     }
   }
 
+  const normalizedManifest = {
+    name: manifestName,
+    version: manifestVersion,
+    apiVersion: manifestApiVersion,
+  };
+
+  if (manifestApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
+    return ok({
+      manifest: normalizedManifest as SyncProviderRegistrationV2["manifest"],
+      provider: registration.provider as SyncProviderV2,
+    });
+  }
+
   return ok({
-    manifest: {
-      name: manifestName,
-      version: manifestVersion,
-      apiVersion: manifestApiVersion,
-    },
-    provider: registration.provider,
+    manifest: normalizedManifest as SyncProviderRegistrationV3["manifest"],
+    provider: registration.provider as SyncProviderV3,
   });
+}
+
+function resolveSupportedApiVersions(
+  options: ValidateSyncProviderRegistrationOptions,
+): readonly number[] {
+  if (options.supportedApiVersions) {
+    return options.supportedApiVersions;
+  }
+
+  if (options.supportedApiVersion !== undefined) {
+    return [options.supportedApiVersion];
+  }
+
+  return SYNC_PROVIDER_SUPPORTED_API_VERSIONS;
+}
+
+function getRequiredSyncProviderMethods(apiVersion: number): readonly string[] | null {
+  if (apiVersion === SYNC_PROVIDER_API_VERSION_V2) {
+    return REQUIRED_SYNC_PROVIDER_V2_METHODS;
+  }
+
+  if (apiVersion === SYNC_PROVIDER_API_VERSION_V3) {
+    return REQUIRED_SYNC_PROVIDER_V3_METHODS;
+  }
+
+  return null;
+}
+
+function createApiVersionMismatchDetails(
+  providerApiVersion: number,
+  supportedApiVersions: readonly number[],
+): Record<string, unknown> {
+  if (supportedApiVersions.length === 1) {
+    return {
+      providerApiVersion,
+      supportedApiVersion: supportedApiVersions[0],
+      supportedApiVersions: [...supportedApiVersions],
+    };
+  }
+
+  return {
+    providerApiVersion,
+    supportedApiVersions: [...supportedApiVersions],
+  };
 }
 
 function normalizeNonEmptyString(value: unknown): string | null {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -27,7 +27,11 @@ import {
   DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
   DEFAULT_DAEMON_VERSION,
 } from "./rpc.js";
-import { type LoadedConfiguredPlugin, loadConfiguredPlugins } from "./sync-plugin-loader.js";
+import {
+  isLoadedSyncPluginV2,
+  type LoadedConfiguredPlugin,
+  loadConfiguredPlugins,
+} from "./sync-plugin-loader.js";
 import {
   createSyncPluginWorkerRuntime,
   resolveSyncPluginExecutionConfig,
@@ -675,6 +679,17 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       let workerRegistration: WorkerRegistration;
 
       if (loadedPlugin.kind === "sync-provider") {
+        if (!isLoadedSyncPluginV2(loadedPlugin)) {
+          runtimeLogger.info("sync provider loaded without runtime execution support yet", {
+            pluginName: loadedPlugin.manifest.name,
+            pluginVersion: loadedPlugin.manifest.version,
+            modulePath: loadedPlugin.modulePath,
+            apiVersion: loadedPlugin.manifest.apiVersion,
+          });
+          loadedPlugins.set(loadedPlugin.workerRegistration.manifest.type, loadedPlugin);
+          continue;
+        }
+
         const pluginConfigResolution = resolveSyncPluginExecutionConfig(
           loadedPlugin.manifest.name,
           pluginConfig,

--- a/packages/daemon/src/sync-plugin-loader.ts
+++ b/packages/daemon/src/sync-plugin-loader.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
-  type SyncProviderRegistration,
+  type AnySyncProviderRegistration,
+  isSyncProviderRegistrationV2,
+  type SyncProviderRegistrationV2,
+  type SyncProviderRegistrationV3,
   type SyncProviderValidationError,
   validateSyncProviderRegistration,
   validateWorkerPluginRegistration,
@@ -30,13 +33,23 @@ export interface SyncPluginLoadError {
   details?: Record<string, unknown>;
 }
 
-export interface LoadedSyncPlugin {
+export interface LoadedSyncPluginV2 {
   kind: "sync-provider";
   workerRegistration: WorkerRegistration;
-  manifest: SyncProviderRegistration["manifest"];
-  provider: SyncProviderRegistration["provider"];
+  manifest: SyncProviderRegistrationV2["manifest"];
+  provider: SyncProviderRegistrationV2["provider"];
   modulePath: string;
 }
+
+export interface LoadedSyncPluginV3 {
+  kind: "sync-provider";
+  workerRegistration: WorkerRegistration;
+  manifest: SyncProviderRegistrationV3["manifest"];
+  provider: SyncProviderRegistrationV3["provider"];
+  modulePath: string;
+}
+
+export type LoadedSyncPlugin = LoadedSyncPluginV2 | LoadedSyncPluginV3;
 
 export interface LoadedWorkerPlugin {
   kind: "worker-plugin";
@@ -47,6 +60,14 @@ export interface LoadedWorkerPlugin {
 }
 
 export type LoadedConfiguredPlugin = LoadedSyncPlugin | LoadedWorkerPlugin;
+
+export function isLoadedSyncPluginV2(plugin: LoadedSyncPlugin): plugin is LoadedSyncPluginV2 {
+  return plugin.manifest.apiVersion === 2;
+}
+
+export function isLoadedSyncPluginV3(plugin: LoadedSyncPlugin): plugin is LoadedSyncPluginV3 {
+  return plugin.manifest.apiVersion === 3;
+}
 
 export interface LoadConfiguredPluginsResult {
   loadedPlugins: LoadedConfiguredPlugin[];
@@ -163,16 +184,29 @@ export async function loadConfiguredPlugins(
 
     seenWorkerTypes.add(workerType);
 
-    loadedPlugins.push({
-      kind: "sync-provider",
-      modulePath,
-      manifest: syncValidation.value.manifest,
-      provider: syncValidation.value.provider,
-      workerRegistration: {
-        manifest: createSyncPluginWorkerManifest(workerType),
-        runtime: createNoopWorkerRuntime(),
-      },
-    });
+    loadedPlugins.push(
+      isSyncProviderRegistrationV2(syncValidation.value)
+        ? {
+            kind: "sync-provider",
+            modulePath,
+            manifest: syncValidation.value.manifest,
+            provider: syncValidation.value.provider,
+            workerRegistration: {
+              manifest: createSyncPluginWorkerManifest(workerType),
+              runtime: createNoopWorkerRuntime(),
+            },
+          }
+        : {
+            kind: "sync-provider",
+            modulePath,
+            manifest: syncValidation.value.manifest,
+            provider: syncValidation.value.provider,
+            workerRegistration: {
+              manifest: createSyncPluginWorkerManifest(workerType),
+              runtime: createNoopWorkerRuntime(),
+            },
+          },
+    );
   }
 
   return {
@@ -215,7 +249,9 @@ function createInvalidWorkerPluginError(
   };
 }
 
-function extractSyncProviderRegistration(moduleExports: unknown): SyncProviderRegistration | null {
+function extractSyncProviderRegistration(
+  moduleExports: unknown,
+): AnySyncProviderRegistration | null {
   if (!moduleExports || typeof moduleExports !== "object") {
     return null;
   }
@@ -226,7 +262,7 @@ function extractSyncProviderRegistration(moduleExports: unknown): SyncProviderRe
     return null;
   }
 
-  return candidate as SyncProviderRegistration;
+  return candidate as AnySyncProviderRegistration;
 }
 
 function extractWorkerPluginRegistration(moduleExports: unknown): WorkerPluginRegistration | null {


### PR DESCRIPTION
## Summary
- add sync-provider API v3 types for structured actor refs and normalized payloads
- accept both v2 and v3 provider manifests during the rollout window
- document the v2/v3 compatibility policy for plugin authors

## Testing
- make pre-pr