### PR TITLE
feat: update core CLI/Electron for actors

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -322,6 +322,34 @@ Task date-range behavior notes:
 - For monthly review, use `--status done --updated-from/--updated-to` to find tasks completed during the target month.
 - Invalid task date input fails with a validation error.
 
+## Actor-aware task and note surfaces
+
+Task and note text output now prefers actor-based identity data when available.
+
+Examples:
+
+```bash
+todu task create --title "Pair on rollout" --project proj-123 --assignee-actor actor-user
+
+todu task update task-123 --assignee-actor actor-user actor-reviewer
+todu task update task-123 --clear-assignees
+
+todu task show task-123
+todu project show proj-123
+
+todu note add "Imported comment" --task task-123 --author-actor actor-reviewer
+todu note list --author-actor actor-reviewer
+```
+
+Behavior notes:
+- `task create --assignee-actor` and `task update --assignee-actor` set actor-based task assignment by actor ID.
+- `task update --clear-assignees` clears actor-based task assignment.
+- `task show` text output displays actor assignees and imported description approval state when applicable.
+- `project show` text output displays the project's authorized assignee actors.
+- `note add --author-actor` and `note list --author-actor` work with actor-based note authorship.
+- `note` text output shows actor-based author names and imported-content approval state when applicable.
+- Legacy `--author` note filtering/input remains available during the compatibility window.
+
 ## Validate connectivity
 
 ```bash

--- a/packages/cli/src/actor-display.ts
+++ b/packages/cli/src/actor-display.ts
@@ -1,0 +1,75 @@
+import type { Actor, ImportedContentApproval } from "@todu/core";
+import type { CliDaemonInvoker } from "./daemon-command-client.js";
+
+export async function buildActorMap(
+  invokeDaemon: CliDaemonInvoker,
+): Promise<Record<string, Actor>> {
+  const result = await invokeDaemon<Actor[]>("actor.list", {});
+  if (!result.ok) {
+    return {};
+  }
+
+  const map: Record<string, Actor> = {};
+  for (const actor of result.value) {
+    map[actor.id] = actor;
+  }
+  return map;
+}
+
+export function formatActorIdentity(actorId: string, actorMap: Record<string, Actor>): string {
+  const actor = actorMap[actorId];
+  if (!actor) {
+    return actorId;
+  }
+
+  const archivedSuffix = actor.archived ? " (archived)" : "";
+  return `${actor.displayName}${archivedSuffix} (${actor.id})`;
+}
+
+export function formatActorDisplay(
+  actorId: string | undefined,
+  actorMap: Record<string, Actor>,
+  fallback?: string,
+): string {
+  if (!actorId) {
+    return fallback ?? "(none)";
+  }
+
+  const actor = actorMap[actorId];
+  if (!actor) {
+    return fallback ?? actorId;
+  }
+
+  return `${actor.displayName}${actor.archived ? " (archived)" : ""}`;
+}
+
+export function formatActorList(
+  actorIds: readonly string[],
+  actorMap: Record<string, Actor>,
+  fallbackNames: readonly string[] = [],
+  options: { includeIds?: boolean } = {},
+): string {
+  if (actorIds.length > 0) {
+    return actorIds
+      .map((actorId) =>
+        options.includeIds
+          ? formatActorIdentity(actorId, actorMap)
+          : formatActorDisplay(actorId, actorMap),
+      )
+      .join(", ");
+  }
+
+  if (fallbackNames.length > 0) {
+    return fallbackNames.join(", ");
+  }
+
+  return "(none)";
+}
+
+export function formatApprovalSummary(approval?: ImportedContentApproval): string | null {
+  if (!approval || approval.state === "notRequired") {
+    return null;
+  }
+
+  return approval.state === "pendingApproval" ? "approval needed" : "approved";
+}

--- a/packages/cli/src/commands/note.test.ts
+++ b/packages/cli/src/commands/note.test.ts
@@ -10,6 +10,76 @@ describe("note commands", () => {
     process.exitCode = undefined;
   });
 
+  it("passes author actor IDs through on note add", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "note.create") {
+        return {
+          ok: true,
+          value: {
+            id: "note-1",
+            content: "Imported note",
+            author: "user",
+            authorActorId: "actor-user",
+            tags: [],
+            createdAt: "2026-03-14T15:00:00.000Z",
+          } satisfies Note,
+        };
+      }
+      if (method === "actor.list") {
+        return {
+          ok: true,
+          value: [{ id: "actor-user", displayName: "user" }],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(["note", "add", "Imported note", "--author-actor", "actor-user"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("note.create", {
+      input: {
+        content: "Imported note",
+        entityType: undefined,
+        entityId: undefined,
+        tags: undefined,
+        author: undefined,
+        authorActorId: "actor-user",
+        createdAt: undefined,
+      },
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("rejects conflicting note author flags", async () => {
+    const invokeDaemon = vi.fn() as unknown as CliDaemonInvoker;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerNoteCommands(program, invokeDaemon);
+
+    await program.parseAsync(
+      ["note", "add", "x", "--author", "user", "--author-actor", "actor-user"],
+      {
+        from: "user",
+      },
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error: --author and --author-actor cannot be used together",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
   it("passes habit attachment through on note add", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "note.create") {
@@ -48,6 +118,7 @@ describe("note commands", () => {
         entityId: "hab-123",
         tags: undefined,
         author: undefined,
+        authorActorId: undefined,
         createdAt: undefined,
       },
     });
@@ -95,6 +166,7 @@ describe("note commands", () => {
         entityId: "hab-123",
         tag: undefined,
         author: undefined,
+        authorActorId: undefined,
         journal: undefined,
         createdFrom: undefined,
         createdTo: undefined,
@@ -139,6 +211,7 @@ describe("note commands", () => {
         entityId: undefined,
         tag: undefined,
         author: undefined,
+        authorActorId: undefined,
         journal: undefined,
         createdFrom: "2026-03-01",
         createdTo: "2026-03-31",
@@ -175,6 +248,7 @@ describe("note commands", () => {
         entityId: undefined,
         tag: undefined,
         author: undefined,
+        authorActorId: undefined,
         journal: true,
         createdFrom: undefined,
         createdTo: undefined,

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -1,5 +1,6 @@
 import type { Note, NoteEntityType } from "@todu/core";
 import type { Command } from "commander";
+import { buildActorMap, formatActorDisplay, formatApprovalSummary } from "../actor-display.js";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { formatJSON, formatTable } from "../format.js";
 
@@ -7,27 +8,38 @@ const NOTE_COLUMNS = [
   { key: "id", label: "ID" },
   { key: "content", label: "Content" },
   { key: "author", label: "Author" },
+  { key: "approval", label: "Approval" },
   { key: "entity", label: "Entity" },
   { key: "tags", label: "Tags" },
   { key: "createdAt", label: "Created" },
 ];
 
-function noteToRow(n: Note): Record<string, string> {
+function noteToRow(
+  n: Note,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+): Record<string, string> {
   const entity = n.entityType ? `${n.entityType}:${n.entityId}` : "";
   const content = n.content.length > 60 ? `${n.content.slice(0, 57)}...` : n.content;
   return {
     id: n.id,
     content,
-    author: n.author,
+    author: formatActorDisplay(n.authorActorId, actorMap, n.author),
+    approval: formatApprovalSummary(n.contentApproval) ?? "-",
     entity,
     tags: n.tags.join(", "),
     createdAt: n.createdAt,
   };
 }
 
-function noteDetail(n: Note): string {
-  const lines = [`ID:      ${n.id}`, `Author:  ${n.author}`, `Created: ${n.createdAt}`];
+function noteDetail(n: Note, actorMap: Awaited<ReturnType<typeof buildActorMap>>): string {
+  const lines = [
+    `ID:      ${n.id}`,
+    `Author:  ${formatActorDisplay(n.authorActorId, actorMap, n.author)}`,
+    `Created: ${n.createdAt}`,
+  ];
   if (n.entityType) lines.push(`Entity:  ${n.entityType}:${n.entityId}`);
+  const approvalSummary = formatApprovalSummary(n.contentApproval);
+  if (approvalSummary) lines.push(`Approval: ${approvalSummary}`);
   if (n.tags.length > 0) lines.push(`Tags:    ${n.tags.join(", ")}`);
   lines.push("", n.content);
   return lines.join("\n");
@@ -73,9 +85,15 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--project <ref>", "attach to a project")
     .option("--habit <id>", "attach to a habit")
     .option("--tag <tags...>", "tags")
-    .option("--author <author>", "author (default: user)")
+    .option("--author <author>", "legacy author display name")
+    .option("--author-actor <actorId>", "author actor ID")
     .option("--created-at <iso>", "ISO timestamp for importing/backdating a journal entry")
     .action(async (content, opts) => {
+      if (opts.author && opts.authorActor) {
+        console.error("Error: --author and --author-actor cannot be used together");
+        process.exitCode = 1;
+        return;
+      }
       let entityType: NoteEntityType | undefined;
       let entityId: string | undefined;
 
@@ -104,6 +122,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
           entityId,
           tags: opts.tag,
           author: opts.author,
+          authorActorId: opts.authorActor,
           createdAt: opts.createdAt,
         },
       });
@@ -118,8 +137,9 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const actorMap = await buildActorMap(invokeDaemon);
         console.log("Note added:");
-        console.log(noteDetail(result.value));
+        console.log(noteDetail(result.value, actorMap));
       }
     });
 
@@ -130,11 +150,17 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--project <ref>", "filter by project")
     .option("--habit <id>", "filter by habit")
     .option("--tag <tag>", "filter by tag")
-    .option("--author <author>", "filter by author")
+    .option("--author <author>", "filter by legacy author display name")
+    .option("--author-actor <actorId>", "filter by author actor ID")
     .option("--journal", "filter to standalone journal entries only")
     .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
     .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
     .action(async (opts) => {
+      if (opts.author && opts.authorActor) {
+        console.error("Error: --author and --author-actor cannot be used together");
+        process.exitCode = 1;
+        return;
+      }
       let entityType: NoteEntityType | undefined;
       let entityId: string | undefined;
 
@@ -162,6 +188,7 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
           entityId,
           tag: opts.tag,
           author: opts.author,
+          authorActorId: opts.authorActor,
           journal: opts.journal,
           createdFrom: opts.from,
           createdTo: opts.to,
@@ -180,7 +207,13 @@ export function registerNoteCommands(program: Command, invokeDaemon: CliDaemonIn
       } else if (result.value.length === 0) {
         console.log("No notes.");
       } else {
-        console.log(formatTable(result.value.map(noteToRow), NOTE_COLUMNS));
+        const actorMap = await buildActorMap(invokeDaemon);
+        console.log(
+          formatTable(
+            result.value.map((value) => noteToRow(value, actorMap)),
+            NOTE_COLUMNS,
+          ),
+        );
       }
     });
 

--- a/packages/cli/src/commands/project.integration.test.ts
+++ b/packages/cli/src/commands/project.integration.test.ts
@@ -78,6 +78,8 @@ describe("project CLI commands", () => {
     const showOutput = run(`project show ${created.id}`);
     expect(showOutput).toContain("JSON Project");
     expect(showOutput).toContain(created.id);
+    expect(showOutput).toContain("Actors:");
+    expect(showOutput).toContain("actor-user");
     expect(showOutput).not.toContain("Sync:");
 
     // Show by name

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,6 +1,7 @@
 import type { Project, ProjectStatus } from "@todu/core";
 import { isProjectStatus } from "@todu/core";
 import type { Command } from "commander";
+import { buildActorMap, formatActorList } from "../actor-display.js";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { colorPriority, colorStatus, formatJSON, formatTable } from "../format.js";
 
@@ -20,12 +21,13 @@ function projectToRow(p: Project): Record<string, string> {
   };
 }
 
-function projectDetail(p: Project): string {
+function projectDetail(p: Project, actorMap: Awaited<ReturnType<typeof buildActorMap>>): string {
   const lines = [
     `ID:          ${p.id}`,
     `Name:        ${p.name}`,
     `Status:      ${p.status}`,
     `Priority:    ${p.priority}`,
+    `Actors:      ${formatActorList(p.authorizedAssigneeActorIds, actorMap, [], { includeIds: true })}`,
     `Created:     ${p.createdAt}`,
     `Updated:     ${p.updatedAt}`,
   ];
@@ -99,8 +101,9 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const actorMap = await buildActorMap(invokeDaemon);
         console.log("Project created:");
-        console.log(projectDetail(result.value));
+        console.log(projectDetail(result.value, actorMap));
       }
     });
 
@@ -152,7 +155,8 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
       if (format === "json") {
         console.log(formatJSON(resolved.value));
       } else {
-        console.log(projectDetail(resolved.value));
+        const actorMap = await buildActorMap(invokeDaemon);
+        console.log(projectDetail(resolved.value, actorMap));
       }
     });
 
@@ -192,8 +196,9 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const actorMap = await buildActorMap(invokeDaemon);
         console.log("Project updated:");
-        console.log(projectDetail(result.value));
+        console.log(projectDetail(result.value, actorMap));
       }
     });
 

--- a/packages/cli/src/commands/task.integration.test.ts
+++ b/packages/cli/src/commands/task.integration.test.ts
@@ -62,12 +62,13 @@ describe("task CLI commands", () => {
 
     // Create task JSON
     const taskJson = run(
-      `--format json task create --title "Add signup" --project "My App" --label feature`,
+      `--format json task create --title "Add signup" --project "My App" --label feature --assignee-actor actor-user`,
     );
     const task = JSON.parse(taskJson);
     expect(task.title).toBe("Add signup");
     expect(task.id).toMatch(/^task-/);
     expect(task.labels).toContain("feature");
+    expect(task.assigneeActorIds).toEqual(["actor-user"]);
 
     // List
     const listOutput = run("task list");
@@ -88,14 +89,17 @@ describe("task CLI commands", () => {
     const showOutput = run(`task show ${task.id}`);
     expect(showOutput).toContain("Add signup");
     expect(showOutput).toContain(task.id);
+    expect(showOutput).toContain("Assignees:");
+    expect(showOutput).toContain("user (actor-user)");
 
     // Update
     const updateOutput = run(
-      `task update ${task.id} --status inprogress --title "Add signup flow"`,
+      `task update ${task.id} --status inprogress --title "Add signup flow" --clear-assignees`,
     );
     expect(updateOutput).toContain("Task updated:");
     expect(updateOutput).toContain("Add signup flow");
     expect(updateOutput).toContain("inprogress");
+    expect(updateOutput).toContain("Assignees:   (none)");
 
     // Search
     const searchOutput = run("task search login");
@@ -114,6 +118,9 @@ describe("task CLI commands", () => {
     // Verify moved
     const archiveTasks = run('--format json task list --project "Archive"');
     expect(JSON.parse(archiveTasks)).toHaveLength(1);
+
+    const textList = run('task list --project "My App"');
+    expect(textList).toContain("Assignees");
 
     const appTasks = run('--format json task list --project "My App"');
     expect(JSON.parse(appTasks)).toHaveLength(1); // only the login bug remains

--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -10,6 +10,76 @@ describe("task commands", () => {
     process.exitCode = undefined;
   });
 
+  it("passes actor assignee updates through on task update", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "task.update") {
+        return {
+          ok: true,
+          value: {
+            id: "task-1",
+            title: "Actor task",
+            status: "active",
+            priority: "medium",
+            projectId: "proj-1",
+            labels: [],
+            assigneeActorIds: ["actor-user"],
+            assignees: [],
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:00:00.000Z",
+          },
+        };
+      }
+      if (method === "project.list") {
+        return { ok: true, value: [] };
+      }
+      if (method === "actor.list") {
+        return {
+          ok: true,
+          value: [{ id: "actor-user", displayName: "user" }],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerTaskCommands(program, invokeDaemon);
+
+    await program.parseAsync(["task", "update", "task-1", "--assignee-actor", "actor-user"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("task.update", {
+      id: "task-1",
+      input: expect.objectContaining({ assigneeActorIds: ["actor-user"] }),
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("rejects conflicting assignee update flags", async () => {
+    const invokeDaemon = vi.fn() as unknown as CliDaemonInvoker;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerTaskCommands(program, invokeDaemon);
+
+    await program.parseAsync(
+      ["task", "update", "task-1", "--assignee-actor", "actor-user", "--clear-assignees"],
+      {
+        from: "user",
+      },
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Error: --assignee-actor and --clear-assignees cannot be used together",
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
   it("passes created-at date range filtering through on task list", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "task.list") {

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,6 +1,7 @@
 import type { Task, TaskSortOptions, TaskStatus, TaskWithDetail } from "@todu/core";
 import { isTaskPriority, isTaskSortField, isTaskStatus } from "@todu/core";
 import type { Command } from "commander";
+import { buildActorMap, formatActorList, formatApprovalSummary } from "../actor-display.js";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { colorPriority, colorStatus, formatJSON, formatTable } from "../format.js";
 
@@ -10,31 +11,44 @@ const TASK_COLUMNS = [
   { key: "status", label: "Status", colorize: colorStatus },
   { key: "priority", label: "Priority", colorize: colorPriority },
   { key: "project", label: "Project" },
+  { key: "assignees", label: "Assignees" },
 ];
 
-function taskToRow(t: Task, projectName?: string): Record<string, string> {
+function taskToRow(
+  t: Task,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+  projectName?: string,
+): Record<string, string> {
   return {
     id: t.id,
     title: t.title,
     status: t.status,
     priority: t.priority,
     project: projectName ?? t.projectId,
+    assignees: formatActorList(t.assigneeActorIds, actorMap, t.assignees),
   };
 }
 
-function taskDetail(t: TaskWithDetail, projectName?: string): string {
+function taskDetail(
+  t: TaskWithDetail,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+  projectName?: string,
+): string {
   const lines = [
     `ID:          ${t.id}`,
     `Title:       ${t.title}`,
     `Status:      ${t.status}`,
     `Priority:    ${t.priority}`,
     `Project:     ${projectName ?? t.projectId}`,
+    `Assignees:   ${formatActorList(t.assigneeActorIds, actorMap, t.assignees, { includeIds: true })}`,
     `Labels:      ${t.labels.length > 0 ? t.labels.join(", ") : "(none)"}`,
     `Created:     ${t.createdAt}`,
     `Updated:     ${t.updatedAt}`,
   ];
   if (t.dueDate) lines.push(`Due:         ${t.dueDate}`);
   if (t.scheduledDate) lines.push(`Scheduled:   ${t.scheduledDate}`);
+  const approvalSummary = formatApprovalSummary(t.descriptionApproval);
+  if (approvalSummary) lines.push(`Approval:    ${approvalSummary}`);
   if (t.description) {
     lines.push("", "Description:", t.description);
   }
@@ -107,6 +121,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--priority <priority>", "priority (low, medium, high)", "medium")
     .option("--description <desc>", "task description")
     .option("--label <labels...>", "labels")
+    .option("--assignee-actor <actorIds...>", "assign actor IDs")
     .option("--due <date>", "due date (ISO format)")
     .option("--scheduled <date>", "scheduled date (ISO format)")
     .action(async (opts) => {
@@ -124,6 +139,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           priority: opts.priority,
           description: opts.description,
           labels: opts.label,
+          assigneeActorIds: opts.assigneeActor,
           dueDate: opts.due,
           scheduledDate: opts.scheduled,
         },
@@ -139,8 +155,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const actorMap = await buildActorMap(invokeDaemon);
         console.log("Task created:");
-        console.log(taskDetail(result.value, project.name));
+        console.log(taskDetail(result.value, actorMap, project.name));
       }
     });
 
@@ -229,8 +246,11 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
-        const nameMap = await buildProjectNameMap(invokeDaemon);
-        const rows = result.value.map((t) => taskToRow(t, nameMap[t.projectId]));
+        const [nameMap, actorMap] = await Promise.all([
+          buildProjectNameMap(invokeDaemon),
+          buildActorMap(invokeDaemon),
+        ]);
+        const rows = result.value.map((t) => taskToRow(t, actorMap, nameMap[t.projectId]));
         console.log(formatTable(rows, TASK_COLUMNS));
       }
     });
@@ -247,12 +267,15 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const nameMap = await buildProjectNameMap(invokeDaemon);
+      const [nameMap, actorMap] = await Promise.all([
+        buildProjectNameMap(invokeDaemon),
+        buildActorMap(invokeDaemon),
+      ]);
       const format = program.opts().format;
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
-        console.log(taskDetail(result.value, nameMap[result.value.projectId]));
+        console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
       }
     });
 
@@ -265,9 +288,17 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--priority <priority>", "new priority")
     .option("--description <desc>", "new description")
     .option("--label <labels...>", "replace labels")
+    .option("--assignee-actor <actorIds...>", "replace assignee actors by actor ID")
+    .option("--clear-assignees", "clear all actor-based assignees")
     .option("--due <date>", "new due date")
     .option("--scheduled <date>", "new scheduled date")
     .action(async (id, opts) => {
+      if (opts.assigneeActor && opts.clearAssignees) {
+        console.error("Error: --assignee-actor and --clear-assignees cannot be used together");
+        process.exitCode = 1;
+        return;
+      }
+
       const result = await invokeDaemon<TaskWithDetail>("task.update", {
         id,
         input: {
@@ -276,6 +307,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           priority: opts.priority,
           description: opts.description,
           labels: opts.label,
+          assigneeActorIds: opts.clearAssignees ? [] : opts.assigneeActor,
           dueDate: opts.due,
           scheduledDate: opts.scheduled,
         },
@@ -287,13 +319,16 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const nameMap = await buildProjectNameMap(invokeDaemon);
+      const [nameMap, actorMap] = await Promise.all([
+        buildProjectNameMap(invokeDaemon),
+        buildActorMap(invokeDaemon),
+      ]);
       const format = program.opts().format;
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
         console.log("Task updated:");
-        console.log(taskDetail(result.value, nameMap[result.value.projectId]));
+        console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
       }
     });
 
@@ -343,8 +378,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
+        const actorMap = await buildActorMap(invokeDaemon);
         console.log(`Moved task to ${project.name}:`);
-        console.log(taskDetail(result.value, project.name));
+        console.log(taskDetail(result.value, actorMap, project.name));
       }
     });
 
@@ -364,8 +400,11 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
       if (format === "json") {
         console.log(formatJSON(result.value));
       } else {
-        const nameMap = await buildProjectNameMap(invokeDaemon);
-        const rows = result.value.map((t) => taskToRow(t, nameMap[t.projectId]));
+        const [nameMap, actorMap] = await Promise.all([
+          buildProjectNameMap(invokeDaemon),
+          buildActorMap(invokeDaemon),
+        ]);
+        const rows = result.value.map((t) => taskToRow(t, actorMap, nameMap[t.projectId]));
         console.log(formatTable(rows, TASK_COLUMNS));
       }
     });
@@ -386,13 +425,16 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           return;
         }
 
-        const nameMap = await buildProjectNameMap(invokeDaemon);
+        const [nameMap, actorMap] = await Promise.all([
+          buildProjectNameMap(invokeDaemon),
+          buildActorMap(invokeDaemon),
+        ]);
         const format = program.opts().format;
         if (format === "json") {
           console.log(formatJSON(result.value));
         } else {
           console.log(`Task ${targetStatus}:`);
-          console.log(taskDetail(result.value, nameMap[result.value.projectId]));
+          console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
         }
       });
   }

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -50,6 +50,11 @@ export function createCoreNamespaceHandlers(
   const method = createMethodExecutor(options.getTodu);
 
   return {
+    actor: {
+      list: method(async (_request, todu) => {
+        return todu.actor.list();
+      }),
+    },
     project: {
       create: method(async (request, todu) => {
         const input = getRequiredObjectParam<CreateProjectInput>(request, "input");

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -30,6 +30,7 @@ export const DAEMON_BASE_METHODS = [
 export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] as const;
 
 export const CORE_DAEMON_NAMESPACE_METHODS = {
+  actor: ["list"],
   project: ["create", "list", "get", "update", "delete"],
   task: ["create", "list", "get", "update", "delete", "move", "search"],
   label: ["create", "list", "update", "delete"],

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -2,6 +2,23 @@ import { describe, expect, it, vi } from "vitest";
 import { createDaemonToduClient } from "./daemon-todu-client.js";
 
 describe("createDaemonToduClient", () => {
+  it("routes actor.list to daemon RPC and preserves Result shape", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: [{ id: "actor-user", displayName: "user" }],
+    });
+
+    const client = createDaemonToduClient({ request });
+
+    const result = await client.actor.list();
+
+    expect(request).toHaveBeenCalledWith("actor.list", {});
+    expect(result).toEqual({
+      ok: true,
+      value: [{ id: "actor-user", displayName: "user" }],
+    });
+  });
+
   it("routes task.list to daemon RPC and preserves Result shape", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -4,6 +4,9 @@ import type { DaemonConnectionManager } from "./daemon-connection-manager.js";
 import { mapDaemonErrorToToduError } from "./daemon-error-mapping.js";
 
 interface DaemonBackedToduMethods {
+  actor: {
+    list(): Promise<Result<unknown, ToduError>>;
+  };
   project: {
     list(filter?: unknown): Promise<Result<unknown, ToduError>>;
     get(id: string): Promise<Result<unknown, ToduError>>;
@@ -45,6 +48,9 @@ export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "re
     invokeDaemonResult<T>(daemon, method, params);
 
   const client: DaemonBackedToduMethods = {
+    actor: {
+      list: () => invoke("actor.list", {}),
+    },
     project: {
       list: (filter) => invoke("project.list", { filter }),
       get: (id) => invoke("project.get", { id }),

--- a/packages/electron/src/main/ipc.integration.test.ts
+++ b/packages/electron/src/main/ipc.integration.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it, vi } from "vitest";
 import { createDaemonIpcHandlers, mapDaemonErrorToToduError } from "./ipc.js";
 
 describe("createDaemonIpcHandlers", () => {
+  it("routes actor IPC handlers to daemon RPC and preserves Result contract", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: [{ id: "actor-user", displayName: "user" }],
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+    });
+
+    const result = await handlers["todu:actor:list"](undefined);
+
+    expect(daemon.request).toHaveBeenCalledWith("actor.list", {});
+    expect(result).toEqual({
+      ok: true,
+      value: [{ id: "actor-user", displayName: "user" }],
+    });
+  });
+
   it("routes task IPC handlers to daemon RPC and preserves Result contract", async () => {
     const daemon = {
       request: vi.fn().mockResolvedValue({

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -35,6 +35,9 @@ export function createDaemonIpcHandlers(
     invokeDaemonRaw<T>(options.daemon, method, params);
 
   return {
+    // ── Actor ─────────────────────────────────────────────────────────────
+    "todu:actor:list": () => invokeResult("actor.list"),
+
     // ── Project ───────────────────────────────────────────────────────────
     "todu:project:list": (_event, filter) => invokeResult("project.list", { filter }),
     "todu:project:get": (_event, id) => invokeResult("project.get", { id }),

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -7,6 +7,11 @@ import { contextBridge, ipcRenderer } from "electron";
  * Each method maps 1:1 to an IPC channel registered in main/ipc.ts.
  */
 const api = {
+  // ── Actor ──────────────────────────────────────────────────────────
+  actor: {
+    list: () => ipcRenderer.invoke("todu:actor:list"),
+  },
+
   // ── Project ────────────────────────────────────────────────────────
   project: {
     list: (filter?: unknown) => ipcRenderer.invoke("todu:project:list", filter),

--- a/packages/electron/src/renderer/components/CommentThread.test.tsx
+++ b/packages/electron/src/renderer/components/CommentThread.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Note } from "@todu/core/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as hooks from "../hooks/useTodu.js";
+import { CommentThread } from "./CommentThread.js";
+
+vi.mock("../hooks/useTodu.js", () => ({
+  useActors: vi.fn(),
+  useCreateNote: vi.fn(),
+  useDeleteNote: vi.fn(),
+  useNotes: vi.fn(),
+}));
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1" as Note["id"],
+    content: "Imported comment",
+    author: "legacy-reviewer",
+    authorActorId: "actor-reviewer" as NonNullable<Note["authorActorId"]>,
+    contentApproval: { state: "approved" },
+    entityType: "task",
+    entityId: "task-1",
+    tags: [],
+    createdAt: "2026-03-14T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const createNoteMutate = vi.fn();
+const deleteNoteMutate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(hooks.useActors).mockReturnValue({
+    data: [{ id: "actor-reviewer", displayName: "Reviewer" }],
+  } as ReturnType<typeof hooks.useActors>);
+
+  vi.mocked(hooks.useNotes).mockReturnValue({
+    data: [makeNote()],
+    isLoading: false,
+  } as ReturnType<typeof hooks.useNotes>);
+
+  vi.mocked(hooks.useCreateNote).mockReturnValue({
+    mutate: createNoteMutate,
+    isPending: false,
+  } as ReturnType<typeof hooks.useCreateNote>);
+
+  vi.mocked(hooks.useDeleteNote).mockReturnValue({
+    mutate: deleteNoteMutate,
+  } as ReturnType<typeof hooks.useDeleteNote>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CommentThread", () => {
+  it("renders actor-based authors and approval badges", () => {
+    render(<CommentThread entityType="task" entityId="task-1" />);
+
+    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("Approved import")).toBeDefined();
+    expect(screen.getByText("Imported comment")).toBeDefined();
+  });
+
+  it("creates comments without legacy author strings", async () => {
+    render(<CommentThread entityType="task" entityId="task-1" />);
+
+    fireEvent.change(screen.getByPlaceholderText("Add a comment…"), {
+      target: { value: "New comment" },
+    });
+    fireEvent.click(screen.getByText("Comment"));
+
+    await waitFor(() => {
+      expect(createNoteMutate).toHaveBeenCalledWith(
+        { content: "New comment", entityType: "task", entityId: "task-1" },
+        { onSuccess: expect.any(Function) },
+      );
+    });
+  });
+});

--- a/packages/electron/src/renderer/components/CommentThread.tsx
+++ b/packages/electron/src/renderer/components/CommentThread.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode, useState } from "react";
-import { useCreateNote, useDeleteNote, useNotes } from "../hooks/useTodu.js";
+import { type ReactNode, useMemo, useState } from "react";
+import { useActors, useCreateNote, useDeleteNote, useNotes } from "../hooks/useTodu.js";
+import { createActorMap, getActorName, getApprovalLabel } from "../lib/actors.js";
 
 export function CommentThread({
   entityType,
@@ -9,14 +10,16 @@ export function CommentThread({
   entityId: string;
 }): ReactNode {
   const { data: notes, isLoading } = useNotes({ entityType, entityId });
+  const { data: actors } = useActors();
   const createNote = useCreateNote();
   const deleteNote = useDeleteNote();
   const [newComment, setNewComment] = useState("");
+  const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   const handleSubmit = () => {
     if (!newComment.trim()) return;
     createNote.mutate(
-      { content: newComment.trim(), entityType, entityId, author: "user" },
+      { content: newComment.trim(), entityType, entityId },
       { onSuccess: () => setNewComment("") },
     );
   };
@@ -26,23 +29,29 @@ export function CommentThread({
       <h3 className="section-title">Comments</h3>
       {isLoading && <div className="loading-state">Loading comments…</div>}
       {notes && notes.length === 0 && <div className="empty-hint">No comments yet</div>}
-      {notes?.map((note) => (
-        <div key={note.id} className="comment">
-          <div className="comment-header">
-            <span className="comment-author">{note.author ?? "user"}</span>
-            <span className="comment-date">{note.createdAt.slice(0, 16).replace("T", " ")}</span>
-            <button
-              type="button"
-              className="btn-icon"
-              title="Delete comment"
-              onClick={() => deleteNote.mutate(note.id)}
-            >
-              ✕
-            </button>
+      {notes?.map((note) => {
+        const approvalLabel = getApprovalLabel(note.contentApproval);
+        return (
+          <div key={note.id} className="comment">
+            <div className="comment-header">
+              <span className="comment-author">
+                {getActorName(note.authorActorId, actorMap, note.author)}
+              </span>
+              {approvalLabel && <span className="chip chip-label">{approvalLabel}</span>}
+              <span className="comment-date">{note.createdAt.slice(0, 16).replace("T", " ")}</span>
+              <button
+                type="button"
+                className="btn-icon"
+                title="Delete comment"
+                onClick={() => deleteNote.mutate(note.id)}
+              >
+                ✕
+              </button>
+            </div>
+            <div className="comment-body">{note.content}</div>
           </div>
-          <div className="comment-body">{note.content}</div>
-        </div>
-      ))}
+        );
+      })}
       <div className="comment-input">
         <textarea
           className="input"

--- a/packages/electron/src/renderer/hooks/useTodu.ts
+++ b/packages/electron/src/renderer/hooks/useTodu.ts
@@ -33,6 +33,7 @@ import type {
 // ============================================================================
 
 export const queryKeys = {
+  actors: ["actors"] as const,
   projects: ["projects"] as const,
   project: (id: string) => ["projects", id] as const,
   tasks: (filter?: unknown, sort?: unknown) => ["tasks", filter, sort] as const,
@@ -75,6 +76,17 @@ function unwrap<T>(result: Result<T>): T {
     throw new Error(formatError(result.error));
   }
   return result.value;
+}
+
+// ============================================================================
+// Actor Hooks
+// ============================================================================
+
+export function useActors() {
+  return useQuery({
+    queryKey: queryKeys.actors,
+    queryFn: async () => unwrap(await window.todu.actor.list()),
+  });
 }
 
 // ============================================================================

--- a/packages/electron/src/renderer/lib/actors.ts
+++ b/packages/electron/src/renderer/lib/actors.ts
@@ -1,0 +1,42 @@
+import type { Actor, ImportedContentApproval } from "@todu/core/browser";
+
+export function createActorMap(actors?: Actor[]): Map<string, Actor> {
+  return new Map((actors ?? []).map((actor) => [actor.id, actor]));
+}
+
+export function getActorName(
+  actorId: string | undefined,
+  actorMap: Map<string, Actor>,
+  fallback?: string,
+): string {
+  if (!actorId) {
+    return fallback ?? "Unknown";
+  }
+
+  const actor = actorMap.get(actorId);
+  if (!actor) {
+    return fallback ?? actorId;
+  }
+
+  return `${actor.displayName}${actor.archived ? " (archived)" : ""}`;
+}
+
+export function getActorNames(
+  actorIds: readonly string[],
+  actorMap: Map<string, Actor>,
+  fallbackNames: readonly string[] = [],
+): string[] {
+  if (actorIds.length > 0) {
+    return actorIds.map((actorId) => getActorName(actorId, actorMap));
+  }
+
+  return [...fallbackNames];
+}
+
+export function getApprovalLabel(approval?: ImportedContentApproval): string | null {
+  if (!approval || approval.state === "notRequired") {
+    return null;
+  }
+
+  return approval.state === "pendingApproval" ? "Approval needed" : "Approved import";
+}

--- a/packages/electron/src/renderer/styles.css
+++ b/packages/electron/src/renderer/styles.css
@@ -1101,10 +1101,19 @@ button.detail-description {
   gap: 6px;
 }
 
+.detail-meta-cell-wide {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
 .detail-meta-label {
   font-size: 12px;
   color: var(--text-muted);
   font-weight: 500;
+}
+
+.detail-approval-row {
+  margin-bottom: 8px;
 }
 
 /* Tabbed detail content */

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -1,4 +1,5 @@
 import type {
+  Actor,
   CreateHabitInput,
   CreateLabelInput,
   CreateNoteInput,
@@ -35,6 +36,10 @@ import type {
   UpdateTaskInput,
 } from "@todu/core/browser";
 import type { UpcomingOccurrence } from "@todu/engine";
+
+export interface ToduActorApi {
+  list(): Promise<Result<Actor[]>>;
+}
 
 export interface ToduProjectApi {
   list(filter?: ProjectFilter): Promise<Result<Project[]>>;
@@ -185,6 +190,7 @@ export interface ToduSyncApi {
 }
 
 export interface ToduApi {
+  actor: ToduActorApi;
   project: ToduProjectApi;
   task: ToduTaskApi;
   label: ToduLabelApi;

--- a/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
+++ b/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as hooks from "../hooks/useTodu.js";
+import { NoteList } from "./NoteList.js";
+import { ProjectDetail } from "./ProjectDetail.js";
+import { TaskDetail } from "./TaskDetail.js";
+
+vi.mock("../hooks/useTodu.js", () => ({
+  useActors: vi.fn(),
+  useDeleteNote: vi.fn(),
+  useDeleteProject: vi.fn(),
+  useDeleteTask: vi.fn(),
+  useMoveTask: vi.fn(),
+  useNotes: vi.fn(),
+  useProject: vi.fn(),
+  useProjects: vi.fn(),
+  useSearchTasks: vi.fn(),
+  useTask: vi.fn(),
+  useTasks: vi.fn(),
+  useUpdateProject: vi.fn(),
+  useUpdateTask: vi.fn(),
+}));
+
+vi.mock("../components/CommentThread.js", () => ({
+  CommentThread: () => <div>Comments</div>,
+}));
+
+vi.mock("../components/ConfirmDialog.js", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("../components/MarkdownEditor.js", () => ({
+  MarkdownEditor: ({ value }: { value?: string }) => <div>{value}</div>,
+}));
+
+vi.mock("../components/PriorityChip.js", () => ({
+  PriorityChip: ({ priority }: { priority: string }) => <span>{priority}</span>,
+}));
+
+vi.mock("../components/StatusChip.js", () => ({
+  StatusChip: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+vi.mock("../components/TabBar.js", () => ({
+  TabBar: ({ tabs }: { tabs: Array<{ id: string; label: string }> }) => (
+    <div>
+      {tabs.map((tab) => (
+        <span key={tab.id}>{tab.label}</span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../components/FilterBar.js", () => ({
+  FilterBar: () => <div>FilterBar</div>,
+}));
+
+vi.mock("../components/TaskTable.js", () => ({
+  TaskTable: () => <div>TaskTable</div>,
+}));
+
+function makeTask(overrides: Partial<TaskWithDetail> = {}): TaskWithDetail {
+  return {
+    id: "task-1" as TaskWithDetail["id"],
+    title: "Actor task",
+    status: "active",
+    priority: "medium",
+    projectId: "proj-1" as TaskWithDetail["projectId"],
+    labels: [],
+    assigneeActorIds: ["actor-user", "actor-reviewer"] as Task["assigneeActorIds"],
+    assignees: [],
+    description: "Imported instructions",
+    descriptionApproval: {
+      state: "pendingApproval",
+      sourceBindingId: "bind-1" as NonNullable<
+        TaskWithDetail["descriptionApproval"]
+      >["sourceBindingId"],
+    },
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj-1" as Project["id"],
+    name: "Inbox",
+    status: "active",
+    priority: "medium",
+    authorizedAssigneeActorIds: [
+      "actor-user",
+      "actor-reviewer",
+    ] as Project["authorizedAssigneeActorIds"],
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1" as Note["id"],
+    content: "Imported note",
+    author: "legacy-reviewer",
+    authorActorId: "actor-reviewer" as NonNullable<Note["authorActorId"]>,
+    contentApproval: { state: "pendingApproval" },
+    tags: [],
+    createdAt: "2026-03-14T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  Object.defineProperty(window, "todu", {
+    configurable: true,
+    value: {
+      agent: {
+        focusEntity: vi.fn().mockResolvedValue(undefined),
+        clearFocusedEntity: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+  });
+
+  vi.mocked(hooks.useActors).mockReturnValue({
+    data: [
+      { id: "actor-user", displayName: "user" },
+      { id: "actor-reviewer", displayName: "Reviewer" },
+    ],
+  } as ReturnType<typeof hooks.useActors>);
+
+  vi.mocked(hooks.useProjects).mockReturnValue({
+    data: [makeProject()],
+  } as ReturnType<typeof hooks.useProjects>);
+
+  vi.mocked(hooks.useTask).mockReturnValue({
+    data: makeTask(),
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof hooks.useTask>);
+
+  vi.mocked(hooks.useUpdateTask).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useUpdateTask>);
+
+  vi.mocked(hooks.useDeleteTask).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useDeleteTask>);
+
+  vi.mocked(hooks.useMoveTask).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useMoveTask>);
+
+  vi.mocked(hooks.useProject).mockReturnValue({
+    data: makeProject(),
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof hooks.useProject>);
+
+  vi.mocked(hooks.useUpdateProject).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useUpdateProject>);
+
+  vi.mocked(hooks.useDeleteProject).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useDeleteProject>);
+
+  vi.mocked(hooks.useTasks).mockReturnValue({
+    data: [],
+  } as ReturnType<typeof hooks.useTasks>);
+
+  vi.mocked(hooks.useSearchTasks).mockReturnValue({
+    data: [],
+  } as ReturnType<typeof hooks.useSearchTasks>);
+
+  vi.mocked(hooks.useNotes).mockReturnValue({
+    data: [makeNote()],
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof hooks.useNotes>);
+
+  vi.mocked(hooks.useDeleteNote).mockReturnValue({
+    mutate: vi.fn(),
+  } as ReturnType<typeof hooks.useDeleteNote>);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("actor-aware renderer views", () => {
+  it("shows actor assignees and approval state in task detail", async () => {
+    render(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    expect(screen.getByText("Assignees")).toBeDefined();
+    expect(screen.getByText("user")).toBeDefined();
+    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("Approval needed")).toBeDefined();
+  });
+
+  it("shows authorized assignee actors in project detail", async () => {
+    render(
+      <ProjectDetail
+        projectId="proj-1"
+        onBack={() => {}}
+        onSelectTask={() => {}}
+        onCreateTask={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Authorized assignees")).toBeDefined();
+    expect(screen.getByText("user")).toBeDefined();
+    expect(screen.getByText("Reviewer")).toBeDefined();
+  });
+
+  it("shows actor-based note authors and approval state in note list", async () => {
+    render(<NoteList onCreateNote={() => {}} onNavigateToEntity={() => {}} />);
+
+    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("Approval needed")).toBeDefined();
+    expect(screen.getByText("Imported note")).toBeDefined();
+  });
+});

--- a/packages/electron/src/renderer/views/CreateNoteDialog.tsx
+++ b/packages/electron/src/renderer/views/CreateNoteDialog.tsx
@@ -21,7 +21,6 @@ export function CreateNoteDialog({ onClose }: { onClose: () => void }): ReactNod
       {
         content: content.trim(),
         tags: tags.length > 0 ? tags : undefined,
-        author: "user",
       },
       {
         onSuccess: onClose,

--- a/packages/electron/src/renderer/views/JournalEditor.tsx
+++ b/packages/electron/src/renderer/views/JournalEditor.tsx
@@ -70,7 +70,7 @@ export function JournalEditor({ note, timezone, onClose }: JournalEditorProps): 
       );
     } else {
       createNote.mutate(
-        { content: content.trim(), tags: tags.length > 0 ? tags : undefined, author: "user" },
+        { content: content.trim(), tags: tags.length > 0 ? tags : undefined },
         {
           onSuccess: onClose,
           onError: (err) => setError(err instanceof Error ? err.message : "Failed to create"),

--- a/packages/electron/src/renderer/views/NoteList.tsx
+++ b/packages/electron/src/renderer/views/NoteList.tsx
@@ -1,7 +1,8 @@
 import type { NoteEntityType, NoteFilter, NoteId } from "@todu/core/browser";
 import { type ReactNode, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
-import { useDeleteNote, useNotes, useProjects, useTasks } from "../hooks/useTodu.js";
+import { useActors, useDeleteNote, useNotes, useProjects, useTasks } from "../hooks/useTodu.js";
+import { createActorMap, getActorName, getApprovalLabel } from "../lib/actors.js";
 
 export function NoteList({
   onCreateNote,
@@ -25,8 +26,11 @@ export function NoteList({
   const { data: notes, isLoading, isError, error } = useNotes(filter);
   const { data: projects } = useProjects();
   const { data: tasks } = useTasks();
+  const { data: actors } = useActors();
   const deleteNote = useDeleteNote();
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; preview: string } | null>(null);
+
+  const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   // Build entity name lookup
   const entityNames = useMemo(() => {
@@ -143,6 +147,7 @@ export function NoteList({
             <tr>
               <th>Date</th>
               <th>Author</th>
+              <th>Approval</th>
               <th>Content</th>
               <th>Attached To</th>
               <th>Tags</th>
@@ -153,7 +158,10 @@ export function NoteList({
             {displayNotes.map((note) => (
               <tr key={note.id}>
                 <td className="cell-date">{note.createdAt.slice(0, 16).replace("T", " ")}</td>
-                <td>{note.author}</td>
+                <td>{getActorName(note.authorActorId, actorMap, note.author)}</td>
+                <td>
+                  {getApprovalLabel(note.contentApproval) ?? <span className="empty-hint">-</span>}
+                </td>
                 <td className="cell-content">
                   {note.content.length > 100 ? `${note.content.slice(0, 100)}…` : note.content}
                 </td>

--- a/packages/electron/src/renderer/views/ProjectDetail.tsx
+++ b/packages/electron/src/renderer/views/ProjectDetail.tsx
@@ -10,6 +10,7 @@ import { StatusChip } from "../components/StatusChip.js";
 import { TabBar } from "../components/TabBar.js";
 import { TaskTable } from "../components/TaskTable.js";
 import {
+  useActors,
   useDeleteProject,
   useProject,
   useProjects,
@@ -17,6 +18,7 @@ import {
   useTasks,
   useUpdateProject,
 } from "../hooks/useTodu.js";
+import { createActorMap, getActorNames } from "../lib/actors.js";
 
 // ============================================================================
 // Content tabs
@@ -45,6 +47,7 @@ export function ProjectDetail({
 }): ReactNode {
   const { data: project, isLoading, isError, error } = useProject(projectId);
   const { data: projects } = useProjects();
+  const { data: actors } = useActors();
   const deleteProject = useDeleteProject();
   const updateProject = useUpdateProject();
 
@@ -88,6 +91,7 @@ export function ProjectDetail({
   const [editingDescription, setEditingDescription] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [activeTab, setActiveTab] = useState("tasks");
+  const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   if (isLoading) {
     return (
@@ -130,6 +134,7 @@ export function ProjectDetail({
     deleteProject.mutate(project.id as ProjectId, { onSuccess: onBack });
   };
 
+  const authorizedActorNames = getActorNames(project.authorizedAssigneeActorIds, actorMap);
   const taskCount = tasks?.length ?? 0;
   const displayTasks = searchQuery.length > 0 ? searchResults : tasks;
 
@@ -217,6 +222,23 @@ export function ProjectDetail({
             <option value="medium">Medium</option>
             <option value="low">Low</option>
           </select>
+        </div>
+      </div>
+
+      <div className="detail-meta-row">
+        <div className="detail-meta-cell detail-meta-cell-wide">
+          <span className="detail-meta-label">Authorized assignees</span>
+          <div className="label-chips">
+            {authorizedActorNames.length > 0 ? (
+              authorizedActorNames.map((actorName) => (
+                <span key={actorName} className="chip chip-label">
+                  {actorName}
+                </span>
+              ))
+            ) : (
+              <span className="empty-hint">None</span>
+            )}
+          </div>
         </div>
       </div>
 

--- a/packages/electron/src/renderer/views/TaskDetail.tsx
+++ b/packages/electron/src/renderer/views/TaskDetail.tsx
@@ -5,7 +5,7 @@ import {
   type TaskPriority,
   type TaskStatus,
 } from "@todu/core/browser";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { CommentThread } from "../components/CommentThread.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { MarkdownEditor } from "../components/MarkdownEditor.js";
@@ -13,12 +13,14 @@ import { PriorityChip } from "../components/PriorityChip.js";
 import { StatusChip } from "../components/StatusChip.js";
 import { TabBar } from "../components/TabBar.js";
 import {
+  useActors,
   useDeleteTask,
   useMoveTask,
   useProjects,
   useTask,
   useUpdateTask,
 } from "../hooks/useTodu.js";
+import { createActorMap, getActorNames, getApprovalLabel } from "../lib/actors.js";
 
 // ============================================================================
 // Status Shortcuts
@@ -74,6 +76,7 @@ const TABS = [
 export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => void }): ReactNode {
   const { data: task, isLoading, isError, error } = useTask(taskId);
   const { data: projects } = useProjects();
+  const { data: actors } = useActors();
   const updateTask = useUpdateTask();
   const deleteTask = useDeleteTask();
   const moveTask = useMoveTask();
@@ -90,6 +93,7 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   const [titleValue, setTitleValue] = useState("");
   const [editingDescription, setEditingDescription] = useState(false);
   const [activeTab, setActiveTab] = useState("description");
+  const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   if (isLoading) {
     return (
@@ -139,6 +143,9 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   const handleMove = (projectId: string) => {
     moveTask.mutate({ id: task.id as TaskId, projectId: createProjectId(projectId) });
   };
+
+  const assigneeNames = getActorNames(task.assigneeActorIds, actorMap, task.assignees);
+  const descriptionApprovalLabel = getApprovalLabel(task.descriptionApproval);
 
   return (
     <div className="view-container">
@@ -255,12 +262,34 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
         </div>
       </div>
 
+      <div className="detail-meta-row">
+        <div className="detail-meta-cell detail-meta-cell-wide">
+          <span className="detail-meta-label">Assignees</span>
+          <div className="label-chips">
+            {assigneeNames.length > 0 ? (
+              assigneeNames.map((assignee) => (
+                <span key={assignee} className="chip chip-label">
+                  {assignee}
+                </span>
+              ))
+            ) : (
+              <span className="empty-hint">None</span>
+            )}
+          </div>
+        </div>
+      </div>
+
       {/* Tabbed content */}
       <div className="detail-tabs">
         <TabBar tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
 
         {activeTab === "description" && (
           <div className="detail-tab-content">
+            {descriptionApprovalLabel && (
+              <div className="detail-approval-row">
+                <span className="chip chip-label">{descriptionApprovalLabel}</span>
+              </div>
+            )}
             {editingDescription ? (
               <MarkdownEditor
                 value={task.description ?? ""}

--- a/packages/engine/src/actors.ts
+++ b/packages/engine/src/actors.ts
@@ -1,0 +1,19 @@
+import type { DocHandle } from "@automerge/automerge-repo/slim";
+import { type Actor, type CatalogDocument, ok, type Result } from "@todu/core";
+import type { ActorNamespace } from "./todu.js";
+
+function cloneActor(actor: Actor): Actor {
+  return {
+    id: actor.id,
+    displayName: actor.displayName,
+    ...(actor.archived !== undefined ? { archived: actor.archived } : {}),
+  };
+}
+
+export function createActorNamespace(catalog: DocHandle<CatalogDocument>): ActorNamespace {
+  return {
+    async list(): Promise<Result<Actor[]>> {
+      return ok((catalog.doc()?.actors ?? []).map(cloneActor));
+    },
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@automerge/automerge-repo/slim";
 import type { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import { createActorNamespace } from "./actors.js";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 import { observeAllChanges } from "./change-observer.js";
 import { createHabitNamespace } from "./habits.js";
@@ -50,6 +51,7 @@ export {
 export { addRemoteSyncAdapter, isSyncServerAvailable } from "./sync-client.js";
 export { DEFAULT_SYNC_PORT } from "./sync-server.js";
 export type {
+  ActorNamespace,
   HabitNamespace,
   IntegrationNamespace,
   LabelNamespace,
@@ -252,6 +254,7 @@ export async function createTodu(
         actors: createSyncRuntimeActorTools(storage.catalog),
       },
     },
+    actor: createActorNamespace(storage.catalog),
     project: createProjectNamespace(storage.catalog),
     task: createTaskNamespace(storage.catalog, storage.repo),
     label: createLabelNamespace(storage.catalog, storage.repo),

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -94,6 +94,10 @@ export interface ToduConfig {
 // Each vertical slice will implement its namespace.
 // ============================================================================
 
+export interface ActorNamespace {
+  list(): Promise<Result<Actor[]>>;
+}
+
 export interface ProjectNamespace {
   create(input: CreateProjectInput): Promise<Result<Project>>;
   list(filter?: ProjectFilter): Promise<Result<Project[]>>;
@@ -222,6 +226,7 @@ export interface ConfigNamespace {
 }
 
 export interface Todu {
+  actor: ActorNamespace;
   project: ProjectNamespace;
   task: TaskNamespace;
   label: LabelNamespace;
@@ -269,6 +274,9 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
   const stub = () => notImplemented();
 
   return {
+    actor: {
+      list: stub,
+    },
     project: {
       create: stub,
       list: stub,

--- a/vitest.all.config.ts
+++ b/vitest.all.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@todu/core/browser": path.resolve(root, "packages/core/src/browser.ts"),
       "@todu/core": path.resolve(root, "packages/core/src/index.ts"),
       "@todu/engine": path.resolve(root, "packages/engine/src/index.ts"),
       "@todu/cli": path.resolve(root, "packages/cli/src/index.ts"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@todu/core/browser": path.resolve(root, "packages/core/src/browser.ts"),
       "@todu/core": path.resolve(root, "packages/core/src/index.ts"),
       "@todu/engine": path.resolve(root, "packages/engine/src/index.ts"),
       "@todu/cli": path.resolve(root, "packages/cli/src/index.ts"),


### PR DESCRIPTION
## Summary
- expose a read-only actor RPC/client surface so CLI and Electron can resolve actor identities
- update core CLI task/project/note output and task/note commands for actor-based assignment/authorship and approval visibility
- update core Electron task/project/note/comment views to show actor identities and imported-content approval state, and stop sending legacy note author strings in active note/comment creation flows
- add unit coverage for the new CLI/Electron actor-aware behavior and add Vitest alias support for `@todu/core/browser`

## Verification
- `make pre-pr`
- `npm run --workspace=packages/electron build`

## Notes
- Per user request, I did not run integration tests for this task.

Task: #task-377500c1
