### PR TITLE
feat: add CLI project authorization management

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -343,19 +343,27 @@ Behavior notes:
 - `actor archive` and `actor unarchive` toggle archived state without deleting the actor.
 - Invalid actor operations return daemon-backed validation or not-found errors.
 
-## Actor-aware task and note surfaces
+## Project authorization and actor-aware task surfaces
 
-Task and note text output now prefers actor-based identity data when available.
+Project authorization is managed through each project's `authorizedAssigneeActorIds` allowlist.
 
 Examples:
 
 ```bash
+todu actor create --id actor-reviewer --name "Reviewer"
+
+todu project auth show proj-123
+todu project auth add proj-123 actor-reviewer
+todu project auth remove proj-123 actor-reviewer
+todu project auth set proj-123 actor-user actor-reviewer
+
 todu task create --title "Pair on rollout" --project proj-123 --assignee-actor actor-user
 
 todu task update task-123 --assignee-actor actor-user actor-reviewer
 todu task update task-123 --clear-assignees
 
 todu task show task-123
+todu task list --project proj-123
 todu project show proj-123
 
 todu note add "Imported comment" --task task-123 --author-actor actor-reviewer
@@ -363,10 +371,14 @@ todu note list --author-actor actor-reviewer
 ```
 
 Behavior notes:
+- `project auth show` displays the authorized actor list with display names and actor IDs.
+- `project auth add`, `remove`, and `set` use daemon-backed project authorization updates instead of editing raw project JSON indirectly.
+- `project auth set` replaces the full authorized list; omitting actor IDs clears it.
+- `project show` text and JSON output include resolved `authorizedActors` and any `staleUnauthorizedAssignees` still present on project tasks.
 - `task create --assignee-actor` and `task update --assignee-actor` set actor-based task assignment by actor ID.
 - `task update --clear-assignees` clears actor-based task assignment.
-- `task show` text output displays actor assignees and imported description approval state when applicable.
-- `project show` text output displays the project's authorized assignee actors.
+- `task show` and `task list` mark archived or unauthorized assignees instead of silently hiding them.
+- JSON task output now includes `assigneeActors` with resolved actor display metadata and authorization state.
 - `note add --author-actor` and `note list --author-actor` work with actor-based note authorship.
 - `note` text output shows actor-based author names and imported-content approval state when applicable.
 - Legacy `--author` note filtering/input remains available during the compatibility window.

--- a/packages/cli/src/actor-display.ts
+++ b/packages/cli/src/actor-display.ts
@@ -1,6 +1,14 @@
 import type { Actor, ImportedContentApproval } from "@todu/core";
 import type { CliDaemonInvoker } from "./daemon-command-client.js";
 
+export interface ActorDisplayInfo {
+  id: string;
+  displayName: string;
+  archived: boolean;
+  authorized: boolean;
+  known: boolean;
+}
+
 export async function buildActorMap(
   invokeDaemon: CliDaemonInvoker,
 ): Promise<Record<string, Actor>> {
@@ -16,45 +24,89 @@ export async function buildActorMap(
   return map;
 }
 
-export function formatActorIdentity(actorId: string, actorMap: Record<string, Actor>): string {
+export function resolveActorDisplayInfo(
+  actorId: string,
+  actorMap: Record<string, Actor>,
+  options: { authorizedActorIds?: readonly string[] } = {},
+): ActorDisplayInfo {
   const actor = actorMap[actorId];
-  if (!actor) {
-    return actorId;
+  const authorized =
+    options.authorizedActorIds === undefined || options.authorizedActorIds.includes(actorId);
+
+  return {
+    id: actorId,
+    displayName: actor?.displayName ?? actorId,
+    archived: actor?.archived ?? false,
+    authorized,
+    known: actor !== undefined,
+  };
+}
+
+function formatActorStatusSuffix(
+  info: ActorDisplayInfo,
+  options: { includeIds?: boolean } = {},
+): string {
+  const details: string[] = [];
+
+  if (options.includeIds) {
+    details.push(info.id);
+  }
+  if (info.archived) {
+    details.push("archived");
+  }
+  if (!info.authorized) {
+    details.push("unauthorized");
+  }
+  if (!info.known) {
+    details.push("unknown");
   }
 
-  const archivedSuffix = actor.archived ? " (archived)" : "";
-  return `${actor.displayName}${archivedSuffix} (${actor.id})`;
+  return details.length > 0 ? ` (${details.join(", ")})` : "";
+}
+
+export function formatActorIdentity(
+  actorId: string,
+  actorMap: Record<string, Actor>,
+  options: { authorizedActorIds?: readonly string[] } = {},
+): string {
+  const info = resolveActorDisplayInfo(actorId, actorMap, options);
+  return `${info.displayName}${formatActorStatusSuffix(info, { includeIds: true })}`;
 }
 
 export function formatActorDisplay(
   actorId: string | undefined,
   actorMap: Record<string, Actor>,
   fallback?: string,
+  options: { authorizedActorIds?: readonly string[] } = {},
 ): string {
   if (!actorId) {
     return fallback ?? "(none)";
   }
 
-  const actor = actorMap[actorId];
-  if (!actor) {
-    return fallback ?? actorId;
+  const info = resolveActorDisplayInfo(actorId, actorMap, options);
+  if (!info.known && fallback) {
+    return fallback;
   }
 
-  return `${actor.displayName}${actor.archived ? " (archived)" : ""}`;
+  return `${info.displayName}${formatActorStatusSuffix(info)}`;
 }
 
 export function formatActorList(
   actorIds: readonly string[],
   actorMap: Record<string, Actor>,
   fallbackNames: readonly string[] = [],
-  options: { includeIds?: boolean } = {},
+  options: { includeIds?: boolean; authorizedActorIds?: readonly string[] } = {},
 ): string {
   if (actorIds.length > 0) {
     return actorIds
       .map((actorId) =>
         options.includeIds
-          ? formatActorIdentity(actorId, actorMap)
-          : formatActorDisplay(actorId, actorMap),
+          ? formatActorIdentity(actorId, actorMap, {
+              authorizedActorIds: options.authorizedActorIds,
+            })
+          : formatActorDisplay(actorId, actorMap, undefined, {
+              authorizedActorIds: options.authorizedActorIds,
+            }),
       )
       .join(", ");
   }

--- a/packages/cli/src/commands/project.integration.test.ts
+++ b/packages/cli/src/commands/project.integration.test.ts
@@ -34,7 +34,13 @@ describe("project CLI commands", () => {
     try {
       const result = execSync(`node ${cliPath} ${args}`, {
         cwd: rootDir,
-        env: { ...process.env, TODU_DATA_DIR: tmpDir, TODUAI_NO_SYNC: "1" },
+        env: {
+          ...process.env,
+          TODU_DATA_DIR: tmpDir,
+          TODU_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_NO_SYNC: "1",
+        },
         encoding: "utf-8",
         timeout: 15000,
       });
@@ -78,7 +84,7 @@ describe("project CLI commands", () => {
     const showOutput = run(`project show ${created.id}`);
     expect(showOutput).toContain("JSON Project");
     expect(showOutput).toContain(created.id);
-    expect(showOutput).toContain("Actors:");
+    expect(showOutput).toContain("Authorized:");
     expect(showOutput).toContain("actor-user");
     expect(showOutput).not.toContain("Sync:");
 
@@ -107,6 +113,48 @@ describe("project CLI commands", () => {
     const remaining = JSON.parse(afterDelete);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].name).toBe("Test Project");
+  });
+
+  it("manages project authorization and surfaces stale assignees", { timeout: 30000 }, () => {
+    run('--format json actor create --id actor-reviewer --name "Reviewer"');
+    const project = JSON.parse(run('--format json project create --name "Auth Project"'));
+
+    const authAdd = run(`project auth add ${project.id} actor-reviewer`);
+    expect(authAdd).toContain("Project authorization updated:");
+    expect(authAdd).toContain("Reviewer (actor-reviewer)");
+
+    const task = JSON.parse(
+      run(
+        `--format json task create --title "Assigned task" --project "${project.id}" --assignee-actor actor-reviewer`,
+      ),
+    );
+    expect(task.assigneeActors[0]).toMatchObject({ id: "actor-reviewer", authorized: true });
+
+    const authRemove = run(`project auth remove ${project.id} actor-reviewer`);
+    expect(authRemove).toContain("Unauthorized task assignees:");
+    expect(authRemove).toContain("Assigned task");
+    expect(authRemove).toContain("Reviewer (actor-reviewer, unauthorized)");
+
+    const showJson = JSON.parse(run(`--format json project show ${project.id}`));
+    expect(showJson.authorizedActors).toEqual([
+      expect.objectContaining({ id: "actor-user", authorized: true }),
+    ]);
+    expect(showJson.staleUnauthorizedAssignees).toEqual([
+      expect.objectContaining({
+        title: "Assigned task",
+        assignees: [expect.objectContaining({ id: "actor-reviewer", authorized: false })],
+      }),
+    ]);
+
+    const authSet = JSON.parse(
+      run(`--format json project auth set ${project.id} actor-user actor-reviewer`),
+    );
+    expect(authSet.authorizedActors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "actor-user" }),
+        expect.objectContaining({ id: "actor-reviewer", authorized: true }),
+      ]),
+    );
   });
 
   it("handles errors gracefully", () => {

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,7 +1,12 @@
-import type { Project, ProjectStatus } from "@todu/core";
+import type { Project, ProjectStatus, Task } from "@todu/core";
 import { isProjectStatus } from "@todu/core";
 import type { Command } from "commander";
-import { buildActorMap, formatActorList } from "../actor-display.js";
+import {
+  type ActorDisplayInfo,
+  buildActorMap,
+  formatActorList,
+  resolveActorDisplayInfo,
+} from "../actor-display.js";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { colorPriority, colorStatus, formatJSON, formatTable } from "../format.js";
 
@@ -12,29 +17,139 @@ const PROJECT_COLUMNS = [
   { key: "priority", label: "Priority", colorize: colorPriority },
 ];
 
-function projectToRow(p: Project): Record<string, string> {
+interface ProjectDisplay extends Project {
+  authorizedActors: ActorDisplayInfo[];
+  staleUnauthorizedAssignees: Array<{
+    taskId: Task["id"];
+    title: string;
+    assignees: ActorDisplayInfo[];
+  }>;
+}
+
+function projectToRow(project: Project): Record<string, string> {
   return {
-    id: p.id,
-    name: p.name,
-    status: p.status,
-    priority: p.priority,
+    id: project.id,
+    name: project.name,
+    status: project.status,
+    priority: project.priority,
   };
 }
 
-function projectDetail(p: Project, actorMap: Awaited<ReturnType<typeof buildActorMap>>): string {
+async function buildProjectDisplay(
+  invokeDaemon: CliDaemonInvoker,
+  project: Project,
+): Promise<ProjectDisplay> {
+  const [actorMapResult, tasksResult] = await Promise.all([
+    buildActorMap(invokeDaemon),
+    invokeDaemon<Task[]>("task.list", {
+      filter: {
+        projectId: project.id,
+      },
+    }),
+  ]);
+
+  const authorizedActorIds = project.authorizedAssigneeActorIds ?? [];
+  const authorizedActors = authorizedActorIds.map((actorId) =>
+    resolveActorDisplayInfo(actorId, actorMapResult),
+  );
+
+  const staleUnauthorizedAssignees = tasksResult.ok
+    ? tasksResult.value.flatMap((task) => {
+        const assignees = task.assigneeActorIds
+          .filter((actorId) => !authorizedActorIds.includes(actorId))
+          .map((actorId) =>
+            resolveActorDisplayInfo(actorId, actorMapResult, {
+              authorizedActorIds: authorizedActorIds,
+            }),
+          );
+
+        return assignees.length > 0
+          ? [
+              {
+                taskId: task.id,
+                title: task.title,
+                assignees,
+              },
+            ]
+          : [];
+      })
+    : [];
+
+  return {
+    ...project,
+    authorizedActors,
+    staleUnauthorizedAssignees,
+  };
+}
+
+function formatActorDisplayInfoList(
+  actors: readonly ActorDisplayInfo[],
+  options: { includeIds?: boolean; authorizedActorIds?: readonly string[] } = {},
+): string {
+  const actorMap = actors.reduce<
+    Record<string, { id: string; displayName: string; archived?: boolean }>
+  >((map, actor) => {
+    map[actor.id] = {
+      id: actor.id,
+      displayName: actor.displayName,
+      ...(actor.archived ? { archived: true } : {}),
+    };
+    return map;
+  }, {});
+
+  return formatActorList(
+    actors.map((actor) => actor.id),
+    actorMap as Parameters<typeof formatActorList>[1],
+    [],
+    options,
+  );
+}
+
+function projectDetail(project: ProjectDisplay): string {
   const lines = [
-    `ID:          ${p.id}`,
-    `Name:        ${p.name}`,
-    `Status:      ${p.status}`,
-    `Priority:    ${p.priority}`,
-    `Actors:      ${formatActorList(p.authorizedAssigneeActorIds, actorMap, [], { includeIds: true })}`,
-    `Created:     ${p.createdAt}`,
-    `Updated:     ${p.updatedAt}`,
+    `ID:          ${project.id}`,
+    `Name:        ${project.name}`,
+    `Status:      ${project.status}`,
+    `Priority:    ${project.priority}`,
+    `Authorized:  ${formatActorDisplayInfoList(project.authorizedActors, { includeIds: true })}`,
+    `Created:     ${project.createdAt}`,
+    `Updated:     ${project.updatedAt}`,
   ];
-  if (p.description) {
-    lines.push(`Description: ${p.description}`);
+  if (project.description) {
+    lines.push(`Description: ${project.description}`);
+  }
+  if (project.staleUnauthorizedAssignees.length > 0) {
+    lines.push("", "Unauthorized task assignees:");
+    for (const stale of project.staleUnauthorizedAssignees) {
+      lines.push(
+        `- ${stale.title} (${stale.taskId}): ${formatActorDisplayInfoList(stale.assignees, {
+          includeIds: true,
+          authorizedActorIds: project.authorizedAssigneeActorIds ?? [],
+        })}`,
+      );
+    }
   }
   return lines.join("\n");
+}
+
+async function printProject(
+  program: Command,
+  invokeDaemon: CliDaemonInvoker,
+  project: Project,
+  heading?: string,
+): Promise<void> {
+  const display = await buildProjectDisplay(invokeDaemon, project);
+  const format = program.opts().format;
+
+  if (format === "json") {
+    console.log(formatJSON(display));
+    return;
+  }
+
+  if (heading) {
+    console.log(heading);
+  }
+  console.log(projectDetail(display));
 }
 
 /**
@@ -44,7 +159,6 @@ async function resolveProject(
   invokeDaemon: CliDaemonInvoker,
   ref: string,
 ): Promise<{ ok: true; value: Project } | { ok: false; message: string }> {
-  // Try as ID
   const byId = await invokeDaemon<Project>("project.get", { id: ref });
   if (byId.ok) {
     return byId;
@@ -54,13 +168,12 @@ async function resolveProject(
     return { ok: false, message: formatDaemonCommandError(byId.error) };
   }
 
-  // Try name search
   const list = await invokeDaemon<Project[]>("project.list", {});
   if (!list.ok) {
     return { ok: false, message: formatDaemonCommandError(list.error) };
   }
 
-  const matches = list.value.filter((p) => p.name.toLowerCase() === ref.toLowerCase());
+  const matches = list.value.filter((project) => project.name.toLowerCase() === ref.toLowerCase());
   if (matches.length === 1) {
     return { ok: true, value: matches[0] };
   }
@@ -75,7 +188,6 @@ async function resolveProject(
 export function registerProjectCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const project = program.command("project").description("Manage projects");
 
-  // create
   project
     .command("create")
     .description("Create a new project")
@@ -97,17 +209,9 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const actorMap = await buildActorMap(invokeDaemon);
-        console.log("Project created:");
-        console.log(projectDetail(result.value, actorMap));
-      }
+      await printProject(program, invokeDaemon, result.value, "Project created:");
     });
 
-  // list
   project
     .command("list")
     .description("List projects")
@@ -128,7 +232,9 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
           process.exitCode = 1;
           return;
         }
-        projects = projects.filter((p) => p.status === (opts.status as ProjectStatus));
+        projects = projects.filter(
+          (candidate) => candidate.status === (opts.status as ProjectStatus),
+        );
       }
 
       const format = program.opts().format;
@@ -139,7 +245,6 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
       }
     });
 
-  // show
   project
     .command("show <ref>")
     .description("Show project details (by ID or name)")
@@ -151,16 +256,9 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(resolved.value));
-      } else {
-        const actorMap = await buildActorMap(invokeDaemon);
-        console.log(projectDetail(resolved.value, actorMap));
-      }
+      await printProject(program, invokeDaemon, resolved.value);
     });
 
-  // update
   project
     .command("update <ref>")
     .description("Update a project (by ID or name)")
@@ -192,17 +290,97 @@ export function registerProjectCommands(program: Command, invokeDaemon: CliDaemo
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const actorMap = await buildActorMap(invokeDaemon);
-        console.log("Project updated:");
-        console.log(projectDetail(result.value, actorMap));
-      }
+      await printProject(program, invokeDaemon, result.value, "Project updated:");
     });
 
-  // delete
+  const auth = project.command("auth").description("Manage project authorized assignee actors");
+
+  auth
+    .command("show <ref>")
+    .description("Show a project's authorized actor list")
+    .action(async (ref) => {
+      const resolved = await resolveProject(invokeDaemon, ref);
+      if (!resolved.ok) {
+        console.error(resolved.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      await printProject(program, invokeDaemon, resolved.value);
+    });
+
+  auth
+    .command("add <ref> <actorIds...>")
+    .description("Add one or more actor IDs to a project's authorized list")
+    .action(async (ref, actorIds: string[]) => {
+      const resolved = await resolveProject(invokeDaemon, ref);
+      if (!resolved.ok) {
+        console.error(resolved.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await invokeDaemon<Project>("project.addAuthorizedActors", {
+        id: resolved.value.id,
+        actorIds,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      await printProject(program, invokeDaemon, result.value, "Project authorization updated:");
+    });
+
+  auth
+    .command("remove <ref> <actorIds...>")
+    .description("Remove one or more actor IDs from a project's authorized list")
+    .action(async (ref, actorIds: string[]) => {
+      const resolved = await resolveProject(invokeDaemon, ref);
+      if (!resolved.ok) {
+        console.error(resolved.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await invokeDaemon<Project>("project.removeAuthorizedActors", {
+        id: resolved.value.id,
+        actorIds,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      await printProject(program, invokeDaemon, result.value, "Project authorization updated:");
+    });
+
+  auth
+    .command("set <ref> [actorIds...]")
+    .description("Replace a project's authorized list (omit actor IDs to clear it)")
+    .action(async (ref, actorIds: string[] = []) => {
+      const resolved = await resolveProject(invokeDaemon, ref);
+      if (!resolved.ok) {
+        console.error(resolved.message);
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await invokeDaemon<Project>("project.setAuthorizedActors", {
+        id: resolved.value.id,
+        actorIds,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      await printProject(program, invokeDaemon, result.value, "Project authorization updated:");
+    });
+
   project
     .command("delete <ref>")
     .description("Delete a project (by ID or name)")

--- a/packages/cli/src/commands/task.integration.test.ts
+++ b/packages/cli/src/commands/task.integration.test.ts
@@ -33,7 +33,13 @@ describe("task CLI commands", () => {
     try {
       const result = execSync(`node ${cliPath} ${args}`, {
         cwd: rootDir,
-        env: { ...process.env, TODU_DATA_DIR: tmpDir, TODUAI_NO_SYNC: "1" },
+        env: {
+          ...process.env,
+          TODU_DATA_DIR: tmpDir,
+          TODU_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_NO_SYNC: "1",
+        },
         encoding: "utf-8",
         timeout: 15000,
       });
@@ -192,6 +198,32 @@ describe("task CLI commands", () => {
     const parsed = JSON.parse(marchOnly);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].title).toBe("March task");
+  });
+
+  it("marks unauthorized assignees in task text and json output", { timeout: 30000 }, () => {
+    run('--format json actor create --id actor-reviewer --name "Reviewer"');
+    const project = JSON.parse(run('--format json project create --name "Auth Task Project"'));
+    run(`project auth add ${project.id} actor-reviewer`);
+
+    const task = JSON.parse(
+      run(
+        `--format json task create --title "Review rollout" --project "${project.id}" --assignee-actor actor-reviewer`,
+      ),
+    );
+    expect(task.assigneeActors[0]).toMatchObject({ id: "actor-reviewer", authorized: true });
+
+    run(`project auth remove ${project.id} actor-reviewer`);
+
+    const showOutput = run(`task show ${task.id}`);
+    expect(showOutput).toContain("Reviewer (actor-reviewer, unauthorized)");
+
+    const listOutput = run(`task list --project "${project.id}"`);
+    expect(listOutput).toContain("Reviewer (unauthorized)");
+
+    const showJson = JSON.parse(run(`--format json task show ${task.id}`));
+    expect(showJson.assigneeActors).toEqual([
+      expect.objectContaining({ id: "actor-reviewer", authorized: false }),
+    ]);
   });
 
   it("handles errors gracefully", () => {

--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -88,6 +88,9 @@ describe("task commands", () => {
           value: [] satisfies Task[],
         };
       }
+      if (method === "project.list" || method === "actor.list") {
+        return { ok: true, value: [] };
+      }
 
       throw new Error(`Unexpected method: ${method}`);
     });
@@ -128,6 +131,9 @@ describe("task commands", () => {
           ok: true,
           value: [] satisfies Task[],
         };
+      }
+      if (method === "project.list" || method === "actor.list") {
+        return { ok: true, value: [] };
       }
 
       throw new Error(`Unexpected method: ${method}`);

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,7 +1,12 @@
 import type { Task, TaskSortOptions, TaskStatus, TaskWithDetail } from "@todu/core";
 import { isTaskPriority, isTaskSortField, isTaskStatus } from "@todu/core";
 import type { Command } from "commander";
-import { buildActorMap, formatActorList, formatApprovalSummary } from "../actor-display.js";
+import {
+  buildActorMap,
+  formatActorList,
+  formatApprovalSummary,
+  resolveActorDisplayInfo,
+} from "../actor-display.js";
 import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
 import { colorPriority, colorStatus, formatJSON, formatTable } from "../format.js";
 
@@ -14,45 +19,131 @@ const TASK_COLUMNS = [
   { key: "assignees", label: "Assignees" },
 ];
 
+type ProjectSummary = {
+  id: string;
+  name: string;
+  authorizedAssigneeActorIds: string[];
+};
+
+type ProjectSummaryMap = Record<string, ProjectSummary>;
+
+type TaskOutput<T extends Task | TaskWithDetail> = T & {
+  assigneeActors: Array<{
+    id: string;
+    displayName: string;
+    archived: boolean;
+    authorized: boolean;
+    known: boolean;
+  }>;
+};
+
 function taskToRow(
-  t: Task,
+  task: Task,
   actorMap: Awaited<ReturnType<typeof buildActorMap>>,
-  projectName?: string,
+  project?: ProjectSummary,
 ): Record<string, string> {
   return {
-    id: t.id,
-    title: t.title,
-    status: t.status,
-    priority: t.priority,
-    project: projectName ?? t.projectId,
-    assignees: formatActorList(t.assigneeActorIds, actorMap, t.assignees),
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    priority: task.priority,
+    project: project?.name ?? task.projectId,
+    assignees: formatActorList(task.assigneeActorIds, actorMap, task.assignees, {
+      authorizedActorIds: project?.authorizedAssigneeActorIds,
+    }),
   };
 }
 
 function taskDetail(
-  t: TaskWithDetail,
+  task: TaskWithDetail,
   actorMap: Awaited<ReturnType<typeof buildActorMap>>,
-  projectName?: string,
+  project?: ProjectSummary,
 ): string {
   const lines = [
-    `ID:          ${t.id}`,
-    `Title:       ${t.title}`,
-    `Status:      ${t.status}`,
-    `Priority:    ${t.priority}`,
-    `Project:     ${projectName ?? t.projectId}`,
-    `Assignees:   ${formatActorList(t.assigneeActorIds, actorMap, t.assignees, { includeIds: true })}`,
-    `Labels:      ${t.labels.length > 0 ? t.labels.join(", ") : "(none)"}`,
-    `Created:     ${t.createdAt}`,
-    `Updated:     ${t.updatedAt}`,
+    `ID:          ${task.id}`,
+    `Title:       ${task.title}`,
+    `Status:      ${task.status}`,
+    `Priority:    ${task.priority}`,
+    `Project:     ${project?.name ?? task.projectId}`,
+    `Assignees:   ${formatActorList(task.assigneeActorIds, actorMap, task.assignees, {
+      includeIds: true,
+      authorizedActorIds: project?.authorizedAssigneeActorIds,
+    })}`,
+    `Labels:      ${task.labels.length > 0 ? task.labels.join(", ") : "(none)"}`,
+    `Created:     ${task.createdAt}`,
+    `Updated:     ${task.updatedAt}`,
   ];
-  if (t.dueDate) lines.push(`Due:         ${t.dueDate}`);
-  if (t.scheduledDate) lines.push(`Scheduled:   ${t.scheduledDate}`);
-  const approvalSummary = formatApprovalSummary(t.descriptionApproval);
+  if (task.dueDate) lines.push(`Due:         ${task.dueDate}`);
+  if (task.scheduledDate) lines.push(`Scheduled:   ${task.scheduledDate}`);
+  const approvalSummary = formatApprovalSummary(task.descriptionApproval);
   if (approvalSummary) lines.push(`Approval:    ${approvalSummary}`);
-  if (t.description) {
-    lines.push("", "Description:", t.description);
+  if (task.description) {
+    lines.push("", "Description:", task.description);
   }
   return lines.join("\n");
+}
+
+function enrichTaskForOutput<T extends Task | TaskWithDetail>(
+  task: T,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+  project?: ProjectSummary,
+): TaskOutput<T> {
+  return {
+    ...task,
+    assigneeActors: task.assigneeActorIds.map((actorId) =>
+      resolveActorDisplayInfo(actorId, actorMap, {
+        authorizedActorIds: project?.authorizedAssigneeActorIds,
+      }),
+    ),
+  };
+}
+
+async function printTask<T extends Task | TaskWithDetail>(
+  program: Command,
+  invokeDaemon: CliDaemonInvoker,
+  task: T,
+  heading?: string,
+): Promise<void> {
+  const [projectMap, actorMap] = await Promise.all([
+    buildProjectMap(invokeDaemon),
+    buildActorMap(invokeDaemon),
+  ]);
+  const project = projectMap[task.projectId];
+  const format = program.opts().format;
+
+  if (format === "json") {
+    console.log(formatJSON(enrichTaskForOutput(task, actorMap, project)));
+    return;
+  }
+
+  if (heading) {
+    console.log(heading);
+  }
+  console.log(taskDetail(task as TaskWithDetail, actorMap, project));
+}
+
+async function printTaskList(
+  program: Command,
+  invokeDaemon: CliDaemonInvoker,
+  tasks: Task[],
+): Promise<void> {
+  const [projectMap, actorMap] = await Promise.all([
+    buildProjectMap(invokeDaemon),
+    buildActorMap(invokeDaemon),
+  ]);
+  const format = program.opts().format;
+
+  if (format === "json") {
+    console.log(
+      formatJSON(
+        tasks.map((task) => enrichTaskForOutput(task, actorMap, projectMap[task.projectId])),
+      ),
+    );
+    return;
+  }
+
+  const rows = tasks.map((task) => taskToRow(task, actorMap, projectMap[task.projectId]));
+  console.log(formatTable(rows, TASK_COLUMNS));
 }
 
 /**
@@ -63,7 +154,6 @@ async function resolveProjectId(
   invokeDaemon: CliDaemonInvoker,
   ref: string,
 ): Promise<{ ok: true; id: string; name: string } | { ok: false; message: string }> {
-  // Try as ID
   const byId = await invokeDaemon<{ id: string; name: string }>("project.get", { id: ref });
   if (byId.ok) {
     return { ok: true, id: byId.value.id, name: byId.value.name };
@@ -73,13 +163,12 @@ async function resolveProjectId(
     return { ok: false, message: formatDaemonCommandError(byId.error) };
   }
 
-  // Try name search
   const list = await invokeDaemon<Array<{ id: string; name: string }>>("project.list", {});
   if (!list.ok) {
     return { ok: false, message: formatDaemonCommandError(list.error) };
   }
 
-  const matches = list.value.filter((p) => p.name.toLowerCase() === ref.toLowerCase());
+  const matches = list.value.filter((project) => project.name.toLowerCase() === ref.toLowerCase());
   if (matches.length === 1) {
     return { ok: true, id: matches[0].id, name: matches[0].name };
   }
@@ -91,28 +180,18 @@ async function resolveProjectId(
   return { ok: false, message: `Project not found: ${ref}` };
 }
 
-/**
- * Build a map of projectId → projectName for display.
- */
-async function buildProjectNameMap(
-  invokeDaemon: CliDaemonInvoker,
-): Promise<Record<string, string>> {
-  const result = await invokeDaemon<Array<{ id: string; name: string }>>("project.list", {});
+async function buildProjectMap(invokeDaemon: CliDaemonInvoker): Promise<ProjectSummaryMap> {
+  const result = await invokeDaemon<ProjectSummary[]>("project.list", {});
   if (!result.ok) {
     return {};
   }
 
-  const map: Record<string, string> = {};
-  for (const p of result.value) {
-    map[p.id] = p.name;
-  }
-  return map;
+  return Object.fromEntries(result.value.map((project) => [project.id, project]));
 }
 
 export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const task = program.command("task").description("Manage tasks");
 
-  // create
   task
     .command("create")
     .description("Create a new task")
@@ -151,17 +230,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const actorMap = await buildActorMap(invokeDaemon);
-        console.log("Task created:");
-        console.log(taskDetail(result.value, actorMap, project.name));
-      }
+      await printTask(program, invokeDaemon, result.value, "Task created:");
     });
 
-  // list
   task
     .command("list")
     .description("List tasks")
@@ -189,13 +260,12 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         projectId = project.id;
       }
 
-      // Parse multi-status: --status active,inprogress
       let status: TaskStatus | TaskStatus[] | undefined;
       if (opts.status) {
-        const parts = opts.status.split(",").map((s: string) => s.trim());
-        for (const s of parts) {
-          if (!isTaskStatus(s)) {
-            console.error(`Error: invalid status: ${s}`);
+        const parts = opts.status.split(",").map((value: string) => value.trim());
+        for (const value of parts) {
+          if (!isTaskStatus(value)) {
+            console.error(`Error: invalid status: ${value}`);
             process.exitCode = 1;
             return;
           }
@@ -209,7 +279,6 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      // Parse sort
       let sort: TaskSortOptions | undefined;
       if (opts.sort) {
         if (!isTaskSortField(opts.sort)) {
@@ -242,20 +311,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const [nameMap, actorMap] = await Promise.all([
-          buildProjectNameMap(invokeDaemon),
-          buildActorMap(invokeDaemon),
-        ]);
-        const rows = result.value.map((t) => taskToRow(t, actorMap, nameMap[t.projectId]));
-        console.log(formatTable(rows, TASK_COLUMNS));
-      }
+      await printTaskList(program, invokeDaemon, result.value);
     });
 
-  // show
   task
     .command("show <id>")
     .description("Show task details")
@@ -267,19 +325,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const [nameMap, actorMap] = await Promise.all([
-        buildProjectNameMap(invokeDaemon),
-        buildActorMap(invokeDaemon),
-      ]);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
-      }
+      await printTask(program, invokeDaemon, result.value);
     });
 
-  // update
   task
     .command("update <id>")
     .description("Update a task")
@@ -319,20 +367,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const [nameMap, actorMap] = await Promise.all([
-        buildProjectNameMap(invokeDaemon),
-        buildActorMap(invokeDaemon),
-      ]);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        console.log("Task updated:");
-        console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
-      }
+      await printTask(program, invokeDaemon, result.value, "Task updated:");
     });
 
-  // delete
   task
     .command("delete <id>")
     .description("Delete a task")
@@ -352,7 +389,6 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
       }
     });
 
-  // move
   task
     .command("move <id> <project>")
     .description("Move a task to another project")
@@ -374,17 +410,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const actorMap = await buildActorMap(invokeDaemon);
-        console.log(`Moved task to ${project.name}:`);
-        console.log(taskDetail(result.value, actorMap, project.name));
-      }
+      await printTask(program, invokeDaemon, result.value, `Moved task to ${project.name}:`);
     });
 
-  // search
   task
     .command("search <query>")
     .description("Search tasks by title")
@@ -396,20 +424,9 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
         return;
       }
 
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(result.value));
-      } else {
-        const [nameMap, actorMap] = await Promise.all([
-          buildProjectNameMap(invokeDaemon),
-          buildActorMap(invokeDaemon),
-        ]);
-        const rows = result.value.map((t) => taskToRow(t, actorMap, nameMap[t.projectId]));
-        console.log(formatTable(rows, TASK_COLUMNS));
-      }
+      await printTaskList(program, invokeDaemon, result.value);
     });
 
-  // Status shortcut helper
   function statusShortcut(name: string, description: string, targetStatus: TaskStatus) {
     task
       .command(`${name} <id>`)
@@ -425,17 +442,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           return;
         }
 
-        const [nameMap, actorMap] = await Promise.all([
-          buildProjectNameMap(invokeDaemon),
-          buildActorMap(invokeDaemon),
-        ]);
-        const format = program.opts().format;
-        if (format === "json") {
-          console.log(formatJSON(result.value));
-        } else {
-          console.log(`Task ${targetStatus}:`);
-          console.log(taskDetail(result.value, actorMap, nameMap[result.value.projectId]));
-        }
+        await printTask(program, invokeDaemon, result.value, `Task ${targetStatus}:`);
       });
   }
 

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -99,6 +99,21 @@ export function createCoreNamespaceHandlers(
         const input = getRequiredObjectParam<UpdateProjectInput>(request, "input");
         return todu.project.update(id, input);
       }),
+      addAuthorizedActors: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        const actorIds = getRequiredStringArrayParam(request, "actorIds", false).map(createActorId);
+        return todu.project.addAuthorizedActors(id, actorIds);
+      }),
+      removeAuthorizedActors: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        const actorIds = getRequiredStringArrayParam(request, "actorIds", false).map(createActorId);
+        return todu.project.removeAuthorizedActors(id, actorIds);
+      }),
+      setAuthorizedActors: method(async (request, todu) => {
+        const id = createProjectId(getRequiredStringParam(request, "id"));
+        const actorIds = getRequiredStringArrayParam(request, "actorIds", true).map(createActorId);
+        return todu.project.setAuthorizedActors(id, actorIds);
+      }),
       delete: method(async (request, todu) => {
         const id = createProjectId(getRequiredStringParam(request, "id"));
         return todu.project.delete(id);
@@ -391,6 +406,31 @@ function getOptionalNumberParam(request: ProtocolRequestFrame, field: string): n
   }
 
   return Math.floor(value);
+}
+
+function getRequiredStringArrayParam(
+  request: ProtocolRequestFrame,
+  field: string,
+  allowEmpty: boolean,
+): string[] {
+  const value = request.params[field];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw createProtocolError(
+      "BAD_REQUEST",
+      `${request.method} requires params.${field} as an array of strings`,
+      { field },
+    );
+  }
+
+  if (!allowEmpty && value.length === 0) {
+    throw createProtocolError(
+      "BAD_REQUEST",
+      `${request.method} requires params.${field} as a non-empty array of strings`,
+      { field },
+    );
+  }
+
+  return value;
 }
 
 function getRequiredObjectParam<T extends object>(request: ProtocolRequestFrame, field: string): T {

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -31,7 +31,16 @@ export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] a
 
 export const CORE_DAEMON_NAMESPACE_METHODS = {
   actor: ["list", "create", "rename", "archive", "unarchive"],
-  project: ["create", "list", "get", "update", "delete"],
+  project: [
+    "create",
+    "list",
+    "get",
+    "update",
+    "addAuthorizedActors",
+    "removeAuthorizedActors",
+    "setAuthorizedActors",
+    "delete",
+  ],
   task: ["create", "list", "get", "update", "delete", "move", "search"],
   label: ["create", "list", "update", "delete"],
   integration: ["create", "list", "get", "update", "delete", "status"],

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -90,6 +90,9 @@ describe("createDaemonRuntime", () => {
         "actor.rename",
         "actor.archive",
         "actor.unarchive",
+        "project.addAuthorizedActors",
+        "project.removeAuthorizedActors",
+        "project.setAuthorizedActors",
         "integration.create",
         "integration.status",
         "recurring.process",
@@ -331,6 +334,57 @@ describe("createDaemonRuntime", () => {
     expect(updateResponse.id).toBe("project-update-1");
     expect(updateResponse.result).toEqual(
       expect.objectContaining({ id: projectId, name: "Work Updated", priority: "high" }),
+    );
+
+    const addAuthorizedActorsResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-add-authorized-1",
+      method: "project.addAuthorizedActors",
+      params: {
+        id: projectId,
+        actorIds: ["actor-user"],
+      },
+    });
+
+    expect(addAuthorizedActorsResponse.id).toBe("project-add-authorized-1");
+    expect(addAuthorizedActorsResponse.result).toEqual(
+      expect.objectContaining({
+        id: projectId,
+        authorizedAssigneeActorIds: ["actor-user"],
+      }),
+    );
+
+    const removeAuthorizedActorsResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-remove-authorized-1",
+      method: "project.removeAuthorizedActors",
+      params: {
+        id: projectId,
+        actorIds: ["actor-user"],
+      },
+    });
+
+    expect(removeAuthorizedActorsResponse.id).toBe("project-remove-authorized-1");
+    expect(removeAuthorizedActorsResponse.result).toEqual(
+      expect.objectContaining({
+        id: projectId,
+        authorizedAssigneeActorIds: [],
+      }),
+    );
+
+    const setAuthorizedActorsResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-set-authorized-1",
+      method: "project.setAuthorizedActors",
+      params: {
+        id: projectId,
+        actorIds: ["actor-user"],
+      },
+    });
+
+    expect(setAuthorizedActorsResponse.id).toBe("project-set-authorized-1");
+    expect(setAuthorizedActorsResponse.result).toEqual(
+      expect.objectContaining({
+        id: projectId,
+        authorizedAssigneeActorIds: ["actor-user"],
+      }),
     );
 
     const deleteResponse = await sendRequest(runtime.config().socketPath, {

--- a/packages/engine/src/projects.integration.test.ts
+++ b/packages/engine/src/projects.integration.test.ts
@@ -294,6 +294,80 @@ describe("project namespace", () => {
     });
   });
 
+  describe("authorized actor management", () => {
+    let projectId: ProjectId;
+
+    beforeEach(async () => {
+      const project = await todu.project.create({ name: "Authorized Actors" });
+      if (!project.ok) throw new Error("create failed");
+      projectId = project.value.id;
+
+      const createdActor = await todu.actor.create({
+        id: createActorId("actor-reviewer"),
+        displayName: "Reviewer",
+      });
+      if (!createdActor.ok) throw new Error("actor create failed");
+    });
+
+    it("adds authorized actors without duplicating existing ids", async () => {
+      const result = await todu.project.addAuthorizedActors(projectId, [
+        createActorId("actor-user"),
+        createActorId("actor-reviewer"),
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.authorizedAssigneeActorIds).toEqual([
+        DEFAULT_OWNER_ACTOR_ID,
+        createActorId("actor-reviewer"),
+      ]);
+    });
+
+    it("removes authorized actors while leaving others intact", async () => {
+      await todu.project.setAuthorizedActors(projectId, [
+        createActorId("actor-user"),
+        createActorId("actor-reviewer"),
+      ]);
+
+      const result = await todu.project.removeAuthorizedActors(projectId, [
+        createActorId("actor-reviewer"),
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.authorizedAssigneeActorIds).toEqual([DEFAULT_OWNER_ACTOR_ID]);
+    });
+
+    it("replaces the full authorized actor list", async () => {
+      const result = await todu.project.setAuthorizedActors(projectId, [
+        createActorId("actor-reviewer"),
+      ]);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.authorizedAssigneeActorIds).toEqual([createActorId("actor-reviewer")]);
+    });
+
+    it("allows clearing the authorized actor list", async () => {
+      const result = await todu.project.setAuthorizedActors(projectId, []);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.authorizedAssigneeActorIds).toEqual([]);
+    });
+
+    it("returns not found for unknown actors in authorization updates", async () => {
+      const result = await todu.project.addAuthorizedActors(projectId, [
+        createActorId("actor-missing"),
+      ]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("actor");
+    });
+  });
+
   describe("delete", () => {
     it("deletes an existing project", async () => {
       const created = await todu.project.create({ name: "To Delete" });

--- a/packages/engine/src/projects.ts
+++ b/packages/engine/src/projects.ts
@@ -1,8 +1,10 @@
 import crypto from "node:crypto";
 import type { DocHandle } from "@automerge/automerge-repo";
 import {
+  type ActorId,
   type CatalogDocument,
   type CreateProjectInput,
+  createActorId,
   createProjectId,
   err,
   notFound,
@@ -12,6 +14,7 @@ import {
   type ProjectId,
   type Result,
   type UpdateProjectInput,
+  validateActorIds,
   validateCreateProjectInput,
   validateUpdateProjectInput,
 } from "@todu/core";
@@ -22,8 +25,12 @@ import type { ProjectNamespace } from "./todu.js";
 // ============================================================================
 
 export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): ProjectNamespace {
+  function normalizeActorIds(actorIds: readonly ActorId[]): ActorId[] {
+    return actorIds.map((actorId) => createActorId(actorId.trim()));
+  }
+
   function findMissingAuthorizedActorId(
-    actorIds: Project["authorizedAssigneeActorIds"],
+    actorIds: readonly ActorId[],
   ): Project["authorizedAssigneeActorIds"][number] | null {
     const catalogDoc = catalog.doc();
     if (!catalogDoc) return actorIds[0] ?? null;
@@ -32,15 +39,95 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
     return actorIds.find((actorId) => !catalogActorIds.has(actorId)) ?? null;
   }
 
+  function getProjectIndex(id: ProjectId): Result<number> {
+    const doc = catalog.doc();
+    if (!doc) return err(notFound("project", id));
+
+    const index = doc.projects.findIndex((project) => project.id === id);
+    if (index === -1) {
+      return err(notFound("project", id));
+    }
+
+    return ok(index);
+  }
+
+  function validateAuthorizedActorIds(actorIds: readonly ActorId[]): Result<ActorId[]> {
+    const normalizedActorIds = normalizeActorIds(actorIds);
+    const actorIdsError = validateActorIds("actorIds", normalizedActorIds);
+    if (actorIdsError) {
+      return err(actorIdsError);
+    }
+
+    const missingActorId = findMissingAuthorizedActorId(normalizedActorIds);
+    if (missingActorId) {
+      return err(notFound("actor", missingActorId));
+    }
+
+    return ok(normalizedActorIds);
+  }
+
+  async function update(id: ProjectId, input: UpdateProjectInput): Promise<Result<Project>> {
+    const validationErr = validateUpdateProjectInput(input);
+    if (validationErr) return err(validationErr);
+
+    const projectIndex = getProjectIndex(id);
+    if (!projectIndex.ok) return projectIndex;
+
+    const doc = catalog.doc();
+    if (!doc) return err(notFound("project", id));
+
+    const nextAuthorizedAssigneeActorIds = normalizeActorIds(
+      input.authorizedAssigneeActorIds ??
+        doc.projects[projectIndex.value].authorizedAssigneeActorIds,
+    );
+    const missingActorId = findMissingAuthorizedActorId(nextAuthorizedAssigneeActorIds);
+    if (missingActorId) {
+      return err(notFound("actor", missingActorId));
+    }
+
+    const now = new Date().toISOString();
+
+    catalog.change((nextDoc) => {
+      const project = nextDoc.projects[projectIndex.value];
+      if (input.name !== undefined) project.name = input.name.trim();
+      if (input.description !== undefined) project.description = input.description.trim();
+      if (input.status !== undefined) project.status = input.status;
+      if (input.priority !== undefined) project.priority = input.priority;
+      if (input.authorizedAssigneeActorIds !== undefined) {
+        project.authorizedAssigneeActorIds.splice(
+          0,
+          project.authorizedAssigneeActorIds.length,
+          ...nextAuthorizedAssigneeActorIds,
+        );
+      }
+      project.updatedAt = now;
+    });
+
+    return ok(cloneProject(catalog.doc()!.projects[projectIndex.value]));
+  }
+
+  async function updateAuthorizedActors(
+    id: ProjectId,
+    actorIds: readonly ActorId[],
+  ): Promise<Result<Project>> {
+    const validatedActorIds = validateAuthorizedActorIds(actorIds);
+    if (!validatedActorIds.ok) return validatedActorIds;
+
+    return update(id, {
+      authorizedAssigneeActorIds: validatedActorIds.value,
+    });
+  }
+
   return {
     async create(input: CreateProjectInput): Promise<Result<Project>> {
       const validationErr = validateCreateProjectInput(input);
       if (validationErr) return err(validationErr);
 
       const catalogDoc = catalog.doc();
-      const authorizedAssigneeActorIds =
+      const authorizedAssigneeActorIds = normalizeActorIds(
         input.authorizedAssigneeActorIds ??
-        (catalogDoc?.ownerActorId ? [catalogDoc.ownerActorId] : []);
+          (catalogDoc?.ownerActorId ? [catalogDoc.ownerActorId] : []),
+      );
       const missingActorId = findMissingAuthorizedActorId(authorizedAssigneeActorIds);
       if (missingActorId) {
         return err(notFound("actor", missingActorId));
@@ -58,13 +145,12 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
         createdAt: now,
         updatedAt: now,
       };
-      // Automerge doesn't allow undefined — only set optional fields if present
       if (input.description !== undefined) {
         project.description = input.description.trim();
       }
 
-      catalog.change((doc) => {
-        doc.projects.push(project);
+      catalog.change((nextDoc) => {
+        nextDoc.projects.push(project);
       });
 
       return ok(project);
@@ -78,14 +164,14 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
 
       if (filter?.status) {
         const statuses = Array.isArray(filter.status) ? filter.status : [filter.status];
-        filtered = filtered.filter((p) => statuses.includes(p.status));
+        filtered = filtered.filter((project) => statuses.includes(project.status));
       }
       if (filter?.priority) {
-        filtered = filtered.filter((p) => p.priority === filter.priority);
+        filtered = filtered.filter((project) => project.priority === filter.priority);
       }
       if (filter?.search) {
         const lowerQuery = filter.search.toLowerCase();
-        filtered = filtered.filter((p) => p.name.toLowerCase().includes(lowerQuery));
+        filtered = filtered.filter((project) => project.name.toLowerCase().includes(lowerQuery));
       }
 
       return ok(filtered);
@@ -95,64 +181,62 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
       const doc = catalog.doc();
       if (!doc) return err(notFound("project", id));
 
-      const project = doc.projects.find((p) => p.id === id);
+      const project = doc.projects.find((candidate) => candidate.id === id);
       if (!project) return err(notFound("project", id));
 
       return ok(cloneProject(project));
     },
 
-    async update(id: ProjectId, input: UpdateProjectInput): Promise<Result<Project>> {
-      const validationErr = validateUpdateProjectInput(input);
-      if (validationErr) return err(validationErr);
+    update,
 
-      const doc = catalog.doc();
-      if (!doc) return err(notFound("project", id));
+    async addAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>> {
+      const project = await this.get(id);
+      if (!project.ok) return project;
 
-      const index = doc.projects.findIndex((p) => p.id === id);
-      if (index === -1) return err(notFound("project", id));
+      const validatedActorIds = validateAuthorizedActorIds(actorIds);
+      if (!validatedActorIds.ok) return validatedActorIds;
 
-      const nextAuthorizedAssigneeActorIds =
-        input.authorizedAssigneeActorIds ?? doc.projects[index].authorizedAssigneeActorIds;
-      const missingActorId = findMissingAuthorizedActorId(nextAuthorizedAssigneeActorIds);
-      if (missingActorId) {
-        return err(notFound("actor", missingActorId));
-      }
+      const nextAuthorizedActorIds = [
+        ...project.value.authorizedAssigneeActorIds,
+        ...validatedActorIds.value.filter(
+          (actorId) => !project.value.authorizedAssigneeActorIds.includes(actorId),
+        ),
+      ];
 
-      const now = new Date().toISOString();
+      return updateAuthorizedActors(id, nextAuthorizedActorIds);
+    },
 
-      catalog.change((doc) => {
-        const project = doc.projects[index];
-        if (input.name !== undefined) project.name = input.name.trim();
-        if (input.description !== undefined) project.description = input.description.trim();
-        if (input.status !== undefined) project.status = input.status;
-        if (input.priority !== undefined) project.priority = input.priority;
-        if (input.authorizedAssigneeActorIds !== undefined) {
-          project.authorizedAssigneeActorIds.splice(
-            0,
-            project.authorizedAssigneeActorIds.length,
-            ...input.authorizedAssigneeActorIds,
-          );
-        }
-        project.updatedAt = now;
-      });
+    async removeAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>> {
+      const project = await this.get(id);
+      if (!project.ok) return project;
 
-      // Read back the updated project
-      const updated = catalog.doc()!.projects[index];
-      return ok(cloneProject(updated));
+      const validatedActorIds = validateAuthorizedActorIds(actorIds);
+      if (!validatedActorIds.ok) return validatedActorIds;
+
+      const actorIdsToRemove = new Set(validatedActorIds.value);
+      return updateAuthorizedActors(
+        id,
+        project.value.authorizedAssigneeActorIds.filter(
+          (actorId) => !actorIdsToRemove.has(actorId),
+        ),
+      );
+    },
+
+    async setAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>> {
+      return updateAuthorizedActors(id, actorIds);
     },
 
     async delete(id: ProjectId): Promise<Result<void>> {
       const doc = catalog.doc();
       if (!doc) return err(notFound("project", id));
 
-      const index = doc.projects.findIndex((p) => p.id === id);
+      const index = doc.projects.findIndex((project) => project.id === id);
       if (index === -1) return err(notFound("project", id));
 
       // TODO: When tasks slice lands, check for non-empty TaskListDocument
       // For now, allow deletion unconditionally.
-
-      catalog.change((doc) => {
-        doc.projects.splice(index, 1);
+      catalog.change((nextDoc) => {
+        nextDoc.projects.splice(index, 1);
       });
 
       return ok(undefined);
@@ -161,15 +245,15 @@ export function createProjectNamespace(catalog: DocHandle<CatalogDocument>): Pro
 }
 
 /** Clone a project out of the Automerge proxy */
-function cloneProject(p: Project): Project {
+function cloneProject(project: Project): Project {
   return {
-    id: p.id,
-    name: p.name,
-    description: p.description,
-    status: p.status,
-    priority: p.priority,
-    authorizedAssigneeActorIds: [...(p.authorizedAssigneeActorIds ?? [])],
-    createdAt: p.createdAt,
-    updatedAt: p.updatedAt,
+    id: project.id,
+    name: project.name,
+    description: project.description,
+    status: project.status,
+    priority: project.priority,
+    authorizedAssigneeActorIds: [...(project.authorizedAssigneeActorIds ?? [])],
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
   };
 }

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -108,6 +108,9 @@ export interface ProjectNamespace {
   list(filter?: ProjectFilter): Promise<Result<Project[]>>;
   get(id: ProjectId): Promise<Result<Project>>;
   update(id: ProjectId, input: UpdateProjectInput): Promise<Result<Project>>;
+  addAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>>;
+  removeAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>>;
+  setAuthorizedActors(id: ProjectId, actorIds: ActorId[]): Promise<Result<Project>>;
   delete(id: ProjectId): Promise<Result<void>>;
 }
 
@@ -291,6 +294,9 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
       list: stub,
       get: stub,
       update: stub,
+      addAuthorizedActors: stub,
+      removeAuthorizedActors: stub,
+      setAuthorizedActors: stub,
       delete: stub,
     },
     task: {


### PR DESCRIPTION
## Summary
- add daemon-backed project authorization commands for show/add/remove/set flows
- surface archived authorized actors and stale unauthorized assignees in project/task CLI output
- add focused engine, daemon, and CLI coverage plus docs updates

## Checks
- make pre-pr

Task: #task-ebc982fe