### PR TITLE
feat: add CLI approval commands

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -383,6 +383,28 @@ Behavior notes:
 - `note` text output shows actor-based author names and imported-content approval state when applicable.
 - Legacy `--author` note filtering/input remains available during the compatibility window.
 
+## Approval workflow via CLI
+
+Use explicit approval commands for imported task descriptions and note/comment content:
+
+```bash
+todu approval list
+todu approval list --kind task
+todu approval list --kind note
+
+todu approval approve task-description task-123
+todu approval approve note-content note-123
+```
+
+Behavior notes:
+- `approval list` shows only content currently pending approval.
+- `approval list --kind task|note` filters by task descriptions vs note/comment content.
+- `approval approve task-description <task-id>` approves the current imported task description revision explicitly.
+- `approval approve note-content <note-id>` approves the current imported note/comment revision explicitly.
+- Approval actions reject unknown items, content that is already approved, and content that does not require approval.
+- `task show` and `note list` continue to display current approval state in normal detail output.
+- JSON output for `approval list` and `approval approve ...` remains structured for automation.
+
 ## Validate connectivity
 
 ```bash

--- a/packages/cli/src/commands/approval.integration.test.ts
+++ b/packages/cli/src/commands/approval.integration.test.ts
@@ -1,0 +1,133 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createActorId, createIntegrationBindingId } from "@todu/core";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTodu } from "../../../engine/src/index.js";
+import { type DaemonHandle, startDaemonForTests } from "../test-helpers/daemon-process.js";
+
+describe("approval CLI commands", () => {
+  let tmpDir: string;
+  let daemon: DaemonHandle | null = null;
+  let taskId = "";
+  let noteId = "";
+  const rootDir = path.resolve(__dirname, "../../../..");
+  const cliPath = path.resolve(rootDir, "packages/cli/dist/index.js");
+
+  beforeAll(() => {
+    execSync("npm run build", { cwd: rootDir, stdio: "pipe", timeout: 30000 });
+  });
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-approval-test-"));
+
+    const seeded = await createTodu({ storagePath: tmpDir });
+    const project = await seeded.project.create({ name: "Approval CLI Project" });
+    if (!project.ok) throw new Error("project create failed");
+
+    const task = await seeded.task.create({
+      title: "Imported task",
+      projectId: project.value.id,
+      description: "Imported task description",
+      descriptionApproval: {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-cli"),
+        sourceActorId: createActorId("actor-user"),
+      },
+    });
+    if (!task.ok) throw new Error("task create failed");
+    taskId = task.value.id;
+
+    const note = await seeded.note.create({
+      content: "Imported note content",
+      entityType: "task",
+      entityId: taskId,
+      contentApproval: {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-cli"),
+        sourceActorId: createActorId("actor-user"),
+      },
+    });
+    if (!note.ok) throw new Error("note create failed");
+    noteId = note.value.id;
+
+    await seeded.close();
+    daemon = await startDaemonForTests(rootDir, tmpDir);
+  });
+
+  afterEach(async () => {
+    if (daemon) {
+      await daemon.stop("test-cleanup");
+      daemon = null;
+    }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(args: string, expectFail = false): string {
+    try {
+      const result = execSync(`node ${cliPath} ${args}`, {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          TODU_DATA_DIR: tmpDir,
+          TODU_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_DAEMON_SOCKET: path.join(tmpDir, "daemon.sock"),
+          TODUAI_NO_SYNC: "1",
+        },
+        encoding: "utf-8",
+        timeout: 15000,
+      });
+      return result.trim();
+    } catch (error: unknown) {
+      if (expectFail) {
+        const err = error as { stderr?: string; stdout?: string };
+        return (err.stderr || err.stdout || "").trim();
+      }
+      throw error;
+    }
+  }
+
+  it("lists and approves pending task and note content", { timeout: 30000 }, () => {
+    const listOutput = run("approval list");
+    expect(listOutput).toContain("task description");
+    expect(listOutput).toContain("note content");
+    expect(listOutput).toContain(taskId);
+    expect(listOutput).toContain(noteId);
+
+    const taskOnly = JSON.parse(run("--format json approval list --kind task"));
+    expect(taskOnly).toHaveLength(1);
+    expect(taskOnly[0]).toMatchObject({
+      kind: "taskDescription",
+      taskId,
+      state: "pendingApproval",
+    });
+
+    const approveTask = run(`approval approve task-description ${taskId}`);
+    expect(approveTask).toContain("Approval updated:");
+    expect(approveTask).toContain("State:       approved");
+
+    const taskJson = JSON.parse(run(`--format json task show ${taskId}`));
+    expect(taskJson.descriptionApproval).toMatchObject({ state: "approved" });
+
+    const approveNote = JSON.parse(run(`--format json approval approve note-content ${noteId}`));
+    expect(approveNote).toMatchObject({ kind: "noteContent", noteId, state: "approved" });
+
+    const noteList = JSON.parse(run(`--format json note list --task ${taskId}`));
+    expect(noteList[0].contentApproval).toMatchObject({ state: "approved" });
+
+    const remaining = JSON.parse(run("--format json approval list"));
+    expect(remaining).toEqual([]);
+  });
+
+  it("fails clearly for invalid approval actions", { timeout: 30000 }, () => {
+    run(`--format json approval approve task-description ${taskId}`);
+
+    const alreadyApproved = run(`approval approve task-description ${taskId}`, true);
+    expect(alreadyApproved).toContain("already approved");
+
+    const missing = run("approval approve note-content note-missing", true);
+    expect(missing).toContain("note not found");
+  });
+});

--- a/packages/cli/src/commands/approval.test.ts
+++ b/packages/cli/src/commands/approval.test.ts
@@ -1,0 +1,89 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliDaemonInvoker } from "../daemon-command-client.js";
+import { registerApprovalCommands } from "./approval.js";
+
+describe("approval commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("passes list filters through to the daemon", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "approval.list") {
+        return { ok: true, value: [] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerApprovalCommands(program, invokeDaemonMock as unknown as CliDaemonInvoker);
+
+    await program.parseAsync(["--format", "json", "approval", "list", "--kind", "task"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("approval.list", {
+      filter: {
+        kind: "taskDescription",
+      },
+    });
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual([]);
+  });
+
+  it("rejects invalid approval kinds", async () => {
+    const invokeDaemon = vi.fn() as unknown as CliDaemonInvoker;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerApprovalCommands(program, invokeDaemon);
+
+    await program.parseAsync(["approval", "list", "--kind", "weird"], { from: "user" });
+
+    expect(errorSpy).toHaveBeenCalledWith("Error: invalid approval kind: weird");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("passes task description approvals through to the daemon", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "approval.approveTaskDescription") {
+        return {
+          ok: true,
+          value: {
+            kind: "taskDescription",
+            state: "approved",
+            taskId: "task-1",
+            taskTitle: "Imported task",
+            projectId: "proj-1",
+            contentPreview: "Imported instructions",
+          },
+        };
+      }
+      if (method === "project.list") {
+        return { ok: true, value: [] };
+      }
+      if (method === "actor.list") {
+        return { ok: true, value: [] };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerApprovalCommands(program, invokeDaemonMock as unknown as CliDaemonInvoker);
+
+    await program.parseAsync(["approval", "approve", "task-description", "task-1"], {
+      from: "user",
+    });
+
+    expect(invokeDaemonMock).toHaveBeenCalledWith("approval.approveTaskDescription", {
+      taskId: "task-1",
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/approval.ts
+++ b/packages/cli/src/commands/approval.ts
@@ -1,0 +1,204 @@
+import type { ApprovalItem, ApprovalItemKind, Project } from "@todu/core";
+import type { Command } from "commander";
+import { buildActorMap, formatActorDisplay } from "../actor-display.js";
+import { type CliDaemonInvoker, formatDaemonCommandError } from "../daemon-command-client.js";
+import { formatJSON, formatTable } from "../format.js";
+
+const APPROVAL_COLUMNS = [
+  { key: "kind", label: "Kind" },
+  { key: "target", label: "Target" },
+  { key: "scope", label: "Scope" },
+  { key: "source", label: "Source" },
+  { key: "preview", label: "Preview" },
+];
+
+function parseApprovalKind(value: string): ApprovalItemKind | null {
+  switch (value) {
+    case "task":
+      return "taskDescription";
+    case "note":
+      return "noteContent";
+    default:
+      return null;
+  }
+}
+
+async function buildProjectNameMap(
+  invokeDaemon: CliDaemonInvoker,
+): Promise<Record<string, string>> {
+  const result = await invokeDaemon<Project[]>("project.list", {});
+  if (!result.ok) {
+    return {};
+  }
+
+  return Object.fromEntries(result.value.map((project) => [project.id, project.name]));
+}
+
+function formatApprovalKind(kind: ApprovalItemKind): string {
+  return kind === "taskDescription" ? "task description" : "note content";
+}
+
+function approvalToRow(
+  approval: ApprovalItem,
+  projectNameMap: Record<string, string>,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+): Record<string, string> {
+  return {
+    kind: formatApprovalKind(approval.kind),
+    target: approval.taskId ?? approval.noteId ?? "-",
+    scope:
+      approval.kind === "taskDescription"
+        ? (projectNameMap[approval.projectId ?? ""] ?? approval.projectId ?? "-")
+        : approval.entityType && approval.entityId
+          ? `${approval.entityType}:${approval.entityId}`
+          : "journal",
+    source: approval.sourceActorId
+      ? formatActorDisplay(approval.sourceActorId, actorMap)
+      : (approval.sourceBindingId ?? "-"),
+    preview: approval.contentPreview,
+  };
+}
+
+function approvalDetail(
+  approval: ApprovalItem,
+  projectNameMap: Record<string, string>,
+  actorMap: Awaited<ReturnType<typeof buildActorMap>>,
+): string {
+  const lines = [
+    `Kind:        ${formatApprovalKind(approval.kind)}`,
+    `State:       ${approval.state}`,
+    `Target:      ${approval.taskId ?? approval.noteId ?? "-"}`,
+  ];
+
+  if (approval.kind === "taskDescription") {
+    lines.push(`Task:        ${approval.taskTitle ?? approval.taskId ?? "-"}`);
+    lines.push(
+      `Project:     ${projectNameMap[approval.projectId ?? ""] ?? approval.projectId ?? "-"}`,
+    );
+  } else {
+    lines.push(
+      `Entity:      ${approval.entityType && approval.entityId ? `${approval.entityType}:${approval.entityId}` : "journal"}`,
+    );
+  }
+
+  if (approval.sourceBindingId) {
+    lines.push(`Binding:     ${approval.sourceBindingId}`);
+  }
+  if (approval.sourceActorId) {
+    lines.push(`Source:      ${formatActorDisplay(approval.sourceActorId, actorMap)}`);
+  }
+  if (approval.reviewedAt) {
+    lines.push(`Reviewed:    ${approval.reviewedAt}`);
+  }
+  if (approval.reviewedByActorId) {
+    lines.push(`Reviewed by: ${formatActorDisplay(approval.reviewedByActorId, actorMap)}`);
+  }
+  lines.push(`Preview:     ${approval.contentPreview}`);
+
+  return lines.join("\n");
+}
+
+export function registerApprovalCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
+  const approval = program.command("approval").description("Manage imported content approvals");
+
+  approval
+    .command("list")
+    .description("List content currently pending approval")
+    .option("--kind <kind>", "filter by kind (task or note)")
+    .action(async (opts) => {
+      let kind: ApprovalItemKind | undefined;
+      if (opts.kind) {
+        const parsedKind = parseApprovalKind(opts.kind);
+        if (!parsedKind) {
+          console.error(`Error: invalid approval kind: ${opts.kind}`);
+          process.exitCode = 1;
+          return;
+        }
+        kind = parsedKind;
+      }
+
+      const result = await invokeDaemon<ApprovalItem[]>("approval.list", {
+        filter: {
+          kind,
+        },
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(result.value));
+        return;
+      }
+
+      const [projectNameMap, actorMap] = await Promise.all([
+        buildProjectNameMap(invokeDaemon),
+        buildActorMap(invokeDaemon),
+      ]);
+      console.log(
+        formatTable(
+          result.value.map((item) => approvalToRow(item, projectNameMap, actorMap)),
+          APPROVAL_COLUMNS,
+        ),
+      );
+    });
+
+  const approve = approval.command("approve").description("Approve imported content explicitly");
+
+  approve
+    .command("task-description <taskId>")
+    .description("Approve imported task description content")
+    .action(async (taskId) => {
+      const result = await invokeDaemon<ApprovalItem>("approval.approveTaskDescription", {
+        taskId,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(result.value));
+        return;
+      }
+
+      const [projectNameMap, actorMap] = await Promise.all([
+        buildProjectNameMap(invokeDaemon),
+        buildActorMap(invokeDaemon),
+      ]);
+      console.log("Approval updated:");
+      console.log(approvalDetail(result.value, projectNameMap, actorMap));
+    });
+
+  approve
+    .command("note-content <noteId>")
+    .description("Approve imported note or comment content")
+    .action(async (noteId) => {
+      const result = await invokeDaemon<ApprovalItem>("approval.approveNoteContent", {
+        noteId,
+      });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      const format = program.opts().format;
+      if (format === "json") {
+        console.log(formatJSON(result.value));
+        return;
+      }
+
+      const [projectNameMap, actorMap] = await Promise.all([
+        buildProjectNameMap(invokeDaemon),
+        buildActorMap(invokeDaemon),
+      ]);
+      console.log("Approval updated:");
+      console.log(approvalDetail(result.value, projectNameMap, actorMap));
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from "commander";
 import { registerActorCommands } from "./commands/actor.js";
+import { registerApprovalCommands } from "./commands/approval.js";
 import { registerConfigCommands } from "./commands/config.js";
 import { registerDaemonCommands } from "./commands/daemon.js";
 import { registerHabitCommands } from "./commands/habit.js";
@@ -41,6 +42,7 @@ const invokeDaemon = createCliDaemonInvoker(program);
 
 // Register command groups
 registerActorCommands(program, invokeDaemon);
+registerApprovalCommands(program, invokeDaemon);
 registerDaemonCommands(program, invokeDaemon);
 registerProjectCommands(program, invokeDaemon);
 registerTaskCommands(program, invokeDaemon);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -454,6 +454,34 @@ export interface NoteFilter {
   timezone?: string;
 }
 
+export const APPROVAL_ITEM_KINDS = ["taskDescription", "noteContent"] as const;
+export type ApprovalItemKind = (typeof APPROVAL_ITEM_KINDS)[number];
+
+export function isApprovalItemKind(value: string): value is ApprovalItemKind {
+  return (APPROVAL_ITEM_KINDS as readonly string[]).includes(value);
+}
+
+export interface ApprovalListFilter {
+  kind?: ApprovalItemKind;
+}
+
+export interface ApprovalItem {
+  kind: ApprovalItemKind;
+  state: ContentApprovalState;
+  taskId?: TaskId;
+  noteId?: NoteId;
+  projectId?: ProjectId;
+  taskTitle?: string;
+  entityType?: NoteEntityType;
+  entityId?: string;
+  contentPreview: string;
+  sourceBindingId?: IntegrationBindingId;
+  sourceActorId?: ActorId;
+  sourceFingerprint?: string;
+  reviewedAt?: string;
+  reviewedByActorId?: ActorId;
+}
+
 // ============================================================================
 // Status transitions
 // ============================================================================

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -1,4 +1,5 @@
 import {
+  type ApprovalListFilter,
   type CreateActorInput,
   type CreateHabitInput,
   type CreateIntegrationBindingInput,
@@ -150,6 +151,20 @@ export function createCoreNamespaceHandlers(
       search: method(async (request, todu) => {
         const query = getRequiredStringParam(request, "query");
         return todu.task.search(query);
+      }),
+    },
+    approval: {
+      list: method(async (request, todu) => {
+        const filter = getOptionalObjectParam<ApprovalListFilter>(request, "filter");
+        return todu.approval.list(filter);
+      }),
+      approveTaskDescription: method(async (request, todu) => {
+        const id = createTaskId(getRequiredStringParam(request, "taskId"));
+        return todu.approval.approveTaskDescription(id);
+      }),
+      approveNoteContent: method(async (request, todu) => {
+        const id = createNoteId(getRequiredStringParam(request, "noteId"));
+        return todu.approval.approveNoteContent(id);
       }),
     },
     label: {

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -42,6 +42,7 @@ export const CORE_DAEMON_NAMESPACE_METHODS = {
     "delete",
   ],
   task: ["create", "list", "get", "update", "delete", "move", "search"],
+  approval: ["list", "approveTaskDescription", "approveNoteContent"],
   label: ["create", "list", "update", "delete"],
   integration: ["create", "list", "get", "update", "delete", "status"],
   note: ["create", "list", "update", "delete"],

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -93,6 +93,9 @@ describe("createDaemonRuntime", () => {
         "project.addAuthorizedActors",
         "project.removeAuthorizedActors",
         "project.setAuthorizedActors",
+        "approval.list",
+        "approval.approveTaskDescription",
+        "approval.approveNoteContent",
         "integration.create",
         "integration.status",
         "recurring.process",
@@ -526,6 +529,103 @@ describe("createDaemonRuntime", () => {
       id: "task-delete-1",
       result: null,
     });
+
+    await runtime.stop();
+  });
+
+  it("routes approval namespace methods through runtime adapters", async () => {
+    const runtime = createDaemonRuntime({ storagePath: tmpDir });
+
+    await runtime.start();
+
+    const createProjectResponse = await sendRequest(runtime.config().socketPath, {
+      id: "project-approval-create",
+      method: "project.create",
+      params: {
+        input: {
+          name: "Approval Project",
+        },
+      },
+    });
+
+    const projectId = (createProjectResponse.result as { id: string }).id;
+
+    const createTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "task-approval-create",
+      method: "task.create",
+      params: {
+        input: {
+          title: "Imported task",
+          projectId,
+          description: "Imported task description",
+          descriptionApproval: {
+            state: "pendingApproval",
+            sourceBindingId: "ibind-approval",
+            sourceActorId: "actor-user",
+          },
+        },
+      },
+    });
+
+    const taskId = (createTaskResponse.result as { id: string }).id;
+
+    const createNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-approval-create",
+      method: "note.create",
+      params: {
+        input: {
+          content: "Imported note content",
+          entityType: "task",
+          entityId: taskId,
+          contentApproval: {
+            state: "pendingApproval",
+            sourceBindingId: "ibind-approval",
+            sourceActorId: "actor-user",
+          },
+        },
+      },
+    });
+
+    const noteId = (createNoteResponse.result as { id: string }).id;
+
+    const listApprovalsResponse = await sendRequest(runtime.config().socketPath, {
+      id: "approval-list-1",
+      method: "approval.list",
+      params: {
+        filter: {},
+      },
+    });
+
+    expect(listApprovalsResponse.result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "taskDescription", taskId, state: "pendingApproval" }),
+        expect.objectContaining({ kind: "noteContent", noteId, state: "pendingApproval" }),
+      ]),
+    );
+
+    const approveTaskResponse = await sendRequest(runtime.config().socketPath, {
+      id: "approval-task-1",
+      method: "approval.approveTaskDescription",
+      params: {
+        taskId,
+      },
+    });
+
+    expect(approveTaskResponse.result).toEqual(
+      expect.objectContaining({ kind: "taskDescription", taskId, state: "approved" }),
+    );
+
+    const approveNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "approval-note-1",
+      method: "approval.approveNoteContent",
+      params: {
+        noteId,
+      },
+    });
+
+    expect(approveNoteResponse.result).toEqual(
+      expect.objectContaining({ kind: "noteContent", noteId, state: "approved" }),
+    );
 
     await runtime.stop();
   });

--- a/packages/engine/src/approvals.integration.test.ts
+++ b/packages/engine/src/approvals.integration.test.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createActorId, createIntegrationBindingId, createNoteId, createTaskId } from "@todu/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Todu } from "./index.js";
+import { createTodu } from "./index.js";
+
+describe("approval namespace", () => {
+  let tmpDir: string;
+  let todu: Todu;
+  let taskId: ReturnType<typeof createTaskId>;
+  let noteId: ReturnType<typeof createNoteId>;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-approval-test-"));
+    todu = await createTodu({ storagePath: tmpDir });
+
+    const project = await todu.project.create({ name: "Approval Project" });
+    if (!project.ok) throw new Error("project create failed");
+
+    const task = await todu.task.create({
+      title: "Imported task",
+      projectId: project.value.id,
+      description: "Imported instructions",
+      descriptionApproval: {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-test"),
+        sourceActorId: createActorId("actor-user"),
+      },
+    });
+    if (!task.ok) throw new Error("task create failed");
+    taskId = task.value.id;
+
+    const note = await todu.note.create({
+      content: "Imported comment",
+      entityType: "task",
+      entityId: taskId,
+      contentApproval: {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-test"),
+        sourceActorId: createActorId("actor-user"),
+      },
+    });
+    if (!note.ok) throw new Error("note create failed");
+    noteId = note.value.id;
+
+    const localNote = await todu.note.create({ content: "Local note" });
+    if (!localNote.ok) throw new Error("local note create failed");
+  });
+
+  afterEach(async () => {
+    await todu.close();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists pending approval items and filters by kind", async () => {
+    const all = await todu.approval.list();
+    expect(all.ok).toBe(true);
+    if (!all.ok) return;
+
+    expect(all.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "taskDescription", taskId, state: "pendingApproval" }),
+        expect.objectContaining({ kind: "noteContent", noteId, state: "pendingApproval" }),
+      ]),
+    );
+
+    const tasksOnly = await todu.approval.list({ kind: "taskDescription" });
+    expect(tasksOnly.ok).toBe(true);
+    if (!tasksOnly.ok) return;
+    expect(tasksOnly.value).toHaveLength(1);
+    expect(tasksOnly.value[0]).toMatchObject({ kind: "taskDescription", taskId });
+
+    const notesOnly = await todu.approval.list({ kind: "noteContent" });
+    expect(notesOnly.ok).toBe(true);
+    if (!notesOnly.ok) return;
+    expect(notesOnly.value).toHaveLength(1);
+    expect(notesOnly.value[0]).toMatchObject({ kind: "noteContent", noteId });
+  });
+
+  it("approves pending task descriptions explicitly", async () => {
+    const result = await todu.approval.approveTaskDescription(taskId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toMatchObject({
+      kind: "taskDescription",
+      taskId,
+      state: "approved",
+      reviewedByActorId: "actor-user",
+    });
+    expect(result.value.reviewedAt).toEqual(expect.any(String));
+
+    const task = await todu.task.get(taskId);
+    expect(task.ok).toBe(true);
+    if (!task.ok) return;
+    expect(task.value.descriptionApproval).toMatchObject({
+      state: "approved",
+      reviewedByActorId: "actor-user",
+    });
+  });
+
+  it("approves pending note content explicitly", async () => {
+    const result = await todu.approval.approveNoteContent(noteId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toMatchObject({
+      kind: "noteContent",
+      noteId,
+      state: "approved",
+      reviewedByActorId: "actor-user",
+    });
+    expect(result.value.reviewedAt).toEqual(expect.any(String));
+
+    const notes = await todu.note.list({ entityType: "task", entityId: taskId });
+    expect(notes.ok).toBe(true);
+    if (!notes.ok) return;
+    expect(notes.value[0].contentApproval).toMatchObject({
+      state: "approved",
+      reviewedByActorId: "actor-user",
+    });
+  });
+
+  it("rejects invalid approval actions with clear errors", async () => {
+    const localProject = await todu.project.create({ name: "Local" });
+    if (!localProject.ok) throw new Error("local project create failed");
+    const localTask = await todu.task.create({
+      title: "Local task",
+      projectId: localProject.value.id,
+      description: "Local only",
+    });
+    if (!localTask.ok) throw new Error("local task create failed");
+
+    const notRequired = await todu.approval.approveTaskDescription(localTask.value.id);
+    expect(notRequired.ok).toBe(false);
+    if (notRequired.ok) return;
+    expect(notRequired.error.type).toBe("validation");
+    expect(notRequired.error.message).toContain("does not require approval");
+
+    const firstApproval = await todu.approval.approveNoteContent(noteId);
+    if (!firstApproval.ok) throw new Error("note approval failed");
+    const alreadyApproved = await todu.approval.approveNoteContent(noteId);
+    expect(alreadyApproved.ok).toBe(false);
+    if (alreadyApproved.ok) return;
+    expect(alreadyApproved.error.type).toBe("validation");
+    expect(alreadyApproved.error.message).toContain("already approved");
+
+    const missingTask = await todu.approval.approveTaskDescription(createTaskId("task-missing"));
+    expect(missingTask.ok).toBe(false);
+    if (missingTask.ok) return;
+    expect(missingTask.error.type).toBe("not-found");
+
+    const missingNote = await todu.approval.approveNoteContent(createNoteId("note-missing"));
+    expect(missingNote.ok).toBe(false);
+    if (missingNote.ok) return;
+    expect(missingNote.error.type).toBe("not-found");
+  });
+});

--- a/packages/engine/src/approvals.ts
+++ b/packages/engine/src/approvals.ts
@@ -1,0 +1,169 @@
+import type { DocHandle } from "@automerge/automerge-repo/slim";
+import {
+  type ActorId,
+  type ApprovalItem,
+  type ApprovalListFilter,
+  type CatalogDocument,
+  err,
+  type Note,
+  type NoteId,
+  notFound,
+  ok,
+  type Result,
+  type TaskId,
+  type TaskWithDetail,
+  validationError,
+} from "@todu/core";
+import type { ApprovalNamespace, NoteNamespace, TaskNamespace } from "./todu.js";
+
+const APPROVAL_PREVIEW_LENGTH = 80;
+
+function createContentPreview(content: string): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  if (normalized.length <= APPROVAL_PREVIEW_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, APPROVAL_PREVIEW_LENGTH - 3)}...`;
+}
+
+export function createApprovalNamespace(
+  catalog: DocHandle<CatalogDocument>,
+  taskNamespace: TaskNamespace,
+  noteNamespace: NoteNamespace,
+): ApprovalNamespace {
+  function getReviewedByActorId(): ActorId | undefined {
+    return catalog.doc()?.ownerActorId;
+  }
+
+  function buildTaskApprovalItem(task: TaskWithDetail): ApprovalItem {
+    return {
+      kind: "taskDescription",
+      state: task.descriptionApproval?.state ?? "notRequired",
+      taskId: task.id,
+      projectId: task.projectId,
+      taskTitle: task.title,
+      contentPreview: createContentPreview(task.description ?? ""),
+      sourceBindingId: task.descriptionApproval?.sourceBindingId,
+      sourceActorId: task.descriptionApproval?.sourceActorId,
+      sourceFingerprint: task.descriptionApproval?.sourceFingerprint,
+      reviewedAt: task.descriptionApproval?.reviewedAt,
+      reviewedByActorId: task.descriptionApproval?.reviewedByActorId,
+    };
+  }
+
+  function buildNoteApprovalItem(note: Note): ApprovalItem {
+    return {
+      kind: "noteContent",
+      state: note.contentApproval?.state ?? "notRequired",
+      noteId: note.id,
+      entityType: note.entityType,
+      entityId: note.entityId,
+      contentPreview: createContentPreview(note.content),
+      sourceBindingId: note.contentApproval?.sourceBindingId,
+      sourceActorId: note.contentApproval?.sourceActorId,
+      sourceFingerprint: note.contentApproval?.sourceFingerprint,
+      reviewedAt: note.contentApproval?.reviewedAt,
+      reviewedByActorId: note.contentApproval?.reviewedByActorId,
+    };
+  }
+
+  return {
+    async list(filter?: ApprovalListFilter): Promise<Result<ApprovalItem[]>> {
+      const items: ApprovalItem[] = [];
+
+      if (filter?.kind !== "noteContent") {
+        const tasks = await taskNamespace.list();
+        if (!tasks.ok) return tasks;
+
+        for (const task of tasks.value) {
+          const detail = await taskNamespace.get(task.id);
+          if (!detail.ok) return detail;
+
+          if (
+            detail.value.descriptionApproval?.state === "pendingApproval" &&
+            detail.value.description
+          ) {
+            items.push(buildTaskApprovalItem(detail.value));
+          }
+        }
+      }
+
+      if (filter?.kind !== "taskDescription") {
+        const notes = await noteNamespace.list();
+        if (!notes.ok) return notes;
+
+        for (const note of notes.value) {
+          if (note.contentApproval?.state === "pendingApproval") {
+            items.push(buildNoteApprovalItem(note));
+          }
+        }
+      }
+
+      return ok(items);
+    },
+
+    async approveTaskDescription(taskId: TaskId): Promise<Result<ApprovalItem>> {
+      const task = await taskNamespace.get(taskId);
+      if (!task.ok) return task;
+
+      if (!task.value.description) {
+        return err(validationError("taskId", `Task has no description to approve: ${taskId}`));
+      }
+
+      const approval = task.value.descriptionApproval;
+      if (!approval || approval.state === "notRequired") {
+        return err(
+          validationError("taskId", `Task description does not require approval: ${taskId}`),
+        );
+      }
+      if (approval.state === "approved") {
+        return err(validationError("taskId", `Task description is already approved: ${taskId}`));
+      }
+
+      const reviewedByActorId = getReviewedByActorId();
+      const updated = await taskNamespace.update(taskId, {
+        descriptionApproval: {
+          ...approval,
+          state: "approved",
+          reviewedAt: new Date().toISOString(),
+          ...(reviewedByActorId !== undefined ? { reviewedByActorId } : {}),
+        },
+      });
+      if (!updated.ok) return updated;
+
+      return ok(buildTaskApprovalItem(updated.value));
+    },
+
+    async approveNoteContent(noteId: NoteId): Promise<Result<ApprovalItem>> {
+      const notes = await noteNamespace.list();
+      if (!notes.ok) return notes;
+
+      const note = notes.value.find((candidate) => candidate.id === noteId);
+      if (!note) {
+        return err(notFound("note", noteId));
+      }
+
+      const approval = note.contentApproval;
+      if (!approval || approval.state === "notRequired") {
+        return err(validationError("noteId", `Note content does not require approval: ${noteId}`));
+      }
+      if (approval.state === "approved") {
+        return err(validationError("noteId", `Note content is already approved: ${noteId}`));
+      }
+
+      const reviewedByActorId = getReviewedByActorId();
+      const updated = await noteNamespace.update(noteId, {
+        contentApproval: {
+          ...approval,
+          state: "approved",
+          reviewedAt: new Date().toISOString(),
+          ...(reviewedByActorId !== undefined ? { reviewedByActorId } : {}),
+        },
+      });
+      if (!updated.ok) return updated;
+
+      return ok(buildNoteApprovalItem(updated.value));
+    },
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,6 +6,7 @@ import {
 import type { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import { createActorNamespace } from "./actors.js";
+import { createApprovalNamespace } from "./approvals.js";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
 import { observeAllChanges } from "./change-observer.js";
 import { createHabitNamespace } from "./habits.js";
@@ -52,6 +53,7 @@ export { addRemoteSyncAdapter, isSyncServerAvailable } from "./sync-client.js";
 export { DEFAULT_SYNC_PORT } from "./sync-server.js";
 export type {
   ActorNamespace,
+  ApprovalNamespace,
   HabitNamespace,
   IntegrationNamespace,
   LabelNamespace,
@@ -246,6 +248,8 @@ export async function createTodu(
   }
 
   const stubs = createStubNamespaces(resolvedConfig);
+  const taskNamespace = createTaskNamespace(storage.catalog, storage.repo);
+  const noteNamespace = createNoteNamespace(storage.catalog, storage.repo);
 
   const todu: ToduWithInternalTools = {
     ...stubs,
@@ -256,10 +260,11 @@ export async function createTodu(
     },
     actor: createActorNamespace(storage.catalog),
     project: createProjectNamespace(storage.catalog),
-    task: createTaskNamespace(storage.catalog, storage.repo),
+    task: taskNamespace,
     label: createLabelNamespace(storage.catalog, storage.repo),
     integration: createIntegrationNamespace(storage.catalog, storage.repo),
-    note: createNoteNamespace(storage.catalog, storage.repo),
+    note: noteNamespace,
+    approval: createApprovalNamespace(storage.catalog, taskNamespace, noteNamespace),
     recurring: createRecurringNamespace(storage.catalog, storage.repo),
     habit: createHabitNamespace(storage.catalog, storage.repo),
     sync: {

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -1,6 +1,8 @@
 import type {
   Actor,
   ActorId,
+  ApprovalItem,
+  ApprovalListFilter,
   CreateActorInput,
   CreateHabitInput,
   CreateIntegrationBindingInput,
@@ -154,6 +156,12 @@ export interface NoteNamespace {
   delete(id: NoteId): Promise<Result<void>>;
 }
 
+export interface ApprovalNamespace {
+  list(filter?: ApprovalListFilter): Promise<Result<ApprovalItem[]>>;
+  approveTaskDescription(taskId: TaskId): Promise<Result<ApprovalItem>>;
+  approveNoteContent(noteId: NoteId): Promise<Result<ApprovalItem>>;
+}
+
 export interface RecurringNamespace {
   create(input: CreateRecurringInput): Promise<Result<RecurringTemplate>>;
   list(filter?: RecurringFilter): Promise<Result<RecurringTemplate[]>>;
@@ -240,6 +248,7 @@ export interface Todu {
   label: LabelNamespace;
   integration: IntegrationNamespace;
   note: NoteNamespace;
+  approval: ApprovalNamespace;
   recurring: RecurringNamespace;
   habit: HabitNamespace;
   sync: SyncNamespace;
@@ -328,6 +337,11 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
       list: stub,
       update: stub,
       delete: stub,
+    },
+    approval: {
+      list: stub,
+      approveTaskDescription: stub,
+      approveNoteContent: stub,
     },
     recurring: {
       create: stub,


### PR DESCRIPTION
## Summary
- add daemon-backed approval listing and explicit approval actions for imported task descriptions and note content
- add a core `todu approval` command family with text and JSON output
- add engine, daemon, and CLI coverage plus docs updates

## Checks
- make pre-pr

Task: #task-d8c38055