### PR TITLE
feat: add core actor management commands

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -322,6 +322,27 @@ Task date-range behavior notes:
 - For monthly review, use `--status done --updated-from/--updated-to` to find tasks completed during the target month.
 - Invalid task date input fails with a validation error.
 
+## Actor management via CLI
+
+Manage catalog actors directly through the local daemon:
+
+```bash
+todu actor list
+todu --format json actor list
+
+todu actor create --id actor-reviewer --name "Reviewer"
+todu actor rename actor-reviewer --name "Lead Reviewer"
+todu actor archive actor-reviewer
+todu actor unarchive actor-reviewer
+```
+
+Behavior notes:
+- `actor list` shows actor IDs, display names, and archived state in both text and JSON output.
+- `actor create` rejects duplicate actor IDs.
+- `actor rename` updates only the display name; actor IDs remain stable.
+- `actor archive` and `actor unarchive` toggle archived state without deleting the actor.
+- Invalid actor operations return daemon-backed validation or not-found errors.
+
 ## Actor-aware task and note surfaces
 
 Task and note text output now prefers actor-based identity data when available.

--- a/packages/cli/src/commands/actor.integration.test.ts
+++ b/packages/cli/src/commands/actor.integration.test.ts
@@ -1,0 +1,103 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { type DaemonHandle, startDaemonForTests } from "../test-helpers/daemon-process.js";
+
+describe("actor CLI commands", () => {
+  let tmpDir: string;
+  let daemon: DaemonHandle | null = null;
+  const rootDir = path.resolve(__dirname, "../../../..");
+  const cliPath = path.resolve(rootDir, "packages/cli/dist/index.js");
+
+  beforeAll(() => {
+    execSync("npm run build", { cwd: rootDir, stdio: "pipe", timeout: 30000 });
+  });
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-actor-test-"));
+    daemon = await startDaemonForTests(rootDir, tmpDir);
+  });
+
+  afterEach(async () => {
+    if (daemon) {
+      await daemon.stop("test-cleanup");
+      daemon = null;
+    }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(args: string, expectFail = false): string {
+    const socketPath = path.join(tmpDir, "daemon.sock");
+
+    try {
+      const result = execSync(`node ${cliPath} ${args}`, {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          TODU_DATA_DIR: tmpDir,
+          TODU_DAEMON_SOCKET: socketPath,
+          TODUAI_DAEMON_SOCKET: socketPath,
+          TODUAI_NO_SYNC: "1",
+        },
+        encoding: "utf-8",
+        timeout: 15000,
+      });
+      return result.trim();
+    } catch (e: unknown) {
+      if (expectFail) {
+        const err = e as { stderr?: string; stdout?: string };
+        return (err.stderr || err.stdout || "").trim();
+      }
+      throw e;
+    }
+  }
+
+  it("actor list/create/rename/archive/unarchive flow", () => {
+    const initialList = run("actor list");
+    expect(initialList).toContain("actor-user");
+    expect(initialList).toContain("active");
+
+    const createOutput = run('actor create --id actor-reviewer --name "Reviewer"');
+    expect(createOutput).toContain("Actor created:");
+    expect(createOutput).toContain("actor-reviewer");
+    expect(createOutput).toContain("Archived:    no");
+
+    const listJson = run("--format json actor list");
+    expect(JSON.parse(listJson)).toEqual(
+      expect.arrayContaining([
+        { id: "actor-user", displayName: "user", archived: false },
+        { id: "actor-reviewer", displayName: "Reviewer", archived: false },
+      ]),
+    );
+
+    const renameOutput = run('actor rename actor-reviewer --name "Lead Reviewer"');
+    expect(renameOutput).toContain("Actor renamed:");
+    expect(renameOutput).toContain("Lead Reviewer");
+
+    const archiveOutput = run("actor archive actor-reviewer");
+    expect(archiveOutput).toContain("Actor archived:");
+    expect(archiveOutput).toContain("Archived:    yes");
+
+    const archivedList = run("actor list");
+    expect(archivedList).toContain("actor-reviewer");
+    expect(archivedList).toContain("archived");
+
+    const unarchiveJson = run("--format json actor unarchive actor-reviewer");
+    expect(JSON.parse(unarchiveJson)).toEqual({
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+      archived: false,
+    });
+  });
+
+  it("shows daemon-backed actor errors", () => {
+    const duplicateOutput = run('actor create --id actor-user --name "Duplicate"', true);
+    expect(duplicateOutput).toContain("Actor ID already exists: actor-user");
+
+    const missingOutput = run("actor archive actor-missing", true);
+    expect(missingOutput).toContain("actor not found: actor-missing");
+  });
+});

--- a/packages/cli/src/commands/actor.test.ts
+++ b/packages/cli/src/commands/actor.test.ts
@@ -1,0 +1,106 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliDaemonInvoker } from "../daemon-command-client.js";
+import { registerActorCommands } from "./actor.js";
+
+describe("actor commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("passes create input through to the daemon", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "actor.create") {
+        return {
+          ok: true,
+          value: {
+            id: "actor-reviewer",
+            displayName: "Reviewer",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerActorCommands(program, invokeDaemon);
+
+    await program.parseAsync(["actor", "create", "--id", "actor-reviewer", "--name", "Reviewer"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("actor.create", {
+      input: {
+        id: "actor-reviewer",
+        displayName: "Reviewer",
+      },
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("prints explicit archived state in actor list json output", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "actor.list") {
+        return {
+          ok: true,
+          value: [
+            { id: "actor-user", displayName: "user" },
+            { id: "actor-reviewer", displayName: "Reviewer", archived: true },
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerActorCommands(program, invokeDaemon);
+
+    await program.parseAsync(["--format", "json", "actor", "list"], { from: "user" });
+
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([
+      { id: "actor-user", displayName: "user", archived: false },
+      { id: "actor-reviewer", displayName: "Reviewer", archived: true },
+    ]);
+  });
+
+  it("passes rename input through to the daemon", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "actor.rename") {
+        return {
+          ok: true,
+          value: {
+            id: "actor-reviewer",
+            displayName: "Lead Reviewer",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerActorCommands(program, invokeDaemon);
+
+    await program.parseAsync(["actor", "rename", "actor-reviewer", "--name", "Lead Reviewer"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("actor.rename", {
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/actor.ts
+++ b/packages/cli/src/commands/actor.ts
@@ -1,0 +1,152 @@
+import type { Actor } from "@todu/core";
+import type { Command } from "commander";
+import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
+import { formatJSON, formatTable } from "../format.js";
+
+const ACTOR_COLUMNS = [
+  { key: "id", label: "ID" },
+  { key: "name", label: "Name" },
+  { key: "state", label: "State" },
+];
+
+function normalizeActorForOutput(actor: Actor): Actor & { archived: boolean } {
+  return {
+    ...actor,
+    archived: actor.archived ?? false,
+  };
+}
+
+function actorToRow(actor: Actor): Record<string, string> {
+  return {
+    id: actor.id,
+    name: actor.displayName,
+    state: actor.archived ? "archived" : "active",
+  };
+}
+
+function actorDetail(actor: Actor): string {
+  return [
+    `ID:          ${actor.id}`,
+    `Name:        ${actor.displayName}`,
+    `Archived:    ${actor.archived ? "yes" : "no"}`,
+  ].join("\n");
+}
+
+export function registerActorCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
+  const actor = program.command("actor").description("Manage actors");
+
+  actor
+    .command("list")
+    .description("List actors")
+    .action(async () => {
+      const result = await invokeDaemon<Actor[]>("actor.list", {});
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const actors = result.value.map(normalizeActorForOutput);
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(actors));
+      } else {
+        console.log(formatTable(actors.map(actorToRow), ACTOR_COLUMNS));
+      }
+    });
+
+  actor
+    .command("create")
+    .description("Create an actor")
+    .requiredOption("--id <actorId>", "actor ID")
+    .requiredOption("--name <displayName>", "display name")
+    .action(async (opts) => {
+      const result = await invokeDaemon<Actor>("actor.create", {
+        input: {
+          id: opts.id,
+          displayName: opts.name,
+        },
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const output = normalizeActorForOutput(result.value);
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(output));
+      } else {
+        console.log("Actor created:");
+        console.log(actorDetail(output));
+      }
+    });
+
+  actor
+    .command("rename <id>")
+    .description("Rename an actor display name")
+    .requiredOption("--name <displayName>", "display name")
+    .action(async (id, opts) => {
+      const result = await invokeDaemon<Actor>("actor.rename", {
+        id,
+        displayName: opts.name,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const output = normalizeActorForOutput(result.value);
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(output));
+      } else {
+        console.log("Actor renamed:");
+        console.log(actorDetail(output));
+      }
+    });
+
+  actor
+    .command("archive <id>")
+    .description("Archive an actor")
+    .action(async (id) => {
+      const result = await invokeDaemon<Actor>("actor.archive", { id });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const output = normalizeActorForOutput(result.value);
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(output));
+      } else {
+        console.log("Actor archived:");
+        console.log(actorDetail(output));
+      }
+    });
+
+  actor
+    .command("unarchive <id>")
+    .description("Unarchive an actor")
+    .action(async (id) => {
+      const result = await invokeDaemon<Actor>("actor.unarchive", { id });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const output = normalizeActorForOutput(result.value);
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(output));
+      } else {
+        console.log("Actor unarchived:");
+        console.log(actorDetail(output));
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import { registerActorCommands } from "./commands/actor.js";
 import { registerConfigCommands } from "./commands/config.js";
 import { registerDaemonCommands } from "./commands/daemon.js";
 import { registerHabitCommands } from "./commands/habit.js";
@@ -39,6 +40,7 @@ program
 const invokeDaemon = createCliDaemonInvoker(program);
 
 // Register command groups
+registerActorCommands(program, invokeDaemon);
 registerDaemonCommands(program, invokeDaemon);
 registerProjectCommands(program, invokeDaemon);
 registerTaskCommands(program, invokeDaemon);

--- a/packages/cli/src/test-helpers/daemon-process.ts
+++ b/packages/cli/src/test-helpers/daemon-process.ts
@@ -14,7 +14,12 @@ export async function startDaemonForTests(
   const socketPath = path.join(storagePath, "daemon.sock");
   const daemonProcess = spawn("node", [daemonEntrypoint], {
     cwd: rootDir,
-    env: { ...process.env, TODU_DATA_DIR: storagePath },
+    env: {
+      ...process.env,
+      TODU_DATA_DIR: storagePath,
+      TODU_DAEMON_SOCKET: socketPath,
+      TODUAI_DAEMON_SOCKET: socketPath,
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -162,6 +162,11 @@ export interface Actor {
   archived?: boolean;
 }
 
+export interface CreateActorInput {
+  id: ActorId;
+  displayName: string;
+}
+
 // ============================================================================
 // Imported content approval + binding-scoped actor mapping metadata
 // ============================================================================

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createActorId, createIntegrationBindingId, createProjectId } from "./types.js";
 import {
+  MAX_ACTOR_DISPLAY_NAME_LENGTH,
   MAX_ACTOR_ID_LENGTH,
   MAX_ASSIGNEE_LENGTH,
   MAX_DESCRIPTION_LENGTH,
@@ -9,8 +10,10 @@ import {
   MAX_NOTE_CONTENT_LENGTH,
   MAX_PROJECT_NAME_LENGTH,
   MAX_TASK_TITLE_LENGTH,
+  validateActorDisplayName,
   validateActorIds,
   validateAssignees,
+  validateCreateActorInput,
   validateCreateHabitInput,
   validateCreateIntegrationBindingInput,
   validateCreateLabelInput,
@@ -842,6 +845,37 @@ describe("validateAssignees", () => {
     const error = validateAssignees(["a".repeat(MAX_ASSIGNEE_LENGTH + 1)]);
     expect(error?.field).toBe("assignees");
     expect(error?.message).toContain(`${MAX_ASSIGNEE_LENGTH}`);
+  });
+});
+
+describe("validateCreateActorInput", () => {
+  it("accepts valid actor create input", () => {
+    expect(
+      validateCreateActorInput({ id: createActorId("actor-reviewer"), displayName: "Reviewer" }),
+    ).toBeNull();
+  });
+
+  it("rejects blank actor display names", () => {
+    const error = validateCreateActorInput({
+      id: createActorId("actor-reviewer"),
+      displayName: "   ",
+    });
+    expect(error?.field).toBe("displayName");
+  });
+});
+
+describe("validateActorDisplayName", () => {
+  it("accepts valid actor display names", () => {
+    expect(validateActorDisplayName("displayName", "Reviewer")).toBeNull();
+  });
+
+  it("rejects too-long actor display names", () => {
+    const error = validateActorDisplayName(
+      "displayName",
+      "a".repeat(MAX_ACTOR_DISPLAY_NAME_LENGTH + 1),
+    );
+    expect(error?.field).toBe("displayName");
+    expect(error?.message).toContain(`${MAX_ACTOR_DISPLAY_NAME_LENGTH}`);
   });
 });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,5 +1,6 @@
 import { validateDateString, validateRRule, validateTimezone } from "./schedule.js";
 import type {
+  CreateActorInput,
   CreateHabitInput,
   CreateIntegrationBindingInput,
   CreateLabelInput,
@@ -48,6 +49,7 @@ export const MAX_NOTE_CONTENT_LENGTH = 10000;
 export const MAX_INTEGRATION_FIELD_LENGTH = 255;
 export const MAX_ASSIGNEE_LENGTH = 100;
 export const MAX_ACTOR_ID_LENGTH = 100;
+export const MAX_ACTOR_DISPLAY_NAME_LENGTH = 100;
 export const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
 // ============================================================================
@@ -253,6 +255,32 @@ export function validateActorId(field: string, actorId: string): ValidationError
   if (actorId.trim().length > MAX_ACTOR_ID_LENGTH) {
     return validationError(field, `Actor ID must be ${MAX_ACTOR_ID_LENGTH} characters or less`);
   }
+  return null;
+}
+
+export function validateActorDisplayName(
+  field: string,
+  displayName: string,
+): ValidationError | null {
+  if (typeof displayName !== "string" || displayName.trim().length === 0) {
+    return validationError(field, "Actor display name must be a non-empty string");
+  }
+  if (displayName.trim().length > MAX_ACTOR_DISPLAY_NAME_LENGTH) {
+    return validationError(
+      field,
+      `Actor display name must be ${MAX_ACTOR_DISPLAY_NAME_LENGTH} characters or less`,
+    );
+  }
+  return null;
+}
+
+export function validateCreateActorInput(input: CreateActorInput): ValidationError | null {
+  const actorIdError = validateActorId("id", input.id);
+  if (actorIdError) return actorIdError;
+
+  const displayNameError = validateActorDisplayName("displayName", input.displayName);
+  if (displayNameError) return displayNameError;
+
   return null;
 }
 

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -1,4 +1,5 @@
 import {
+  type CreateActorInput,
   type CreateHabitInput,
   type CreateIntegrationBindingInput,
   type CreateLabelInput,
@@ -6,6 +7,7 @@ import {
   type CreateProjectInput,
   type CreateRecurringInput,
   type CreateTaskInput,
+  createActorId,
   createHabitId,
   createIntegrationBindingId,
   createLabelId,
@@ -53,6 +55,30 @@ export function createCoreNamespaceHandlers(
     actor: {
       list: method(async (_request, todu) => {
         return todu.actor.list();
+      }),
+      create: method(async (request, todu) => {
+        const rawInput = getRequiredObjectParam<{ id: string; displayName: string }>(
+          request,
+          "input",
+        );
+        const input: CreateActorInput = {
+          id: createActorId(rawInput.id),
+          displayName: rawInput.displayName,
+        };
+        return todu.actor.create(input);
+      }),
+      rename: method(async (request, todu) => {
+        const id = createActorId(getRequiredStringParam(request, "id"));
+        const displayName = getRequiredStringParam(request, "displayName");
+        return todu.actor.rename(id, displayName);
+      }),
+      archive: method(async (request, todu) => {
+        const id = createActorId(getRequiredStringParam(request, "id"));
+        return todu.actor.archive(id);
+      }),
+      unarchive: method(async (request, todu) => {
+        const id = createActorId(getRequiredStringParam(request, "id"));
+        return todu.actor.unarchive(id);
       }),
     },
     project: {

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -30,7 +30,7 @@ export const DAEMON_BASE_METHODS = [
 export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] as const;
 
 export const CORE_DAEMON_NAMESPACE_METHODS = {
-  actor: ["list"],
+  actor: ["list", "create", "rename", "archive", "unarchive"],
   project: ["create", "list", "get", "update", "delete"],
   task: ["create", "list", "get", "update", "delete", "move", "search"],
   label: ["create", "list", "update", "delete"],

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -86,6 +86,10 @@ describe("createDaemonRuntime", () => {
 
     expect(DAEMON_CAPABILITY_METHODS).toEqual(
       expect.arrayContaining([
+        "actor.create",
+        "actor.rename",
+        "actor.archive",
+        "actor.unarchive",
         "integration.create",
         "integration.status",
         "recurring.process",
@@ -94,6 +98,87 @@ describe("createDaemonRuntime", () => {
         "sync.join",
       ]),
     );
+
+    await runtime.stop();
+  });
+
+  it("routes actor list/create/rename/archive/unarchive over UDS", async () => {
+    const runtime = createDaemonRuntime({
+      storagePath: tmpDir,
+      role: "authority",
+    });
+
+    await runtime.start();
+
+    const createResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-create-1",
+      method: "actor.create",
+      params: {
+        input: {
+          id: "actor-reviewer",
+          displayName: "Reviewer",
+        },
+      },
+    });
+
+    expect(createResponse.result).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+
+    const renameResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-rename-1",
+      method: "actor.rename",
+      params: {
+        id: "actor-reviewer",
+        displayName: "Lead Reviewer",
+      },
+    });
+
+    expect(renameResponse.result).toEqual({
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+    });
+
+    const archiveResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-archive-1",
+      method: "actor.archive",
+      params: {
+        id: "actor-reviewer",
+      },
+    });
+
+    expect(archiveResponse.result).toEqual({
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+      archived: true,
+    });
+
+    const listResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-list-1",
+      method: "actor.list",
+      params: {},
+    });
+
+    expect(listResponse.result).toEqual(
+      expect.arrayContaining([
+        { id: "actor-user", displayName: "user" },
+        { id: "actor-reviewer", displayName: "Lead Reviewer", archived: true },
+      ]),
+    );
+
+    const unarchiveResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-unarchive-1",
+      method: "actor.unarchive",
+      params: {
+        id: "actor-reviewer",
+      },
+    });
+
+    expect(unarchiveResponse.result).toEqual({
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+    });
 
     await runtime.stop();
   });
@@ -2051,6 +2136,23 @@ describe("createDaemonRuntime", () => {
       },
     });
 
+    const actorRenameBadRequestResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-rename-bad-request",
+      method: "actor.rename",
+      params: {
+        id: "actor-user",
+        displayName: 42,
+      },
+    });
+
+    expect(actorRenameBadRequestResponse.error).toEqual({
+      code: "BAD_REQUEST",
+      message: "actor.rename requires params.displayName as a non-empty string",
+      details: {
+        field: "displayName",
+      },
+    });
+
     const notFoundResponse = await sendRequest(runtime.config().socketPath, {
       id: "project-get-not-found",
       method: "project.get",
@@ -2065,6 +2167,42 @@ describe("createDaemonRuntime", () => {
       details: {
         entity: "project",
         id: "proj-missing",
+      },
+    });
+
+    const actorNotFoundResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-archive-not-found",
+      method: "actor.archive",
+      params: {
+        id: "actor-missing",
+      },
+    });
+
+    expect(actorNotFoundResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "actor not found: actor-missing",
+      details: {
+        entity: "actor",
+        id: "actor-missing",
+      },
+    });
+
+    const actorValidationResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-create-validation",
+      method: "actor.create",
+      params: {
+        input: {
+          id: "actor-user",
+          displayName: "Duplicate",
+        },
+      },
+    });
+
+    expect(actorValidationResponse.error).toEqual({
+      code: "VALIDATION_ERROR",
+      message: "Actor ID already exists: actor-user",
+      details: {
+        field: "id",
       },
     });
 

--- a/packages/engine/src/actors.integration.test.ts
+++ b/packages/engine/src/actors.integration.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createActorId } from "@todu/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Todu } from "./index.js";
+import { createTodu } from "./index.js";
+
+describe("actor namespace", () => {
+  let tmpDir: string;
+  let todu: Todu;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-actor-test-"));
+    todu = await createTodu({ storagePath: tmpDir });
+  });
+
+  afterEach(async () => {
+    await todu.close();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists the default owner actor", async () => {
+    const result = await todu.actor.list();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toEqual([{ id: "actor-user", displayName: "user" }]);
+  });
+
+  it("creates an actor with normalized display name", async () => {
+    const result = await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "  Reviewer  ",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+
+    const listed = await todu.actor.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    expect(listed.value).toContainEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+  });
+
+  it("rejects duplicate actor ids", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const result = await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Duplicate Reviewer",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.type).toBe("validation");
+    expect(result.error.field).toBe("id");
+    expect(result.error.message).toContain("already exists");
+  });
+
+  it("renames an existing actor without changing its id", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const result = await todu.actor.rename(createActorId("actor-reviewer"), "  Lead Reviewer  ");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toEqual({
+      id: "actor-reviewer",
+      displayName: "Lead Reviewer",
+    });
+  });
+
+  it("archives and unarchives actors", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const archived = await todu.actor.archive(createActorId("actor-reviewer"));
+    expect(archived.ok).toBe(true);
+    if (!archived.ok) return;
+    expect(archived.value).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+      archived: true,
+    });
+
+    const unarchived = await todu.actor.unarchive(createActorId("actor-reviewer"));
+    expect(unarchived.ok).toBe(true);
+    if (!unarchived.ok) return;
+    expect(unarchived.value).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+  });
+
+  it("returns not-found for unknown actor ids on mutation", async () => {
+    const result = await todu.actor.archive(createActorId("actor-missing"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.type).toBe("not-found");
+    expect(result.error.entity).toBe("actor");
+    expect(result.error.id).toBe("actor-missing");
+  });
+
+  it("rejects blank actor display names", async () => {
+    const result = await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "   ",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.type).toBe("validation");
+    expect(result.error.field).toBe("displayName");
+  });
+});

--- a/packages/engine/src/actors.ts
+++ b/packages/engine/src/actors.ts
@@ -1,5 +1,17 @@
 import type { DocHandle } from "@automerge/automerge-repo/slim";
-import { type Actor, type CatalogDocument, ok, type Result } from "@todu/core";
+import {
+  type Actor,
+  type CatalogDocument,
+  type CreateActorInput,
+  createActorId,
+  err,
+  notFound,
+  ok,
+  type Result,
+  validateActorDisplayName,
+  validateCreateActorInput,
+  validationError,
+} from "@todu/core";
 import type { ActorNamespace } from "./todu.js";
 
 function cloneActor(actor: Actor): Actor {
@@ -10,10 +22,89 @@ function cloneActor(actor: Actor): Actor {
   };
 }
 
+function normalizeActorDisplayName(displayName: string): string {
+  return displayName.trim();
+}
+
 export function createActorNamespace(catalog: DocHandle<CatalogDocument>): ActorNamespace {
   return {
     async list(): Promise<Result<Actor[]>> {
       return ok((catalog.doc()?.actors ?? []).map(cloneActor));
+    },
+
+    async create(input: CreateActorInput): Promise<Result<Actor>> {
+      const validationErr = validateCreateActorInput(input);
+      if (validationErr) return err(validationErr);
+
+      const doc = catalog.doc();
+      if (!doc) {
+        return err(notFound("catalog", "default"));
+      }
+
+      const normalizedId = createActorId(input.id.trim());
+      if (doc.actors.some((actor) => actor.id === normalizedId)) {
+        return err(validationError("id", `Actor ID already exists: ${normalizedId}`));
+      }
+
+      const actor: Actor = {
+        id: normalizedId,
+        displayName: normalizeActorDisplayName(input.displayName),
+      };
+
+      catalog.change((nextDoc) => {
+        nextDoc.actors.push(actor);
+      });
+
+      return ok(cloneActor(actor));
+    },
+
+    async rename(id, displayName): Promise<Result<Actor>> {
+      const displayNameError = validateActorDisplayName("displayName", displayName);
+      if (displayNameError) return err(displayNameError);
+
+      const doc = catalog.doc();
+      if (!doc) return err(notFound("actor", id));
+
+      const normalizedId = createActorId(id.trim());
+      const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
+      if (index === -1) return err(notFound("actor", normalizedId));
+
+      const normalizedDisplayName = normalizeActorDisplayName(displayName);
+      catalog.change((nextDoc) => {
+        nextDoc.actors[index].displayName = normalizedDisplayName;
+      });
+
+      return ok(cloneActor(catalog.doc()!.actors[index]));
+    },
+
+    async archive(id): Promise<Result<Actor>> {
+      const doc = catalog.doc();
+      if (!doc) return err(notFound("actor", id));
+
+      const normalizedId = createActorId(id.trim());
+      const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
+      if (index === -1) return err(notFound("actor", normalizedId));
+
+      catalog.change((nextDoc) => {
+        nextDoc.actors[index].archived = true;
+      });
+
+      return ok(cloneActor(catalog.doc()!.actors[index]));
+    },
+
+    async unarchive(id): Promise<Result<Actor>> {
+      const doc = catalog.doc();
+      if (!doc) return err(notFound("actor", id));
+
+      const normalizedId = createActorId(id.trim());
+      const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
+      if (index === -1) return err(notFound("actor", normalizedId));
+
+      catalog.change((nextDoc) => {
+        delete nextDoc.actors[index].archived;
+      });
+
+      return ok(cloneActor(catalog.doc()!.actors[index]));
     },
   };
 }

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -1,6 +1,7 @@
 import type {
   Actor,
   ActorId,
+  CreateActorInput,
   CreateHabitInput,
   CreateIntegrationBindingInput,
   CreateLabelInput,
@@ -96,6 +97,10 @@ export interface ToduConfig {
 
 export interface ActorNamespace {
   list(): Promise<Result<Actor[]>>;
+  create(input: CreateActorInput): Promise<Result<Actor>>;
+  rename(id: ActorId, displayName: string): Promise<Result<Actor>>;
+  archive(id: ActorId): Promise<Result<Actor>>;
+  unarchive(id: ActorId): Promise<Result<Actor>>;
 }
 
 export interface ProjectNamespace {
@@ -276,6 +281,10 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
   return {
     actor: {
       list: stub,
+      create: stub,
+      rename: stub,
+      archive: stub,
+      unarchive: stub,
     },
     project: {
       create: stub,


### PR DESCRIPTION
## Summary
- add engine, daemon RPC, and CLI support for actor create/rename/archive/unarchive
- add actor command coverage in unit/integration tests and daemon/runtime checks
- document the new CLI actor-management flows and explicit archived-state output

## Verification
- make pre-pr

Task: #task-828f54ac