### PR TITLE
feat: add actor-aware sync runtime shims

### DIFF
--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -1347,6 +1347,56 @@ describe("createDaemonRuntime", () => {
     expect(runtime.getWorker("github-sync")?.state).toBe("stopped");
   });
 
+  it("loads configured v3 sync plugins and surfaces runtime state via worker.status", async () => {
+    const pluginPath = writeValidSyncPluginModule(tmpDir, "github-plugin-v3.mjs", {
+      providerName: "github",
+      providerVersion: "2.0.0",
+      apiVersion: 3,
+    });
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      syncPluginModulePaths: [pluginPath],
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await runtime.start();
+
+    expect(runtime.getWorker("github-sync")).toMatchObject({
+      state: "running",
+      manifest: {
+        type: "github-sync",
+      },
+    });
+
+    const workerStatusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "worker-status-plugin-v3-1",
+      method: "worker.status",
+      params: {
+        workerType: "github-sync",
+      },
+    });
+
+    expect(workerStatusResponse).toEqual({
+      id: "worker-status-plugin-v3-1",
+      result: {
+        workers: [
+          expect.objectContaining({
+            type: "github-sync",
+            state: "running",
+            requiredDomains: ["sync", "task"],
+          }),
+        ],
+        assignment: {
+          assignedWorkerTypes: null,
+        },
+        enabledWorkerDomains: ["project", "task", "sync"],
+      },
+    });
+
+    await runtime.stop();
+  });
+
   it("executes sync provider work from integration bindings and persists status for later observers", async () => {
     const outputPath = path.join(tmpDir, "github-provider-events.ndjson");
     const pluginPath = writeRecordingSyncPluginModule(tmpDir, "github-recording-plugin.mjs", {
@@ -1493,6 +1543,117 @@ describe("createDaemonRuntime", () => {
     );
 
     await observerRuntime.stop();
+  });
+
+  it("executes mixed v2 and v3 sync providers in the same daemon runtime", async () => {
+    const githubOutputPath = path.join(tmpDir, "github-provider-events.ndjson");
+    const forgejoOutputPath = path.join(tmpDir, "forgejo-provider-events.ndjson");
+    const githubPluginPath = writeRecordingSyncPluginModule(tmpDir, "github-mixed-plugin.mjs", {
+      providerName: "github",
+      providerVersion: "1.0.0",
+      outputPath: githubOutputPath,
+      apiVersion: 2,
+    });
+    const forgejoPluginPath = writeRecordingSyncPluginModule(tmpDir, "forgejo-mixed-plugin.mjs", {
+      providerName: "forgejo",
+      providerVersion: "2.0.0",
+      outputPath: forgejoOutputPath,
+      apiVersion: 3,
+    });
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      socketPath: path.join(tmpDir, "mixed.sock"),
+      syncPluginModulePaths: [githubPluginPath, forgejoPluginPath],
+      syncPluginConfigs: {
+        github: { intervalSeconds: 0.05 },
+        forgejo: { intervalSeconds: 0.05 },
+      },
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await runtime.start();
+
+    const githubProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-mixed-github-create",
+      method: "project.create",
+      params: { input: { name: "GitHub Mixed Project" } },
+    });
+    const githubProjectId = (githubProjectResponse.result as { id: string }).id;
+
+    const forgejoProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-mixed-forgejo-create",
+      method: "project.create",
+      params: { input: { name: "Forgejo Mixed Project" } },
+    });
+    const forgejoProjectId = (forgejoProjectResponse.result as { id: string }).id;
+
+    await sendRequest(runtime.config().socketPath, {
+      id: "task-mixed-github-create",
+      method: "task.create",
+      params: { input: { title: "GitHub Task", projectId: githubProjectId } },
+    });
+    await sendRequest(runtime.config().socketPath, {
+      id: "task-mixed-forgejo-create",
+      method: "task.create",
+      params: { input: { title: "Forgejo Task", projectId: forgejoProjectId } },
+    });
+
+    const githubIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-mixed-github-create",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "github",
+          projectId: githubProjectId,
+          targetKind: "repository",
+          targetRef: "owner/repo",
+          strategy: "bidirectional",
+          enabled: true,
+        },
+      },
+    });
+    const githubBindingId = (githubIntegrationResponse.result as { id: string }).id;
+
+    const forgejoIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-mixed-forgejo-create",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "forgejo",
+          projectId: forgejoProjectId,
+          targetKind: "repository",
+          targetRef: "team/repo",
+          strategy: "bidirectional",
+          enabled: true,
+        },
+      },
+    });
+    const forgejoBindingId = (forgejoIntegrationResponse.result as { id: string }).id;
+
+    await waitForProviderEvent(
+      githubOutputPath,
+      (event) => event.type === "push" && event.bindingId === githubBindingId,
+    );
+    await waitForProviderEvent(
+      forgejoOutputPath,
+      (event) => event.type === "push" && event.bindingId === forgejoBindingId,
+    );
+
+    expect(readProviderEvents(githubOutputPath)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "pull", bindingId: githubBindingId }),
+        expect.objectContaining({ type: "push", bindingId: githubBindingId, taskCount: 1 }),
+      ]),
+    );
+    expect(readProviderEvents(forgejoOutputPath)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "pull", bindingId: forgejoBindingId }),
+        expect.objectContaining({ type: "push", bindingId: forgejoBindingId, taskCount: 1 }),
+      ]),
+    );
+
+    await runtime.stop();
   });
 
   it("loads configured worker plugins and surfaces runtime state via worker.status", async () => {
@@ -2149,15 +2310,37 @@ function writeValidSyncPluginModule(
   options: {
     providerName: string;
     providerVersion: string;
+    apiVersion?: 2 | 3;
   },
 ): string {
   const modulePath = path.join(directory, filename);
 
-  const moduleSource = `export const syncProvider = {
+  const moduleSource =
+    options.apiVersion === 3
+      ? `export const syncProvider = {
   manifest: {
     name: ${JSON.stringify(options.providerName)},
     version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 1,
+    apiVersion: 3,
+  },
+  provider: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    async initialize() {},
+    async shutdown() {},
+    async pull() {
+      return { tasks: [], comments: [] };
+    },
+    async push() {
+      return { commentLinks: [], taskLinks: [] };
+    },
+  },
+};`
+      : `export const syncProvider = {
+  manifest: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    apiVersion: 2,
   },
   provider: {
     name: ${JSON.stringify(options.providerName)},
@@ -2167,7 +2350,9 @@ function writeValidSyncPluginModule(
     async pull() {
       return { tasks: [] };
     },
-    async push() {},
+    async push() {
+      return { commentLinks: [], taskLinks: [] };
+    },
     mapToTask() {
       return {
         id: "task-1",
@@ -2176,6 +2361,7 @@ function writeValidSyncPluginModule(
         priority: "medium",
         projectId: "project-1",
         labels: [],
+        assigneeActorIds: [],
         assignees: [],
         createdAt: new Date(0).toISOString(),
         updatedAt: new Date(0).toISOString(),
@@ -2202,11 +2388,14 @@ function writeRecordingSyncPluginModule(
     providerName: string;
     providerVersion: string;
     outputPath: string;
+    apiVersion?: 2 | 3;
   },
 ): string {
   const modulePath = path.join(directory, filename);
 
-  const moduleSource = `import fs from "node:fs";
+  const moduleSource =
+    options.apiVersion === 3
+      ? `import fs from "node:fs";
 
 const outputPath = ${JSON.stringify(options.outputPath)};
 
@@ -2218,7 +2407,55 @@ export const syncProvider = {
   manifest: {
     name: ${JSON.stringify(options.providerName)},
     version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 1,
+    apiVersion: 3,
+  },
+  provider: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    async initialize(config) {
+      record({ type: "initialize", settings: config.settings });
+    },
+    async shutdown() {
+      record({ type: "shutdown" });
+    },
+    async pull(binding, project) {
+      record({
+        type: "pull",
+        bindingId: binding.id,
+        provider: binding.provider,
+        targetRef: binding.targetRef,
+        projectId: project.id,
+        strategy: binding.strategy,
+      });
+      return { tasks: [], comments: [] };
+    },
+    async push(binding, tasks, project) {
+      record({
+        type: "push",
+        bindingId: binding.id,
+        provider: binding.provider,
+        targetRef: binding.targetRef,
+        projectId: project.id,
+        strategy: binding.strategy,
+        taskCount: tasks.length,
+      });
+      return { commentLinks: [], taskLinks: [] };
+    },
+  },
+};`
+      : `import fs from "node:fs";
+
+const outputPath = ${JSON.stringify(options.outputPath)};
+
+function record(event) {
+  fs.appendFileSync(outputPath, JSON.stringify(event) + "\\n", "utf8");
+}
+
+export const syncProvider = {
+  manifest: {
+    name: ${JSON.stringify(options.providerName)},
+    version: ${JSON.stringify(options.providerVersion)},
+    apiVersion: 2,
   },
   provider: {
     name: ${JSON.stringify(options.providerName)},
@@ -2250,6 +2487,7 @@ export const syncProvider = {
         strategy: binding.strategy,
         taskCount: tasks.length,
       });
+      return { commentLinks: [], taskLinks: [] };
     },
     mapToTask() {
       return {
@@ -2259,6 +2497,7 @@ export const syncProvider = {
         priority: "medium",
         projectId: "project-1",
         labels: [],
+        assigneeActorIds: [],
         assignees: [],
         createdAt: new Date(0).toISOString(),
         updatedAt: new Date(0).toISOString(),

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -1545,6 +1545,127 @@ describe("createDaemonRuntime", () => {
     await observerRuntime.stop();
   });
 
+  it("executes v3 sync provider work from integration bindings and persists status", async () => {
+    const outputPath = path.join(tmpDir, "forgejo-provider-events.ndjson");
+    const pluginPath = writeRecordingSyncPluginModule(tmpDir, "forgejo-recording-plugin.mjs", {
+      providerName: "forgejo",
+      providerVersion: "2.0.0",
+      outputPath,
+      apiVersion: 3,
+    });
+
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      socketPath: path.join(tmpDir, "forgejo-authority.sock"),
+      syncPluginModulePaths: [pluginPath],
+      syncPluginConfigs: {
+        forgejo: {
+          intervalSeconds: 0.05,
+          settings: {
+            token: "env:FORGEJO_TOKEN",
+          },
+        },
+      },
+      enabledWorkerDomains: ["project", "task", "sync"],
+    });
+
+    await runtime.start();
+
+    const createProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-integration-provider-v3-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Provider Project V3",
+        },
+      },
+    });
+
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
+    await sendRequest(runtime.config().socketPath, {
+      id: "task-integration-provider-v3-create",
+      method: "task.create",
+      params: {
+        input: {
+          title: "Existing Task V3",
+          projectId,
+        },
+      },
+    });
+
+    const createIntegrationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-provider-v3-create",
+      method: "integration.create",
+      params: {
+        input: {
+          provider: "forgejo",
+          projectId,
+          targetKind: "repository",
+          targetRef: "team/repo",
+          strategy: "bidirectional",
+          enabled: true,
+        },
+      },
+    });
+
+    const bindingId = (createIntegrationResponse.result as { id: string }).id;
+
+    await waitForProviderEvent(
+      outputPath,
+      (event) => event.type === "push" && event.bindingId === bindingId,
+    );
+
+    expect(readProviderEvents(outputPath)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "initialize",
+          settings: {
+            token: "env:FORGEJO_TOKEN",
+          },
+        }),
+        expect.objectContaining({
+          type: "pull",
+          bindingId,
+          provider: "forgejo",
+          targetRef: "team/repo",
+          projectId,
+          strategy: "bidirectional",
+        }),
+        expect.objectContaining({
+          type: "push",
+          bindingId,
+          provider: "forgejo",
+          targetRef: "team/repo",
+          projectId,
+          strategy: "bidirectional",
+          taskCount: 1,
+        }),
+      ]),
+    );
+
+    const statusResponse = await sendRequest(runtime.config().socketPath, {
+      id: "integration-provider-v3-status",
+      method: "integration.status",
+      params: {
+        id: bindingId,
+      },
+    });
+
+    expect(statusResponse.result).toEqual(
+      expect.objectContaining({
+        bindingId,
+        state: "idle",
+        authorityId: runtime.config().socketPath,
+        lastAttemptedSyncAt: expect.any(String),
+        lastSuccessfulSyncAt: expect.any(String),
+        lastErrorSummary: null,
+      }),
+    );
+
+    await runtime.stop();
+  });
+
   it("executes mixed v2 and v3 sync providers in the same daemon runtime", async () => {
     const githubOutputPath = path.join(tmpDir, "github-provider-events.ndjson");
     const forgejoOutputPath = path.join(tmpDir, "forgejo-provider-events.ndjson");

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -27,11 +27,7 @@ import {
   DEFAULT_DAEMON_REQUEST_TIMEOUT_MS,
   DEFAULT_DAEMON_VERSION,
 } from "./rpc.js";
-import {
-  isLoadedSyncPluginV2,
-  type LoadedConfiguredPlugin,
-  loadConfiguredPlugins,
-} from "./sync-plugin-loader.js";
+import { type LoadedConfiguredPlugin, loadConfiguredPlugins } from "./sync-plugin-loader.js";
 import {
   createSyncPluginWorkerRuntime,
   resolveSyncPluginExecutionConfig,
@@ -679,17 +675,6 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       let workerRegistration: WorkerRegistration;
 
       if (loadedPlugin.kind === "sync-provider") {
-        if (!isLoadedSyncPluginV2(loadedPlugin)) {
-          runtimeLogger.info("sync provider loaded without runtime execution support yet", {
-            pluginName: loadedPlugin.manifest.name,
-            pluginVersion: loadedPlugin.manifest.version,
-            modulePath: loadedPlugin.modulePath,
-            apiVersion: loadedPlugin.manifest.apiVersion,
-          });
-          loadedPlugins.set(loadedPlugin.workerRegistration.manifest.type, loadedPlugin);
-          continue;
-        }
-
         const pluginConfigResolution = resolveSyncPluginExecutionConfig(
           loadedPlugin.manifest.name,
           pluginConfig,
@@ -711,6 +696,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
             modulePath: loadedPlugin.modulePath,
             authorityId: resolvedConfig.socketPath,
             provider: loadedPlugin.provider,
+            providerApiVersion: loadedPlugin.manifest.apiVersion,
             config: pluginConfigResolution.config,
             logger: runtimeLogger,
             getTodu: () => todu,

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1,19 +1,24 @@
 import {
+  type Actor,
+  createActorId,
   createIntegrationBindingId,
   createNoteId,
   createProjectId,
   createTaskId,
   type ExternalComment,
   type ExternalTask,
+  type ImportedCommentInput,
+  type ImportedTaskInput,
   type IntegrationBinding,
   type IntegrationBindingStatus,
   type Note,
   ok,
   type Project,
   type SyncProvider,
+  type SyncProviderV3,
   type Task,
 } from "@todu/core";
-import type { Todu } from "@todu/engine";
+import type { ToduWithInternalTools } from "@todu/engine";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DaemonLogger } from "./logger.js";
 import {
@@ -732,9 +737,17 @@ describe("sync-worker-runtime", () => {
     expect(todu.note.update).toHaveBeenNthCalledWith(1, localNote.id, {
       tags: ["sync:externalId:gh-comment-1"],
     });
-    expect(todu.note.update).toHaveBeenNthCalledWith(2, localNote.id, {
-      content: "remote edit",
-    });
+    expect(todu.note.update).toHaveBeenNthCalledWith(
+      2,
+      localNote.id,
+      expect.objectContaining({
+        content: "remote edit",
+        contentApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+        }),
+      }),
+    );
 
     handle.stop();
   });
@@ -860,21 +873,34 @@ describe("sync-worker-runtime", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(provider.mapToTask).toHaveBeenCalledTimes(1);
-    expect(provider.mapToTask).toHaveBeenCalledWith(pulledTasks[0], project);
-    expect(todu.task.create).toHaveBeenCalledTimes(1);
-    expect(todu.task.create).toHaveBeenCalledWith({
-      title: "Pulled bug",
-      projectId: project.id,
-      status: "waiting",
-      priority: "high",
-      description: "Imported from GitHub",
-      labels: ["bug"],
-      assignees: ["octocat"],
-      externalId: "gh-101",
-      sourceUrl: "https://example.com/issues/101",
-      createdAt: "2021-04-17T14:30:00.000Z",
-      updatedAt: "2026-03-10T15:00:00.000Z",
+    expect(provider.mapToTask).toHaveBeenCalledWith(
+      pulledTasks[0],
+      expect.objectContaining({ id: project.id }),
+    );
+    expect(todu.project.update).toHaveBeenCalledWith(project.id, {
+      authorizedAssigneeActorIds: expect.arrayContaining([createActorId("actor-user")]),
     });
+    expect(todu.task.create).toHaveBeenCalledTimes(1);
+    expect(todu.task.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Pulled bug",
+        projectId: project.id,
+        status: "waiting",
+        priority: "high",
+        description: "Imported from GitHub",
+        descriptionApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+        }),
+        labels: ["bug"],
+        assignees: ["octocat"],
+        assigneeActorIds: expect.arrayContaining([expect.stringMatching(/^actor-imported-/)]),
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+        createdAt: "2021-04-17T14:30:00.000Z",
+        updatedAt: "2026-03-10T15:00:00.000Z",
+      }),
+    );
 
     handle.stop();
   });
@@ -939,17 +965,25 @@ describe("sync-worker-runtime", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(todu.task.update).toHaveBeenCalledTimes(1);
-    expect(todu.task.update).toHaveBeenCalledWith(existingTask.id, {
-      title: "Updated pulled bug",
-      status: "inprogress",
-      priority: "high",
-      description: "Updated from GitHub",
-      labels: ["bug", "synced"],
-      assignees: ["octocat"],
-      externalId: "gh-101",
-      sourceUrl: "https://example.com/issues/101",
-      updatedAt: "2026-03-10T15:00:00.000Z",
-    });
+    expect(todu.task.update).toHaveBeenCalledWith(
+      existingTask.id,
+      expect.objectContaining({
+        title: "Updated pulled bug",
+        status: "inprogress",
+        priority: "high",
+        description: "Updated from GitHub",
+        descriptionApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+        }),
+        labels: ["bug", "synced"],
+        assignees: ["octocat"],
+        assigneeActorIds: expect.arrayContaining([expect.stringMatching(/^actor-imported-/)]),
+        externalId: "gh-101",
+        sourceUrl: "https://example.com/issues/101",
+        updatedAt: "2026-03-10T15:00:00.000Z",
+      }),
+    );
 
     handle.stop();
   });
@@ -1006,18 +1040,25 @@ describe("sync-worker-runtime", () => {
     const handle = runtime.start();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(todu.task.create).toHaveBeenCalledWith({
-      title: "Pulled bug",
-      projectId: project.id,
-      status: "waiting",
-      priority: "high",
-      description: "Imported from GitHub",
-      labels: ["bug"],
-      assignees: ["octocat"],
-      externalId: "gh-101",
-      createdAt: "2021-04-17T14:30:00.000Z",
-      updatedAt: "2021-04-17T14:30:00.000Z",
-    });
+    expect(todu.task.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Pulled bug",
+        projectId: project.id,
+        status: "waiting",
+        priority: "high",
+        description: "Imported from GitHub",
+        descriptionApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+        }),
+        labels: ["bug"],
+        assignees: ["octocat"],
+        assigneeActorIds: expect.arrayContaining([expect.stringMatching(/^actor-imported-/)]),
+        externalId: "gh-101",
+        createdAt: "2021-04-17T14:30:00.000Z",
+        updatedAt: "2021-04-17T14:30:00.000Z",
+      }),
+    );
 
     handle.stop();
   });
@@ -1157,13 +1198,22 @@ describe("sync-worker-runtime", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(todu.note.create).toHaveBeenCalledTimes(1);
-    expect(todu.note.create).toHaveBeenCalledWith({
-      content: "New comment from GitHub",
-      author: "octocat",
-      entityType: "task",
-      entityId: task.id,
-      tags: ["sync:externalId:gh-comment-1"],
-    });
+    expect(todu.note.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "New comment from GitHub",
+        author: "octocat",
+        authorActorId: expect.stringMatching(/^actor-imported-/),
+        contentApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+          sourceActorId: expect.stringMatching(/^actor-imported-/),
+        }),
+        entityType: "task",
+        entityId: task.id,
+        tags: ["sync:externalId:gh-comment-1"],
+        createdAt: "2026-03-10T10:00:00.000Z",
+      }),
+    );
 
     handle.stop();
   });
@@ -1219,9 +1269,18 @@ describe("sync-worker-runtime", () => {
 
     expect(todu.note.create).not.toHaveBeenCalled();
     expect(todu.note.update).toHaveBeenCalledTimes(1);
-    expect(todu.note.update).toHaveBeenCalledWith(existingNote.id, {
-      content: "Updated content from GitHub",
-    });
+    expect(todu.note.update).toHaveBeenCalledWith(
+      existingNote.id,
+      expect.objectContaining({
+        content: "Updated content from GitHub",
+        authorActorId: expect.stringMatching(/^actor-imported-/),
+        contentApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+          sourceActorId: expect.stringMatching(/^actor-imported-/),
+        }),
+      }),
+    );
 
     handle.stop();
   });
@@ -1627,6 +1686,260 @@ describe("sync-worker-runtime", () => {
 
     handle.stop();
   });
+
+  it("reuses trusted actor mappings during v2 pull and skips approval for mapped note authors", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, {
+      strategy: "pull",
+      options: {
+        actorMappings: [
+          {
+            actorId: createActorId("actor-octocat"),
+            externalLogin: "octocat",
+            displayName: "octocat",
+            trusted: true,
+          },
+        ],
+      },
+    });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [
+          {
+            externalId: "gh-101",
+            title: "Pulled bug",
+            description: "Imported from GitHub",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: "Trusted comment",
+            author: "octocat",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      }),
+      mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockReturnValue({
+        id: createTaskId("task-gh-101"),
+        title: "Pulled bug",
+        status: "active",
+        priority: "medium",
+        projectId: project.id,
+        labels: [],
+        assigneeActorIds: [],
+        assignees: ["octocat"],
+        externalId: "gh-101",
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], {
+      actors: [{ id: createActorId("actor-octocat"), displayName: "octocat" }],
+    });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.integration.update).not.toHaveBeenCalled();
+    expect(todu.task.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigneeActorIds: [createActorId("actor-octocat")],
+      }),
+    );
+    expect(todu.note.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorActorId: createActorId("actor-octocat"),
+        contentApproval: expect.objectContaining({
+          state: "notRequired",
+          sourceBindingId: binding.id,
+          sourceActorId: createActorId("actor-octocat"),
+        }),
+      }),
+    );
+
+    handle.stop();
+  });
+
+  it("executes the v3 import path and auto-creates actor mappings", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const provider = createV3Provider({
+      pull: vi.fn<SyncProviderV3["pull"]>().mockResolvedValue({
+        tasks: [
+          {
+            externalId: "gh-101",
+            title: "Pulled via v3",
+            description: "Imported from v3",
+            assignees: [{ externalLogin: "octocat", displayName: "Octocat" }],
+            createdAt: "2026-01-01T00:00:00Z",
+          } satisfies ImportedTaskInput,
+        ],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: "Imported comment",
+            author: { externalLogin: "octobot", displayName: "Octobot" },
+            createdAt: "2026-01-02T00:00:00Z",
+          } satisfies ImportedCommentInput,
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      providerApiVersion: 3,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.integration.update).toHaveBeenCalledTimes(1);
+    expect(todu.integration.update).toHaveBeenCalledWith(
+      binding.id,
+      expect.objectContaining({
+        options: expect.objectContaining({
+          actorMappings: expect.arrayContaining([
+            expect.objectContaining({
+              externalLogin: "octocat",
+              trusted: false,
+            }),
+            expect.objectContaining({
+              externalLogin: "octobot",
+              trusted: false,
+            }),
+          ]),
+        }),
+      }),
+    );
+    expect(todu.task.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Pulled via v3",
+        assigneeActorIds: expect.arrayContaining([expect.stringMatching(/^actor-imported-/)]),
+        descriptionApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+        }),
+      }),
+    );
+    expect(todu.note.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorActorId: expect.stringMatching(/^actor-imported-/),
+        contentApproval: expect.objectContaining({
+          state: "pendingApproval",
+          sourceBindingId: binding.id,
+          sourceActorId: expect.stringMatching(/^actor-imported-/),
+        }),
+      }),
+    );
+
+    handle.stop();
+  });
+
+  it("skips unmapped outbound assignees with warnings on the v3 push path", async () => {
+    const project = createProject();
+    const task = createTask(project.id, {
+      assigneeActorIds: [createActorId("actor-mapped"), createActorId("actor-unmapped")],
+    });
+    const binding = createBinding(project.id, {
+      strategy: "push",
+      options: {
+        actorMappings: [
+          {
+            actorId: createActorId("actor-mapped"),
+            externalLogin: "octocat",
+            displayName: "Octocat",
+          },
+        ],
+      },
+    });
+    const provider = createV3Provider();
+    const logger = createLogger();
+    const todu = createTodu(project, [task], [binding], {
+      actors: [
+        { id: createActorId("actor-mapped"), displayName: "Mapped" },
+        { id: createActorId("actor-unmapped"), displayName: "Unmapped" },
+      ],
+    });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      providerApiVersion: 3,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger,
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(provider.push).toHaveBeenCalledWith(
+      binding,
+      [
+        expect.objectContaining({
+          localTaskId: task.id,
+          assignees: [{ externalLogin: "octocat", displayName: "Octocat" }],
+        }),
+      ],
+      expect.objectContaining({ id: project.id }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "sync plugin skipped unmapped outbound assignee",
+      expect.objectContaining({
+        bindingId: binding.id,
+        taskId: task.id,
+        actorId: createActorId("actor-unmapped"),
+      }),
+    );
+
+    handle.stop();
+  });
 });
 
 function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
@@ -1642,6 +1955,7 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
       priority: "medium",
       projectId: createProject().id,
       labels: [],
+      assigneeActorIds: [],
       assignees: [],
       createdAt: new Date(0).toISOString(),
       updatedAt: new Date(0).toISOString(),
@@ -1656,6 +1970,18 @@ function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
   };
 }
 
+function createV3Provider(overrides: Partial<SyncProviderV3> = {}): SyncProviderV3 {
+  return {
+    initialize: vi.fn<SyncProviderV3["initialize"]>().mockResolvedValue(undefined),
+    pull: vi.fn<SyncProviderV3["pull"]>().mockResolvedValue({ tasks: [], comments: [] }),
+    push: vi.fn<SyncProviderV3["push"]>().mockResolvedValue({ commentLinks: [], taskLinks: [] }),
+    shutdown: vi.fn<SyncProviderV3["shutdown"]>().mockResolvedValue(undefined),
+    name: "github",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
 function createProject(): Project {
   const now = new Date(0).toISOString();
 
@@ -1664,6 +1990,7 @@ function createProject(): Project {
     name: "Project",
     status: "active",
     priority: "medium",
+    authorizedAssigneeActorIds: [createActorId("actor-user")],
     createdAt: now,
     updatedAt: now,
   };
@@ -1679,6 +2006,7 @@ function createTask(projectId: Project["id"], overrides: Partial<Task> = {}): Ta
     priority: overrides.priority ?? "medium",
     projectId,
     labels: overrides.labels ?? [],
+    assigneeActorIds: overrides.assigneeActorIds ?? [],
     assignees: overrides.assignees ?? [],
     externalId: overrides.externalId,
     sourceUrl: overrides.sourceUrl,
@@ -1714,6 +2042,8 @@ function createNote(overrides: Partial<Note> & { content: string }): Note {
     id: createNoteId(overrides.id ?? `note-${Math.random().toString(36).slice(2, 8)}`),
     content: overrides.content,
     author: overrides.author ?? "user",
+    authorActorId: overrides.authorActorId,
+    contentApproval: overrides.contentApproval,
     entityType: overrides.entityType,
     entityId: overrides.entityId,
     tags: overrides.tags ?? [],
@@ -1723,6 +2053,7 @@ function createNote(overrides: Partial<Note> & { content: string }): Note {
 
 interface CreateToduOptions {
   notes?: Note[];
+  actors?: Actor[];
 }
 
 function createTodu(
@@ -1731,10 +2062,15 @@ function createTodu(
   bindings: IntegrationBinding[],
   options: CreateToduOptions = {},
 ): {
-  instance: Todu;
+  instance: ToduWithInternalTools;
   integration: {
     list: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
+  };
+  project: {
+    get: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
   };
   task: {
     list: ReturnType<typeof vi.fn>;
@@ -1748,9 +2084,17 @@ function createTodu(
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
   };
+  actors: Actor[];
 } {
   const tasks: Task[] = [...initialTasks];
   const notes: Note[] = [...(options.notes ?? [])];
+  const actors: Actor[] = [{ id: createActorId("actor-user"), displayName: "user" }];
+  for (const actor of options.actors ?? []) {
+    if (!actors.some((candidate) => candidate.id === actor.id)) {
+      actors.push(actor);
+    }
+  }
+
   const statuses = new Map<string, IntegrationBindingStatus>();
   const integrationList = vi.fn(async (filter?: { provider?: string; enabled?: boolean }) => {
     let filtered = bindings;
@@ -1764,6 +2108,18 @@ function createTodu(
 
     return ok(filtered);
   });
+
+  const integrationUpdate = vi.fn(
+    async (id: string, input: { options?: IntegrationBinding["options"] }) => {
+      const binding = bindings.find((candidate) => candidate.id === id);
+      if (!binding) return ok(undefined);
+      if (input.options !== undefined) {
+        binding.options = input.options;
+      }
+      binding.updatedAt = new Date(0).toISOString();
+      return ok({ ...binding });
+    },
+  );
 
   const updateStatus = vi.fn(
     async (
@@ -1810,6 +2166,29 @@ function createTodu(
     },
   );
 
+  const projectGet = vi.fn().mockImplementation(async (id: string) => {
+    if (project.id !== id) return ok(undefined);
+    return ok({ ...project, authorizedAssigneeActorIds: [...project.authorizedAssigneeActorIds] });
+  });
+
+  const projectUpdate = vi.fn().mockImplementation(
+    async (
+      id: string,
+      input: {
+        authorizedAssigneeActorIds?: Project["authorizedAssigneeActorIds"];
+      },
+    ) => {
+      if (project.id !== id) return ok(undefined);
+      if (input.authorizedAssigneeActorIds !== undefined) {
+        project.authorizedAssigneeActorIds = [...input.authorizedAssigneeActorIds];
+      }
+      return ok({
+        ...project,
+        authorizedAssigneeActorIds: [...project.authorizedAssigneeActorIds],
+      });
+    },
+  );
+
   const taskList = vi.fn().mockImplementation(async (filter?: { projectId?: string }) => {
     if (!filter?.projectId) {
       return ok([...tasks]);
@@ -1833,7 +2212,9 @@ function createTodu(
         status?: Task["status"];
         priority?: Task["priority"];
         description?: string;
+        descriptionApproval?: unknown;
         labels?: string[];
+        assigneeActorIds?: Task["assigneeActorIds"];
         assignees?: string[];
         externalId?: string;
         sourceUrl?: string;
@@ -1847,6 +2228,7 @@ function createTodu(
           priority: input.priority ?? "medium",
           projectId: input.projectId as Project["id"],
           labels: input.labels ?? [],
+          assigneeActorIds: input.assigneeActorIds ?? [],
           assignees: input.assignees ?? [],
           createdAt: input.createdAt ?? new Date(0).toISOString(),
           updatedAt: input.updatedAt ?? input.createdAt ?? new Date(0).toISOString(),
@@ -1866,7 +2248,9 @@ function createTodu(
         status?: Task["status"];
         priority?: Task["priority"];
         description?: string;
+        descriptionApproval?: unknown;
         labels?: string[];
+        assigneeActorIds?: Task["assigneeActorIds"];
         assignees?: string[];
         externalId?: string;
         sourceUrl?: string;
@@ -1879,6 +2263,7 @@ function createTodu(
       if (input.status !== undefined) task.status = input.status;
       if (input.priority !== undefined) task.priority = input.priority;
       if (input.labels !== undefined) task.labels = [...input.labels];
+      if (input.assigneeActorIds !== undefined) task.assigneeActorIds = [...input.assigneeActorIds];
       if (input.assignees !== undefined) task.assignees = [...input.assignees];
       if (input.externalId !== undefined) task.externalId = input.externalId;
       if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl;
@@ -1898,42 +2283,60 @@ function createTodu(
         filtered = filtered.filter((n) => n.entityId === filter.entityId);
       }
       if (filter?.tag) {
-        const tag = filter.tag;
-        filtered = filtered.filter((n) => n.tags.includes(tag));
+        filtered = filtered.filter((n) => n.tags.includes(filter.tag));
       }
       return ok(filtered);
     },
   );
 
-  const noteCreate = vi.fn(
-    async (input: {
-      content: string;
-      author?: string;
-      entityType?: string;
-      entityId?: string;
-      tags?: string[];
-    }) => {
-      const note: Note = {
-        id: createNoteId(`note-${String(noteIdCounter++).padStart(3, "0")}`),
-        content: input.content,
-        author: input.author ?? "user",
-        entityType: input.entityType as Note["entityType"],
-        entityId: input.entityId,
-        tags: input.tags ?? [],
-        createdAt: new Date(0).toISOString(),
-      };
-      notes.push(note);
+  const noteCreate = vi
+    .fn()
+    .mockImplementation(
+      async (input: {
+        content: string;
+        author?: string;
+        authorActorId?: Note["authorActorId"];
+        contentApproval?: Note["contentApproval"];
+        entityType?: string;
+        entityId?: string;
+        tags?: string[];
+        createdAt?: string;
+      }) => {
+        const note: Note = {
+          id: createNoteId(`note-${String(noteIdCounter++).padStart(3, "0")}`),
+          content: input.content,
+          author: input.author ?? "user",
+          authorActorId: input.authorActorId,
+          contentApproval: input.contentApproval,
+          entityType: input.entityType as Note["entityType"],
+          entityId: input.entityId,
+          tags: input.tags ?? [],
+          createdAt: input.createdAt ?? new Date(0).toISOString(),
+        };
+        notes.push(note);
+        return ok(note);
+      },
+    );
+
+  const noteUpdate = vi.fn().mockImplementation(
+    async (
+      id: string,
+      input: {
+        content?: string;
+        tags?: string[];
+        authorActorId?: Note["authorActorId"];
+        contentApproval?: Note["contentApproval"];
+      },
+    ) => {
+      const note = notes.find((n) => n.id === id);
+      if (!note) return ok(undefined);
+      if (input.content !== undefined) note.content = input.content;
+      if (input.tags !== undefined) note.tags = input.tags;
+      if (input.authorActorId !== undefined) note.authorActorId = input.authorActorId;
+      if (input.contentApproval !== undefined) note.contentApproval = input.contentApproval;
       return ok(note);
     },
   );
-
-  const noteUpdate = vi.fn(async (id: string, input: { content?: string; tags?: string[] }) => {
-    const note = notes.find((n) => n.id === id);
-    if (!note) return ok(undefined);
-    if (input.content !== undefined) note.content = input.content;
-    if (input.tags !== undefined) note.tags = input.tags;
-    return ok(note);
-  });
 
   const noteDelete = vi.fn(async (id: string) => {
     const index = notes.findIndex((n) => n.id === id);
@@ -1941,10 +2344,33 @@ function createTodu(
     return ok(undefined);
   });
 
+  const actorList = vi.fn().mockImplementation(async () => ok([...actors]));
+  const actorEnsure = vi
+    .fn()
+    .mockImplementation(async (input: { id: Actor["id"]; displayName: string }) => {
+      const existing = actors.find((actor) => actor.id === input.id);
+      if (existing) return ok(existing);
+      const created: Actor = { id: input.id, displayName: input.displayName };
+      actors.push(created);
+      return ok(created);
+    });
+
   return {
     instance: {
+      __internal: {
+        syncRuntime: {
+          actors: {
+            list: actorList,
+            getOwnerActorId: vi
+              .fn()
+              .mockImplementation(async () => ok(createActorId("actor-user"))),
+            ensure: actorEnsure,
+          },
+        },
+      },
       project: {
-        get: vi.fn().mockResolvedValue(ok(project)),
+        get: projectGet,
+        update: projectUpdate,
       },
       task: {
         list: taskList,
@@ -1954,6 +2380,7 @@ function createTodu(
       },
       integration: {
         list: integrationList,
+        update: integrationUpdate,
         updateStatus,
       },
       note: {
@@ -1962,10 +2389,15 @@ function createTodu(
         update: noteUpdate,
         delete: noteDelete,
       },
-    } as unknown as Todu,
+    } as unknown as ToduWithInternalTools,
     integration: {
       list: integrationList,
+      update: integrationUpdate,
       updateStatus,
+    },
+    project: {
+      get: projectGet,
+      update: projectUpdate,
     },
     task: {
       list: taskList,
@@ -1979,6 +2411,7 @@ function createTodu(
       update: noteUpdate,
       delete: noteDelete,
     },
+    actors,
   };
 }
 

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -1,20 +1,35 @@
+import crypto from "node:crypto";
 import {
+  type Actor,
+  type ActorId,
+  type AnySyncProvider,
+  createActorId,
   createProjectId,
+  type ExportedCommentInput,
+  type ExportedTaskInput,
+  type ExternalActorRef,
   type ExternalComment,
   type ExternalTask,
+  type ImportedCommentInput,
+  type ImportedContentApproval,
+  type ImportedTaskInput,
   type IntegrationBinding,
+  type IntegrationBindingActorMapping,
   MAX_DESCRIPTION_LENGTH,
   MAX_NOTE_CONTENT_LENGTH,
   type Note,
   type Project,
-  type SyncProvider,
+  SYNC_PROVIDER_API_VERSION_V2,
+  SYNC_PROVIDER_API_VERSION_V3,
   type SyncProviderPushCommentLink,
   type SyncProviderPushTaskLink,
+  type SyncProviderV2,
+  type SyncProviderV3,
   type Task,
   type TaskPushPayload,
   type ToduError,
 } from "@todu/core";
-import type { Todu } from "@todu/engine";
+import type { Todu, ToduWithInternalTools } from "@todu/engine";
 import type { DaemonLogger } from "./logger.js";
 import type { WorkerRuntime } from "./workers.js";
 
@@ -47,7 +62,8 @@ export interface CreateSyncPluginWorkerRuntimeOptions {
   pluginVersion: string;
   modulePath: string;
   authorityId: string;
-  provider: SyncProvider;
+  provider: AnySyncProvider;
+  providerApiVersion?: number;
   config: SyncPluginExecutionConfig;
   logger: DaemonLogger;
   getTodu: () => Todu | null;
@@ -56,6 +72,35 @@ export interface CreateSyncPluginWorkerRuntimeOptions {
     clearTimeoutFn?: (timeout: ReturnType<typeof setTimeout>) => void;
     now?: () => number;
   };
+}
+
+interface SyncBindingActorState {
+  binding: IntegrationBinding;
+  actorMappings: IntegrationBindingActorMapping[];
+  actorsById: Map<string, Actor>;
+  mappingsChanged: boolean;
+}
+
+interface RuntimeImportedTask {
+  externalId: string;
+  title: string;
+  description?: string;
+  status?: Task["status"];
+  priority?: Task["priority"];
+  labels?: string[];
+  assignees?: ExternalActorRef[];
+  sourceUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface RuntimeImportedComment {
+  externalId: string;
+  externalTaskId: string;
+  body: string;
+  author?: ExternalActorRef;
+  createdAt: string;
+  updatedAt?: string;
 }
 
 export function resolveSyncPluginExecutionConfig(
@@ -135,6 +180,7 @@ export function createSyncPluginWorkerRuntime(
   const clearTimeoutFn = options.scheduler?.clearTimeoutFn ?? clearTimeout;
   const now = options.scheduler?.now ?? (() => Date.now());
   const runtimeLogger = options.logger.child(`sync-plugin.${options.pluginName}`);
+  const providerApiVersion = options.providerApiVersion ?? SYNC_PROVIDER_API_VERSION_V2;
 
   return {
     start() {
@@ -239,62 +285,102 @@ export function createSyncPluginWorkerRuntime(
           throw new Error(`project load failed: ${formatToduError(projectResult.error)}`);
         }
 
+        let project = projectResult.value;
+        const actorState = await createBindingActorState(activeTodu, binding);
+
         await ensureInitialized();
 
         if (binding.strategy === "pull" || binding.strategy === "bidirectional") {
-          const pullResult = await options.provider.pull(binding, projectResult.value);
+          if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
+            const provider = options.provider as SyncProviderV2;
+            const pullResult = await provider.pull(binding, project);
 
-          if (pullResult.tasks.length > 0) {
-            await applyPulledTasks(
-              activeTodu,
-              options.provider,
-              projectResult.value,
-              pullResult.tasks,
+            if (pullResult.tasks.length > 0) {
+              const pullStats = await applyPulledTasksV2(
+                activeTodu,
+                actorState,
+                provider,
+                project,
+                pullResult.tasks,
+              );
+              project = pullStats.project;
+            }
+
+            if (pullResult.comments && pullResult.comments.length > 0) {
+              await applyPulledCommentsV2(activeTodu, actorState, project.id, pullResult.comments);
+            }
+          } else if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V3) {
+            const provider = options.provider as SyncProviderV3;
+            const pullResult = await provider.pull(binding, project);
+
+            if (pullResult.tasks.length > 0) {
+              const pullStats = await applyPulledTasksV3(
+                activeTodu,
+                actorState,
+                project,
+                pullResult.tasks,
+              );
+              project = pullStats.project;
+            }
+
+            if (pullResult.comments && pullResult.comments.length > 0) {
+              await applyPulledCommentsV3(activeTodu, actorState, project.id, pullResult.comments);
+            }
+          } else {
+            throw new Error(
+              `unsupported sync provider API version at runtime: ${providerApiVersion}`,
             );
-          }
-
-          if (pullResult.comments && pullResult.comments.length > 0) {
-            await applyPulledComments(activeTodu, projectResult.value.id, pullResult.comments);
           }
         }
 
         if (binding.strategy === "push" || binding.strategy === "bidirectional") {
-          const tasksResult = await activeTodu.task.list({ projectId: projectResult.value.id });
-          if (!tasksResult.ok) {
-            throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+          if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
+            const provider = options.provider as SyncProviderV2;
+            const pushPayloads = await buildPushPayloadsV2(
+              activeTodu,
+              actorState,
+              project,
+              runtimeLogger,
+            );
+            const pushResult = await provider.push(binding, pushPayloads, project);
+            if (
+              !pushResult ||
+              !Array.isArray(pushResult.commentLinks) ||
+              !Array.isArray(pushResult.taskLinks)
+            ) {
+              throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
+            }
+
+            await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
+            await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
+          } else if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V3) {
+            const provider = options.provider as SyncProviderV3;
+            const pushPayloads = await buildPushPayloadsV3(
+              activeTodu,
+              actorState,
+              project,
+              runtimeLogger,
+            );
+            const pushResult = await provider.push(binding, pushPayloads, project);
+            if (
+              !pushResult ||
+              !Array.isArray(pushResult.commentLinks) ||
+              !Array.isArray(pushResult.taskLinks)
+            ) {
+              throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
+            }
+
+            await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
+            await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
+          } else {
+            throw new Error(
+              `unsupported sync provider API version at runtime: ${providerApiVersion}`,
+            );
           }
+        }
 
-          const pushPayloads: TaskPushPayload[] = [];
-          for (const task of tasksResult.value) {
-            const detailResult = await activeTodu.task.get(task.id);
-            const taskDetail = detailResult.ok
-              ? detailResult.value
-              : { ...task, description: undefined };
-
-            const commentsResult = await activeTodu.note.list({
-              entityType: "task",
-              entityId: task.id,
-            });
-            const comments: Note[] = commentsResult.ok ? commentsResult.value : [];
-
-            pushPayloads.push({ ...taskDetail, comments });
-          }
-
-          const pushResult = await options.provider.push(
-            binding,
-            pushPayloads,
-            projectResult.value,
-          );
-          if (
-            !pushResult ||
-            !Array.isArray(pushResult.commentLinks) ||
-            !Array.isArray(pushResult.taskLinks)
-          ) {
-            throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
-          }
-
-          await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
-          await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
+        if (actorState.mappingsChanged) {
+          await persistBindingActorMappings(activeTodu, actorState);
         }
 
         await updateBindingStatus(activeTodu, binding, {
@@ -356,6 +442,7 @@ export function createSyncPluginWorkerRuntime(
             modulePath: options.modulePath,
             bindingCount: bindingsResult.value.length,
             durationMs: Math.max(0, Math.round(now() - startedAtMs)),
+            providerApiVersion,
           });
 
           scheduleNext(config.intervalMs);
@@ -369,6 +456,7 @@ export function createSyncPluginWorkerRuntime(
             modulePath: options.modulePath,
             attempt: retryAttempt,
             nextRetryMs: delayMs,
+            providerApiVersion,
             error: summarizeError(error),
           });
 
@@ -465,214 +553,6 @@ async function applyPushTaskLinks(todu: Todu, links: SyncProviderPushTaskLink[])
   }
 }
 
-function normalizePulledTaskTimestamp(
-  task: ExternalTask,
-  field: "createdAt" | "updatedAt",
-): string | null {
-  const value = task[field];
-  if (value === undefined) {
-    return null;
-  }
-
-  const timestamp = new Date(value);
-  if (Number.isNaN(timestamp.getTime())) {
-    throw new Error(
-      `pulled task has invalid ${field}: externalId=${task.externalId} value=${value}`,
-    );
-  }
-
-  return timestamp.toISOString();
-}
-
-function getPulledTaskTimestamps(task: ExternalTask): {
-  createdAt?: string;
-  updatedAt?: string;
-  comparisonTimestamp: string | null;
-} {
-  const createdAt = normalizePulledTaskTimestamp(task, "createdAt");
-  const updatedAt = normalizePulledTaskTimestamp(task, "updatedAt");
-  const effectiveCreatedAt = createdAt ?? updatedAt ?? undefined;
-  const effectiveUpdatedAt = updatedAt ?? createdAt ?? undefined;
-
-  return {
-    createdAt: effectiveCreatedAt,
-    updatedAt: effectiveUpdatedAt,
-    comparisonTimestamp: effectiveUpdatedAt ?? null,
-  };
-}
-
-function buildPulledTaskCreateInput(
-  mappedTask: Task,
-  project: Project,
-  externalTask: ExternalTask,
-  timestamps: { createdAt?: string; updatedAt?: string },
-): {
-  title: string;
-  projectId: Project["id"];
-  status: Task["status"];
-  priority: Task["priority"];
-  description?: string;
-  labels: string[];
-  assignees: string[];
-  externalId: string;
-  sourceUrl?: string;
-  createdAt?: string;
-  updatedAt?: string;
-} {
-  const input: {
-    title: string;
-    projectId: Project["id"];
-    status: Task["status"];
-    priority: Task["priority"];
-    description?: string;
-    labels: string[];
-    assignees: string[];
-    externalId: string;
-    sourceUrl?: string;
-    createdAt?: string;
-    updatedAt?: string;
-  } = {
-    title: mappedTask.title,
-    projectId: project.id,
-    status: mappedTask.status,
-    priority: mappedTask.priority,
-    labels: mappedTask.labels,
-    assignees: mappedTask.assignees,
-    externalId: mappedTask.externalId ?? externalTask.externalId,
-  };
-
-  if (externalTask.description !== undefined) {
-    input.description = truncate(externalTask.description, MAX_DESCRIPTION_LENGTH);
-  }
-
-  const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
-  if (sourceUrl !== undefined) {
-    input.sourceUrl = sourceUrl;
-  }
-
-  if (timestamps.createdAt !== undefined) {
-    input.createdAt = timestamps.createdAt;
-  }
-
-  if (timestamps.updatedAt !== undefined) {
-    input.updatedAt = timestamps.updatedAt;
-  }
-
-  return input;
-}
-
-function buildPulledTaskUpdateInput(
-  mappedTask: Task,
-  externalTask: ExternalTask,
-  timestamps: { updatedAt?: string },
-): {
-  title: string;
-  status: Task["status"];
-  priority: Task["priority"];
-  description?: string;
-  labels: string[];
-  assignees: string[];
-  externalId: string;
-  sourceUrl?: string;
-  updatedAt?: string;
-} {
-  const input: {
-    title: string;
-    status: Task["status"];
-    priority: Task["priority"];
-    description?: string;
-    labels: string[];
-    assignees: string[];
-    externalId: string;
-    sourceUrl?: string;
-    updatedAt?: string;
-  } = {
-    title: mappedTask.title,
-    status: mappedTask.status,
-    priority: mappedTask.priority,
-    labels: mappedTask.labels,
-    assignees: mappedTask.assignees,
-    externalId: mappedTask.externalId ?? externalTask.externalId,
-  };
-
-  if (externalTask.description !== undefined) {
-    input.description = truncate(externalTask.description, MAX_DESCRIPTION_LENGTH);
-  }
-
-  const sourceUrl = mappedTask.sourceUrl ?? externalTask.sourceUrl;
-  if (sourceUrl !== undefined) {
-    input.sourceUrl = sourceUrl;
-  }
-
-  if (timestamps.updatedAt !== undefined) {
-    input.updatedAt = timestamps.updatedAt;
-  }
-
-  return input;
-}
-
-async function applyPulledTasks(
-  todu: Todu,
-  provider: SyncProvider,
-  project: Project,
-  tasks: ExternalTask[],
-): Promise<{ created: number; updated: number; skipped: number }> {
-  const stats = { created: 0, updated: 0, skipped: 0 };
-  const tasksResult = await todu.task.list({ projectId: project.id });
-  if (!tasksResult.ok) {
-    throw new Error(`pulled task list failed: ${formatToduError(tasksResult.error)}`);
-  }
-
-  const localByExternalId = new Map<string, Task>();
-  for (const task of tasksResult.value) {
-    if (task.externalId) {
-      localByExternalId.set(task.externalId, task);
-    }
-  }
-
-  for (const externalTask of tasks) {
-    const mappedTask = provider.mapToTask(externalTask, project);
-    const existingTask = localByExternalId.get(externalTask.externalId);
-    const pulledTimestamps = getPulledTaskTimestamps(externalTask);
-    const externalUpdatedAt = pulledTimestamps.comparisonTimestamp;
-
-    if (!existingTask) {
-      const createResult = await todu.task.create(
-        buildPulledTaskCreateInput(mappedTask, project, externalTask, pulledTimestamps),
-      );
-      if (!createResult.ok) {
-        throw new Error(
-          `pulled task create failed: externalId=${externalTask.externalId} error=${formatToduError(createResult.error)}`,
-        );
-      }
-
-      localByExternalId.set(externalTask.externalId, createResult.value);
-      stats.created += 1;
-      continue;
-    }
-
-    if (externalUpdatedAt && externalUpdatedAt <= existingTask.updatedAt) {
-      stats.skipped += 1;
-      continue;
-    }
-
-    const updateResult = await todu.task.update(
-      existingTask.id,
-      buildPulledTaskUpdateInput(mappedTask, externalTask, pulledTimestamps),
-    );
-    if (!updateResult.ok) {
-      throw new Error(
-        `pulled task update failed: task=${existingTask.id} externalId=${externalTask.externalId} error=${formatToduError(updateResult.error)}`,
-      );
-    }
-
-    localByExternalId.set(externalTask.externalId, updateResult.value);
-    stats.updated += 1;
-  }
-
-  return stats;
-}
-
 async function applyPushCommentLinks(
   todu: Todu,
   links: SyncProviderPushCommentLink[],
@@ -708,20 +588,281 @@ async function applyPushCommentLinks(
   }
 }
 
-/**
- * Apply comments pulled from an external provider to local todu notes.
- *
- * Uses a snapshot-based reconciliation model:
- * - Comments with an `externalId` matching an existing note's content tag are updated (last-write-wins by updatedAt).
- * - Comments without a local match are created as new notes.
- * - Local notes with external ID tags that are absent from the pull result are deleted.
- *
- * External IDs are tracked via a `sync:externalId:<value>` tag on each note.
- */
-async function applyPulledComments(
+function normalizeImportedTaskTimestamp(
+  task: RuntimeImportedTask,
+  field: "createdAt" | "updatedAt",
+): string | null {
+  const value = task[field];
+  if (value === undefined) {
+    return null;
+  }
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(
+      `pulled task has invalid ${field}: externalId=${task.externalId} value=${value}`,
+    );
+  }
+
+  return timestamp.toISOString();
+}
+
+function getImportedTaskTimestamps(task: RuntimeImportedTask): {
+  createdAt?: string;
+  updatedAt?: string;
+  comparisonTimestamp: string | null;
+} {
+  const createdAt = normalizeImportedTaskTimestamp(task, "createdAt");
+  const updatedAt = normalizeImportedTaskTimestamp(task, "updatedAt");
+  const effectiveCreatedAt = createdAt ?? updatedAt ?? undefined;
+  const effectiveUpdatedAt = updatedAt ?? createdAt ?? undefined;
+
+  return {
+    createdAt: effectiveCreatedAt,
+    updatedAt: effectiveUpdatedAt,
+    comparisonTimestamp: effectiveUpdatedAt ?? null,
+  };
+}
+
+async function applyPulledTasksV2(
   todu: Todu,
+  actorState: SyncBindingActorState,
+  provider: SyncProviderV2,
+  project: Project,
+  tasks: ExternalTask[],
+): Promise<{ created: number; updated: number; skipped: number; project: Project }> {
+  const importedTasks = tasks.map((externalTask) => {
+    const mappedTask = provider.mapToTask(externalTask, project);
+    return {
+      externalId: mappedTask.externalId ?? externalTask.externalId,
+      title: mappedTask.title,
+      description: externalTask.description,
+      status: mappedTask.status,
+      priority: mappedTask.priority,
+      labels: mappedTask.labels,
+      assignees: mappedTask.assignees.map(createV2ExternalActorRef),
+      sourceUrl: mappedTask.sourceUrl ?? externalTask.sourceUrl,
+      createdAt: externalTask.createdAt,
+      updatedAt: externalTask.updatedAt,
+    } satisfies RuntimeImportedTask;
+  });
+
+  return applyImportedTasks(todu, actorState, project, importedTasks);
+}
+
+async function applyPulledTasksV3(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  project: Project,
+  tasks: ImportedTaskInput[],
+): Promise<{ created: number; updated: number; skipped: number; project: Project }> {
+  const importedTasks = tasks.map((task) => ({
+    externalId: task.externalId,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    labels: task.labels,
+    assignees: task.assignees,
+    sourceUrl: task.sourceUrl,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  })) satisfies RuntimeImportedTask[];
+
+  return applyImportedTasks(todu, actorState, project, importedTasks);
+}
+
+async function applyImportedTasks(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  project: Project,
+  tasks: RuntimeImportedTask[],
+): Promise<{ created: number; updated: number; skipped: number; project: Project }> {
+  const stats = { created: 0, updated: 0, skipped: 0 };
+  const tasksResult = await todu.task.list({ projectId: project.id });
+  if (!tasksResult.ok) {
+    throw new Error(`pulled task list failed: ${formatToduError(tasksResult.error)}`);
+  }
+
+  const localByExternalId = new Map<string, Task>();
+  for (const task of tasksResult.value) {
+    if (task.externalId) {
+      localByExternalId.set(task.externalId, task);
+    }
+  }
+
+  let currentProject = project;
+
+  for (const importedTask of tasks) {
+    const existingTask = localByExternalId.get(importedTask.externalId);
+    const pulledTimestamps = getImportedTaskTimestamps(importedTask);
+    const externalUpdatedAt = pulledTimestamps.comparisonTimestamp;
+    const assigneeResolution = await resolveImportedAssignees(
+      todu,
+      actorState,
+      importedTask.assignees,
+    );
+
+    currentProject = await ensureProjectAuthorizedAssigneeActors(
+      todu,
+      currentProject,
+      assigneeResolution.actorIds,
+    );
+
+    const compatibilityAssignees = assigneeResolution.actorIds.map((actorId) =>
+      getActorDisplayName(actorState, actorId),
+    );
+
+    if (!existingTask) {
+      const createInput: {
+        title: string;
+        projectId: Project["id"];
+        status: Task["status"];
+        priority: Task["priority"];
+        description?: string;
+        descriptionApproval?: ImportedContentApproval;
+        labels: string[];
+        assigneeActorIds: ActorId[];
+        assignees: string[];
+        externalId: string;
+        sourceUrl?: string;
+        createdAt?: string;
+        updatedAt?: string;
+      } = {
+        title: importedTask.title,
+        projectId: currentProject.id,
+        status: importedTask.status ?? "active",
+        priority: importedTask.priority ?? "medium",
+        labels: importedTask.labels ?? [],
+        assigneeActorIds: assigneeResolution.actorIds,
+        assignees: compatibilityAssignees,
+        externalId: importedTask.externalId,
+      };
+
+      if (importedTask.description !== undefined) {
+        createInput.description = truncate(importedTask.description, MAX_DESCRIPTION_LENGTH);
+        createInput.descriptionApproval = buildImportedContentApproval(actorState.binding.id);
+      }
+
+      if (importedTask.sourceUrl !== undefined) {
+        createInput.sourceUrl = importedTask.sourceUrl;
+      }
+      if (pulledTimestamps.createdAt !== undefined) {
+        createInput.createdAt = pulledTimestamps.createdAt;
+      }
+      if (pulledTimestamps.updatedAt !== undefined) {
+        createInput.updatedAt = pulledTimestamps.updatedAt;
+      }
+
+      const createResult = await todu.task.create(createInput);
+      if (!createResult.ok) {
+        throw new Error(
+          `pulled task create failed: externalId=${importedTask.externalId} error=${formatToduError(createResult.error)}`,
+        );
+      }
+
+      localByExternalId.set(importedTask.externalId, createResult.value);
+      stats.created += 1;
+      continue;
+    }
+
+    if (externalUpdatedAt && externalUpdatedAt <= existingTask.updatedAt) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    const updateInput: {
+      title: string;
+      status: Task["status"];
+      priority: Task["priority"];
+      description?: string;
+      descriptionApproval?: ImportedContentApproval;
+      labels: string[];
+      assigneeActorIds: ActorId[];
+      assignees: string[];
+      externalId: string;
+      sourceUrl?: string;
+      updatedAt?: string;
+    } = {
+      title: importedTask.title,
+      status: importedTask.status ?? "active",
+      priority: importedTask.priority ?? "medium",
+      labels: importedTask.labels ?? [],
+      assigneeActorIds: assigneeResolution.actorIds,
+      assignees: compatibilityAssignees,
+      externalId: importedTask.externalId,
+    };
+
+    if (importedTask.description !== undefined) {
+      updateInput.description = truncate(importedTask.description, MAX_DESCRIPTION_LENGTH);
+      updateInput.descriptionApproval = buildImportedContentApproval(actorState.binding.id);
+    }
+
+    if (importedTask.sourceUrl !== undefined) {
+      updateInput.sourceUrl = importedTask.sourceUrl;
+    }
+    if (pulledTimestamps.updatedAt !== undefined) {
+      updateInput.updatedAt = pulledTimestamps.updatedAt;
+    }
+
+    const updateResult = await todu.task.update(existingTask.id, updateInput);
+    if (!updateResult.ok) {
+      throw new Error(
+        `pulled task update failed: task=${existingTask.id} externalId=${importedTask.externalId} error=${formatToduError(updateResult.error)}`,
+      );
+    }
+
+    localByExternalId.set(importedTask.externalId, updateResult.value);
+    stats.updated += 1;
+  }
+
+  return {
+    ...stats,
+    project: currentProject,
+  };
+}
+
+async function applyPulledCommentsV2(
+  todu: Todu,
+  actorState: SyncBindingActorState,
   projectId: Project["id"],
   comments: ExternalComment[],
+): Promise<{ created: number; updated: number; deleted: number }> {
+  const importedComments = comments.map((comment) => ({
+    externalId: comment.externalId,
+    externalTaskId: comment.externalTaskId,
+    body: comment.body,
+    author: comment.author ? createV2ExternalActorRef(comment.author) : undefined,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  })) satisfies RuntimeImportedComment[];
+
+  return applyImportedComments(todu, actorState, projectId, importedComments);
+}
+
+async function applyPulledCommentsV3(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  projectId: Project["id"],
+  comments: ImportedCommentInput[],
+): Promise<{ created: number; updated: number; deleted: number }> {
+  const importedComments = comments.map((comment) => ({
+    externalId: comment.externalId,
+    externalTaskId: comment.externalTaskId,
+    body: comment.body,
+    author: comment.author,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  })) satisfies RuntimeImportedComment[];
+
+  return applyImportedComments(todu, actorState, projectId, importedComments);
+}
+
+async function applyImportedComments(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  projectId: Project["id"],
+  comments: RuntimeImportedComment[],
 ): Promise<{ created: number; updated: number; deleted: number }> {
   const stats = { created: 0, updated: 0, deleted: 0 };
 
@@ -737,8 +878,7 @@ async function applyPulledComments(
     }
   }
 
-  // Group pulled comments by local task
-  const commentsByTask = new Map<string, ExternalComment[]>();
+  const commentsByTask = new Map<string, RuntimeImportedComment[]>();
   for (const comment of comments) {
     const localTaskId = localTaskIdByExternalId.get(comment.externalTaskId);
     if (!localTaskId) {
@@ -753,11 +893,7 @@ async function applyPulledComments(
     }
   }
 
-  // Collect all local task IDs that have at least one pulled comment
-  const affectedTaskIds = new Set(commentsByTask.keys());
-
-  // For each affected local task, reconcile local notes with pulled comments
-  for (const taskId of affectedTaskIds) {
+  for (const taskId of commentsByTask.keys()) {
     const pulledComments = commentsByTask.get(taskId) ?? [];
     const localNotesResult = await todu.note.list({
       entityType: "task",
@@ -765,7 +901,6 @@ async function applyPulledComments(
     });
     const localNotes: Note[] = localNotesResult.ok ? localNotesResult.value : [];
 
-    // Build index of local notes by external ID tag
     const localByExternalId = new Map<string, Note>();
     for (const note of localNotes) {
       const externalId = getSyncExternalIdFromNote(note);
@@ -774,47 +909,551 @@ async function applyPulledComments(
       }
     }
 
-    // Build set of pulled external IDs for delete detection
-    const pulledExternalIds = new Set(pulledComments.map((c) => c.externalId));
+    const pulledExternalIds = new Set(pulledComments.map((comment) => comment.externalId));
 
-    // Create or update pulled comments
     for (const pulled of pulledComments) {
       const localNote = localByExternalId.get(pulled.externalId);
+      const authorResolution = pulled.author
+        ? await resolveImportedActor(todu, actorState, pulled.author)
+        : null;
+      const approval = buildImportedContentApproval(
+        actorState.binding.id,
+        authorResolution?.actor.id,
+        authorResolution?.trusted ?? false,
+      );
 
       if (!localNote) {
-        // Create new note
-        await todu.note.create({
+        const createResult = await todu.note.create({
           content: truncate(pulled.body, MAX_NOTE_CONTENT_LENGTH),
-          author: pulled.author ?? "external",
+          author: authorResolution?.actor.displayName ?? "external",
+          authorActorId: authorResolution?.actor.id,
+          contentApproval: approval,
           entityType: "task",
           entityId: taskId,
           tags: [createSyncExternalIdTag(pulled.externalId)],
+          createdAt: normalizeImportedCommentTimestamp(pulled, "createdAt"),
         });
-        stats.created++;
+        if (!createResult.ok) {
+          throw new Error(
+            `pulled comment create failed: externalId=${pulled.externalId} error=${formatToduError(createResult.error)}`,
+          );
+        }
+        stats.created += 1;
       } else {
-        // Update if external is newer (last-write-wins by updatedAt)
-        const externalUpdatedAt = pulled.updatedAt ?? pulled.createdAt;
+        const externalUpdatedAt = normalizeImportedCommentTimestamp(
+          pulled,
+          pulled.updatedAt !== undefined ? "updatedAt" : "createdAt",
+        );
         const localCreatedAt = localNote.createdAt;
 
         if (externalUpdatedAt > localCreatedAt) {
-          await todu.note.update(localNote.id, {
+          const updateResult = await todu.note.update(localNote.id, {
             content: truncate(pulled.body, MAX_NOTE_CONTENT_LENGTH),
+            authorActorId: authorResolution?.actor.id,
+            contentApproval: approval,
           });
-          stats.updated++;
+          if (!updateResult.ok) {
+            throw new Error(
+              `pulled comment update failed: note=${localNote.id} externalId=${pulled.externalId} error=${formatToduError(updateResult.error)}`,
+            );
+          }
+          stats.updated += 1;
         }
       }
     }
 
-    // Delete local synced notes whose external IDs are absent from pull result
     for (const [externalId, note] of localByExternalId) {
       if (!pulledExternalIds.has(externalId)) {
-        await todu.note.delete(note.id);
-        stats.deleted++;
+        const deleteResult = await todu.note.delete(note.id);
+        if (!deleteResult.ok) {
+          throw new Error(
+            `pulled comment delete failed: note=${note.id} externalId=${externalId} error=${formatToduError(deleteResult.error)}`,
+          );
+        }
+        stats.deleted += 1;
       }
     }
   }
 
   return stats;
+}
+
+async function buildPushPayloadsV2(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  project: Project,
+  logger: DaemonLogger,
+): Promise<TaskPushPayload[]> {
+  const tasksResult = await todu.task.list({ projectId: project.id });
+  if (!tasksResult.ok) {
+    throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+  }
+
+  const pushPayloads: TaskPushPayload[] = [];
+  for (const task of tasksResult.value) {
+    const detailResult = await todu.task.get(task.id);
+    const taskDetail = detailResult.ok ? detailResult.value : { ...task, description: undefined };
+
+    const commentsResult = await todu.note.list({
+      entityType: "task",
+      entityId: task.id,
+    });
+    const comments: Note[] = commentsResult.ok ? commentsResult.value : [];
+
+    const mappedAssignees = buildOutboundV2Assignees(taskDetail, actorState, logger);
+    pushPayloads.push({
+      ...taskDetail,
+      assignees: taskDetail.assigneeActorIds.length > 0 ? mappedAssignees : taskDetail.assignees,
+      comments,
+    });
+  }
+
+  return pushPayloads;
+}
+
+async function buildPushPayloadsV3(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  project: Project,
+  logger: DaemonLogger,
+): Promise<ExportedTaskInput[]> {
+  const tasksResult = await todu.task.list({ projectId: project.id });
+  if (!tasksResult.ok) {
+    throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
+  }
+
+  const pushPayloads: ExportedTaskInput[] = [];
+  for (const task of tasksResult.value) {
+    const detailResult = await todu.task.get(task.id);
+    const taskDetail = detailResult.ok ? detailResult.value : { ...task, description: undefined };
+
+    const commentsResult = await todu.note.list({
+      entityType: "task",
+      entityId: task.id,
+    });
+    const comments: Note[] = commentsResult.ok ? commentsResult.value : [];
+
+    pushPayloads.push({
+      localTaskId: taskDetail.id,
+      externalId: taskDetail.externalId,
+      title: taskDetail.title,
+      description: taskDetail.description,
+      status: taskDetail.status,
+      priority: taskDetail.priority,
+      labels: taskDetail.labels,
+      assignees: buildOutboundV3Assignees(taskDetail, actorState, logger),
+      sourceUrl: taskDetail.sourceUrl,
+      comments: comments.map((comment) => {
+        const exported: ExportedCommentInput = {
+          localNoteId: comment.id,
+          body: comment.content,
+          createdAt: comment.createdAt,
+        };
+        return exported;
+      }),
+    });
+  }
+
+  return pushPayloads;
+}
+
+async function createBindingActorState(
+  todu: Todu,
+  binding: IntegrationBinding,
+): Promise<SyncBindingActorState> {
+  const internalTodu = getToduWithInternals(todu);
+  const actorsResult = await internalTodu.__internal.syncRuntime.actors.list();
+  if (!actorsResult.ok) {
+    throw new Error(`actor list failed: ${formatToduError(actorsResult.error)}`);
+  }
+
+  return {
+    binding,
+    actorMappings: cloneActorMappings(binding),
+    actorsById: new Map(actorsResult.value.map((actor) => [actor.id, actor])),
+    mappingsChanged: false,
+  };
+}
+
+async function persistBindingActorMappings(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+): Promise<void> {
+  const updateResult = await todu.integration.update(actorState.binding.id, {
+    options: {
+      ...(actorState.binding.options ?? {}),
+      actorMappings: actorState.actorMappings,
+    },
+  });
+
+  if (!updateResult.ok) {
+    throw new Error(
+      `integration binding mapping update failed: binding=${actorState.binding.id} error=${formatToduError(updateResult.error)}`,
+    );
+  }
+
+  actorState.binding = updateResult.value;
+  actorState.mappingsChanged = false;
+}
+
+async function resolveImportedAssignees(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  assignees: ExternalActorRef[] | undefined,
+): Promise<{ actorIds: ActorId[] }> {
+  const actorIds: ActorId[] = [];
+  const seen = new Set<string>();
+
+  for (const assignee of assignees ?? []) {
+    const resolution = await resolveImportedActor(todu, actorState, assignee);
+    if (!seen.has(resolution.actor.id)) {
+      seen.add(resolution.actor.id);
+      actorIds.push(resolution.actor.id);
+    }
+  }
+
+  return { actorIds };
+}
+
+async function resolveImportedActor(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  actorRef: ExternalActorRef,
+): Promise<{ actor: Actor; trusted: boolean }> {
+  const normalizedActorRef = normalizeExternalActorRef(actorRef);
+  const existingMapping = findActorMapping(actorState.actorMappings, normalizedActorRef);
+
+  if (existingMapping) {
+    const actor = await ensureRuntimeActor(todu, actorState, {
+      id: createActorId(existingMapping.actorId),
+      displayName: getPreferredExternalActorDisplayName(normalizedActorRef),
+    });
+    return {
+      actor,
+      trusted: existingMapping.trusted === true,
+    };
+  }
+
+  const actorId = createStableImportedActorId(actorState.binding, normalizedActorRef);
+  const actor = await ensureRuntimeActor(todu, actorState, {
+    id: actorId,
+    displayName: getPreferredExternalActorDisplayName(normalizedActorRef),
+  });
+
+  actorState.actorMappings.push({
+    actorId,
+    ...(normalizedActorRef.externalAccountId !== undefined
+      ? { externalAccountId: normalizedActorRef.externalAccountId }
+      : {}),
+    ...(normalizedActorRef.externalLogin !== undefined
+      ? { externalLogin: normalizedActorRef.externalLogin }
+      : {}),
+    ...(normalizedActorRef.displayName !== undefined
+      ? { displayName: normalizedActorRef.displayName }
+      : {}),
+    trusted: false,
+  });
+  actorState.mappingsChanged = true;
+
+  return {
+    actor,
+    trusted: false,
+  };
+}
+
+async function ensureRuntimeActor(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  input: { id: ReturnType<typeof createActorId>; displayName: string },
+): Promise<Actor> {
+  const cachedActor = actorState.actorsById.get(input.id);
+  if (cachedActor) {
+    return cachedActor;
+  }
+
+  const internalTodu = getToduWithInternals(todu);
+  const ensureResult = await internalTodu.__internal.syncRuntime.actors.ensure(input);
+  if (!ensureResult.ok) {
+    throw new Error(`actor ensure failed: ${formatToduError(ensureResult.error)}`);
+  }
+
+  actorState.actorsById.set(ensureResult.value.id, ensureResult.value);
+  return ensureResult.value;
+}
+
+async function ensureProjectAuthorizedAssigneeActors(
+  todu: Todu,
+  project: Project,
+  actorIds: readonly ActorId[],
+): Promise<Project> {
+  const nextAuthorizedAssigneeActorIds = [...project.authorizedAssigneeActorIds];
+  let changed = false;
+
+  for (const actorId of actorIds) {
+    if (!nextAuthorizedAssigneeActorIds.includes(actorId)) {
+      nextAuthorizedAssigneeActorIds.push(actorId);
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return project;
+  }
+
+  const updateResult = await todu.project.update(project.id, {
+    authorizedAssigneeActorIds: nextAuthorizedAssigneeActorIds,
+  });
+  if (!updateResult.ok) {
+    throw new Error(
+      `project authorized assignee update failed: project=${project.id} error=${formatToduError(updateResult.error)}`,
+    );
+  }
+
+  return updateResult.value;
+}
+
+function buildOutboundV2Assignees(
+  task: Task,
+  actorState: SyncBindingActorState,
+  logger: DaemonLogger,
+): string[] {
+  const assignees: string[] = [];
+
+  for (const actorId of task.assigneeActorIds) {
+    const mapping = actorState.actorMappings.find((candidate) => candidate.actorId === actorId);
+    const outboundAssignee = mapping ? getOutboundV2Assignee(mapping) : null;
+
+    if (!mapping || !outboundAssignee) {
+      logger.warn("sync plugin skipped unmapped outbound assignee", {
+        bindingId: actorState.binding.id,
+        provider: actorState.binding.provider,
+        taskId: task.id,
+        taskTitle: task.title,
+        actorId,
+      });
+      continue;
+    }
+
+    assignees.push(outboundAssignee);
+  }
+
+  return assignees;
+}
+
+function buildOutboundV3Assignees(
+  task: Task,
+  actorState: SyncBindingActorState,
+  logger: DaemonLogger,
+): ExternalActorRef[] {
+  const assignees: ExternalActorRef[] = [];
+
+  for (const actorId of task.assigneeActorIds) {
+    const mapping = actorState.actorMappings.find((candidate) => candidate.actorId === actorId);
+    const outboundAssignee = mapping ? getOutboundV3Assignee(mapping) : null;
+
+    if (!mapping || !outboundAssignee) {
+      logger.warn("sync plugin skipped unmapped outbound assignee", {
+        bindingId: actorState.binding.id,
+        provider: actorState.binding.provider,
+        taskId: task.id,
+        taskTitle: task.title,
+        actorId,
+      });
+      continue;
+    }
+
+    assignees.push(outboundAssignee);
+  }
+
+  return assignees;
+}
+
+function getOutboundV2Assignee(mapping: IntegrationBindingActorMapping): string | null {
+  return mapping.externalLogin ?? mapping.displayName ?? mapping.externalAccountId ?? null;
+}
+
+function getOutboundV3Assignee(mapping: IntegrationBindingActorMapping): ExternalActorRef | null {
+  const outboundAssignee: ExternalActorRef = {};
+
+  if (mapping.externalAccountId !== undefined) {
+    outboundAssignee.externalAccountId = mapping.externalAccountId;
+  }
+  if (mapping.externalLogin !== undefined) {
+    outboundAssignee.externalLogin = mapping.externalLogin;
+  }
+  if (mapping.displayName !== undefined) {
+    outboundAssignee.displayName = mapping.displayName;
+  }
+
+  return Object.keys(outboundAssignee).length > 0 ? outboundAssignee : null;
+}
+
+function normalizeExternalActorRef(actorRef: ExternalActorRef): ExternalActorRef {
+  return {
+    ...(parseOptionalString(actorRef.externalAccountId) !== undefined
+      ? { externalAccountId: parseOptionalString(actorRef.externalAccountId)! }
+      : {}),
+    ...(parseOptionalString(actorRef.externalLogin) !== undefined
+      ? { externalLogin: parseOptionalString(actorRef.externalLogin)! }
+      : {}),
+    ...(parseOptionalString(actorRef.displayName) !== undefined
+      ? { displayName: parseOptionalString(actorRef.displayName)! }
+      : {}),
+    ...(actorRef.raw !== undefined ? { raw: actorRef.raw } : {}),
+  };
+}
+
+function createV2ExternalActorRef(value: string): ExternalActorRef {
+  const normalizedValue = value.trim();
+  return {
+    externalLogin: normalizedValue,
+    displayName: normalizedValue,
+    raw: value,
+  };
+}
+
+function createStableImportedActorId(
+  binding: IntegrationBinding,
+  actorRef: ExternalActorRef,
+): ReturnType<typeof createActorId> {
+  const uniqueKey = getExternalActorIdentityKey(actorRef);
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${binding.id}:${binding.provider}:${uniqueKey}`)
+    .digest("hex")
+    .slice(0, 16);
+  return createActorId(`actor-imported-${hash}`);
+}
+
+function getExternalActorIdentityKey(actorRef: ExternalActorRef): string {
+  const externalAccountId = normalizeExternalAccountId(actorRef.externalAccountId);
+  if (externalAccountId) {
+    return `account:${externalAccountId}`;
+  }
+
+  const externalLogin = normalizeExternalLogin(actorRef.externalLogin);
+  if (externalLogin) {
+    return `login:${externalLogin}`;
+  }
+
+  const displayName = normalizeExternalDisplayName(actorRef.displayName);
+  if (displayName) {
+    return `display:${displayName}`;
+  }
+
+  return `raw:${crypto
+    .createHash("sha1")
+    .update(JSON.stringify(actorRef.raw ?? actorRef))
+    .digest("hex")}`;
+}
+
+function findActorMapping(
+  actorMappings: IntegrationBindingActorMapping[],
+  actorRef: ExternalActorRef,
+): IntegrationBindingActorMapping | null {
+  const externalAccountId = normalizeExternalAccountId(actorRef.externalAccountId);
+  if (externalAccountId) {
+    const byAccountId = actorMappings.find(
+      (mapping) => normalizeExternalAccountId(mapping.externalAccountId) === externalAccountId,
+    );
+    if (byAccountId) {
+      return byAccountId;
+    }
+  }
+
+  const externalLogin = normalizeExternalLogin(actorRef.externalLogin);
+  if (externalLogin) {
+    const byLogin = actorMappings.find(
+      (mapping) => normalizeExternalLogin(mapping.externalLogin) === externalLogin,
+    );
+    if (byLogin) {
+      return byLogin;
+    }
+  }
+
+  const displayName = normalizeExternalDisplayName(actorRef.displayName);
+  if (displayName) {
+    const byDisplayName = actorMappings.find(
+      (mapping) => normalizeExternalDisplayName(mapping.displayName) === displayName,
+    );
+    if (byDisplayName) {
+      return byDisplayName;
+    }
+  }
+
+  return null;
+}
+
+function getPreferredExternalActorDisplayName(actorRef: ExternalActorRef): string {
+  return actorRef.displayName ?? actorRef.externalLogin ?? actorRef.externalAccountId ?? "external";
+}
+
+function normalizeExternalAccountId(value: string | undefined): string | null {
+  const normalized = parseOptionalString(value);
+  return normalized ?? null;
+}
+
+function normalizeExternalLogin(value: string | undefined): string | null {
+  const normalized = parseOptionalString(value);
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+function normalizeExternalDisplayName(value: string | undefined): string | null {
+  const normalized = parseOptionalString(value);
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+function buildImportedContentApproval(
+  bindingId: IntegrationBinding["id"],
+  sourceActorId?: Actor["id"],
+  trusted = false,
+): ImportedContentApproval {
+  return {
+    state: trusted ? "notRequired" : "pendingApproval",
+    sourceBindingId: bindingId,
+    ...(sourceActorId !== undefined ? { sourceActorId } : {}),
+  };
+}
+
+function cloneActorMappings(binding: IntegrationBinding): IntegrationBindingActorMapping[] {
+  return (binding.options?.actorMappings ?? []).map((mapping) => ({
+    actorId: mapping.actorId,
+    ...(mapping.externalAccountId !== undefined
+      ? { externalAccountId: mapping.externalAccountId }
+      : {}),
+    ...(mapping.externalLogin !== undefined ? { externalLogin: mapping.externalLogin } : {}),
+    ...(mapping.displayName !== undefined ? { displayName: mapping.displayName } : {}),
+    ...(mapping.trusted !== undefined ? { trusted: mapping.trusted } : {}),
+  }));
+}
+
+function getActorDisplayName(actorState: SyncBindingActorState, actorId: string): string {
+  return actorState.actorsById.get(actorId)?.displayName ?? actorId;
+}
+
+function normalizeImportedCommentTimestamp(
+  comment: RuntimeImportedComment,
+  field: "createdAt" | "updatedAt",
+): string {
+  const value =
+    field === "updatedAt" ? (comment.updatedAt ?? comment.createdAt) : comment.createdAt;
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(
+      `pulled comment has invalid ${field}: externalId=${comment.externalId} value=${value}`,
+    );
+  }
+
+  return timestamp.toISOString();
+}
+
+function getToduWithInternals(todu: Todu): ToduWithInternalTools {
+  const internalTodu = todu as ToduWithInternalTools;
+  if (!internalTodu.__internal?.syncRuntime?.actors) {
+    throw new Error("daemon sync runtime requires engine syncRuntime actor internals");
+  }
+
+  return internalTodu;
 }
 
 function formatToduError(error: ToduError): string {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -13,6 +13,7 @@ import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
 import { createRecurringNamespace } from "./recurring.js";
+import { createSyncRuntimeActorTools } from "./runtime-internals.js";
 import { processTemplates } from "./scheduling.js";
 import { initBootstrapStorage, initEphemeralStorage, type Storage } from "./storage.js";
 import { addRemoteSyncAdapter, connectSyncClient } from "./sync-client.js";
@@ -24,6 +25,7 @@ import {
   type SyncStatus,
   type Todu,
   type ToduConfig,
+  type ToduWithInternalTools,
 } from "./todu.js";
 
 export type { RemoteSyncConfig } from "@todu/core";
@@ -56,10 +58,13 @@ export type {
   ProjectNamespace,
   RecurringNamespace,
   RemoteSyncState,
+  SyncRuntimeActorTools,
   SyncStatus,
   TaskNamespace,
   Todu,
   ToduConfig,
+  ToduInternalTools,
+  ToduWithInternalTools,
 } from "./todu.js";
 
 /**
@@ -240,8 +245,13 @@ export async function createTodu(
 
   const stubs = createStubNamespaces(resolvedConfig);
 
-  return {
+  const todu: ToduWithInternalTools = {
     ...stubs,
+    __internal: {
+      syncRuntime: {
+        actors: createSyncRuntimeActorTools(storage.catalog),
+      },
+    },
     project: createProjectNamespace(storage.catalog),
     task: createTaskNamespace(storage.catalog, storage.repo),
     label: createLabelNamespace(storage.catalog, storage.repo),
@@ -277,4 +287,6 @@ export async function createTodu(
       }
     },
   };
+
+  return todu;
 }

--- a/packages/engine/src/runtime-internals.ts
+++ b/packages/engine/src/runtime-internals.ts
@@ -1,0 +1,48 @@
+import type { DocHandle } from "@automerge/automerge-repo/slim";
+import { type Actor, type ActorId, type CatalogDocument, ok, type Result } from "@todu/core";
+import type { SyncRuntimeActorTools } from "./todu.js";
+
+function cloneActor(actor: Actor): Actor {
+  return {
+    id: actor.id,
+    displayName: actor.displayName,
+    ...(actor.archived !== undefined ? { archived: actor.archived } : {}),
+  };
+}
+
+export function createSyncRuntimeActorTools(
+  catalog: DocHandle<CatalogDocument>,
+): SyncRuntimeActorTools {
+  return {
+    async list(): Promise<Result<Actor[]>> {
+      return ok((catalog.doc()?.actors ?? []).map(cloneActor));
+    },
+
+    async getOwnerActorId(): Promise<Result<ActorId | undefined>> {
+      return ok(catalog.doc()?.ownerActorId);
+    },
+
+    async ensure(input: { id: ActorId; displayName: string }): Promise<Result<Actor>> {
+      const normalizedDisplayName = input.displayName.trim() || String(input.id);
+      const existing = catalog.doc()?.actors.find((actor) => actor.id === input.id);
+      if (existing) {
+        return ok(cloneActor(existing));
+      }
+
+      const nextActor: Actor = {
+        id: input.id,
+        displayName: normalizedDisplayName,
+      };
+
+      catalog.change((doc) => {
+        const alreadyPresent = doc.actors.some((actor) => actor.id === input.id);
+        if (!alreadyPresent) {
+          doc.actors.push(nextActor);
+        }
+      });
+
+      const created = catalog.doc()?.actors.find((actor) => actor.id === input.id) ?? nextActor;
+      return ok(cloneActor(created));
+    },
+  };
+}

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -1,4 +1,6 @@
 import type {
+  Actor,
+  ActorId,
   CreateHabitInput,
   CreateIntegrationBindingInput,
   CreateLabelInput,
@@ -237,6 +239,22 @@ export interface Todu {
   onChange(callback: () => void): () => void;
 
   close(): Promise<void>;
+}
+
+export interface SyncRuntimeActorTools {
+  list(): Promise<Result<Actor[]>>;
+  getOwnerActorId(): Promise<Result<ActorId | undefined>>;
+  ensure(input: { id: ActorId; displayName: string }): Promise<Result<Actor>>;
+}
+
+export interface ToduInternalTools {
+  syncRuntime: {
+    actors: SyncRuntimeActorTools;
+  };
+}
+
+export interface ToduWithInternalTools extends Todu {
+  __internal: ToduInternalTools;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add actor-aware v2/v3 sync runtime shims with runtime-owned mapping and approval logic
- add minimal engine sync-runtime actor internals used by daemon runtime
- add daemon runtime coverage for v2-only, v3-only, and mixed provider execution

## Testing
- make pre-pr
- npm test -- packages/daemon/src/sync-worker-runtime.test.ts
- npx vitest run --config vitest.all.config.ts packages/daemon/src/runtime.integration.test.ts