### PR TITLE
feat: add CLI owner actor management

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -334,6 +334,9 @@ todu actor create --id actor-reviewer --name "Reviewer"
 todu actor rename actor-reviewer --name "Lead Reviewer"
 todu actor archive actor-reviewer
 todu actor unarchive actor-reviewer
+
+todu actor owner show
+todu actor owner set actor-reviewer
 ```
 
 Behavior notes:
@@ -341,6 +344,11 @@ Behavior notes:
 - `actor create` rejects duplicate actor IDs.
 - `actor rename` updates only the display name; actor IDs remain stable.
 - `actor archive` and `actor unarchive` toggle archived state without deleting the actor.
+- `actor owner show` displays the current catalog owner actor clearly in text and JSON output.
+- `actor owner set <actor-id>` changes the canonical `ownerActorId` only after validating that the target actor exists and is not archived.
+- The owner actor has special semantics: legacy `"user"` identity fallback, default note authorship, approval reviewer attribution, and default project authorization all follow the current catalog owner.
+- Changing the owner actor does not silently rewrite unrelated actors or existing project authorization lists.
+- The current owner actor cannot be archived; switch the owner first if needed.
 - Invalid actor operations return daemon-backed validation or not-found errors.
 
 ## Project authorization and actor-aware task surfaces

--- a/packages/cli/src/commands/actor.integration.test.ts
+++ b/packages/cli/src/commands/actor.integration.test.ts
@@ -55,7 +55,12 @@ describe("actor CLI commands", () => {
     }
   }
 
-  it("actor list/create/rename/archive/unarchive flow", () => {
+  it("actor owner/list/create/rename/archive/unarchive flow", () => {
+    const initialOwner = run("actor owner show");
+    expect(initialOwner).toContain("Owner actor:");
+    expect(initialOwner).toContain("actor-user");
+    expect(initialOwner).toContain("Name:        user");
+
     const initialList = run("actor list");
     expect(initialList).toContain("actor-user");
     expect(initialList).toContain("active");
@@ -65,17 +70,26 @@ describe("actor CLI commands", () => {
     expect(createOutput).toContain("actor-reviewer");
     expect(createOutput).toContain("Archived:    no");
 
-    const listJson = run("--format json actor list");
-    expect(JSON.parse(listJson)).toEqual(
-      expect.arrayContaining([
-        { id: "actor-user", displayName: "user", archived: false },
-        { id: "actor-reviewer", displayName: "Reviewer", archived: false },
-      ]),
-    );
+    const setOwnerOutput = run("actor owner set actor-reviewer");
+    expect(setOwnerOutput).toContain("Owner actor updated:");
+    expect(setOwnerOutput).toContain("actor-reviewer");
+    expect(setOwnerOutput).toContain("Reviewer");
+
+    const ownerJson = run("--format json actor owner show");
+    expect(JSON.parse(ownerJson)).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+      archived: false,
+    });
 
     const renameOutput = run('actor rename actor-reviewer --name "Lead Reviewer"');
     expect(renameOutput).toContain("Actor renamed:");
     expect(renameOutput).toContain("Lead Reviewer");
+
+    const archiveOwnerOutput = run("actor archive actor-reviewer", true);
+    expect(archiveOwnerOutput).toContain("Owner actor cannot be archived: actor-reviewer");
+
+    run("actor owner set actor-user");
 
     const archiveOutput = run("actor archive actor-reviewer");
     expect(archiveOutput).toContain("Actor archived:");
@@ -99,5 +113,11 @@ describe("actor CLI commands", () => {
 
     const missingOutput = run("actor archive actor-missing", true);
     expect(missingOutput).toContain("actor not found: actor-missing");
+
+    run('actor create --id actor-reviewer --name "Reviewer"');
+    run("actor archive actor-reviewer");
+
+    const archivedOwnerOutput = run("actor owner set actor-reviewer", true);
+    expect(archivedOwnerOutput).toContain("Archived actor cannot be owner: actor-reviewer");
   });
 });

--- a/packages/cli/src/commands/actor.test.ts
+++ b/packages/cli/src/commands/actor.test.ts
@@ -72,6 +72,46 @@ describe("actor commands", () => {
     ]);
   });
 
+  it("passes owner show and set through to the daemon", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "actor.getOwner") {
+        return {
+          ok: true,
+          value: {
+            id: "actor-user",
+            displayName: "user",
+          },
+        };
+      }
+      if (method === "actor.setOwner") {
+        return {
+          ok: true,
+          value: {
+            id: "actor-reviewer",
+            displayName: "Reviewer",
+          },
+        };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerActorCommands(program, invokeDaemon);
+
+    await program.parseAsync(["actor", "owner", "show"], { from: "user" });
+    expect(invokeDaemonMock).toHaveBeenCalledWith("actor.getOwner", {});
+
+    await program.parseAsync(["actor", "owner", "set", "actor-reviewer"], { from: "user" });
+    expect(invokeDaemonMock).toHaveBeenCalledWith("actor.setOwner", {
+      actorId: "actor-reviewer",
+    });
+    expect(logSpy).toHaveBeenCalled();
+  });
+
   it("passes rename input through to the daemon", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "actor.rename") {

--- a/packages/cli/src/commands/actor.ts
+++ b/packages/cli/src/commands/actor.ts
@@ -32,6 +32,20 @@ function actorDetail(actor: Actor): string {
   ].join("\n");
 }
 
+function printActor(program: Command, actor: Actor, heading?: string): void {
+  const output = normalizeActorForOutput(actor);
+  const format = program.opts().format;
+  if (format === "json") {
+    console.log(formatJSON(output));
+    return;
+  }
+
+  if (heading) {
+    console.log(heading);
+  }
+  console.log(actorDetail(output));
+}
+
 export function registerActorCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const actor = program.command("actor").description("Manage actors");
 
@@ -73,14 +87,41 @@ export function registerActorCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
-      const output = normalizeActorForOutput(result.value);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(output));
-      } else {
-        console.log("Actor created:");
-        console.log(actorDetail(output));
+      printActor(program, result.value, "Actor created:");
+    });
+
+  const owner = actor
+    .command("owner")
+    .description(
+      "Inspect or change the catalog owner actor with special fallback/default semantics",
+    );
+
+  owner
+    .command("show")
+    .description("Show the current owner actor")
+    .action(async () => {
+      const result = await invokeDaemon<Actor>("actor.getOwner", {});
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
       }
+
+      printActor(program, result.value, "Owner actor:");
+    });
+
+  owner
+    .command("set <actorId>")
+    .description("Set the current owner actor to an existing non-archived actor")
+    .action(async (actorId) => {
+      const result = await invokeDaemon<Actor>("actor.setOwner", { actorId });
+      if (!result.ok) {
+        console.error(formatDaemonCommandError(result.error));
+        process.exitCode = 1;
+        return;
+      }
+
+      printActor(program, result.value, "Owner actor updated:");
     });
 
   actor
@@ -98,14 +139,7 @@ export function registerActorCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
-      const output = normalizeActorForOutput(result.value);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(output));
-      } else {
-        console.log("Actor renamed:");
-        console.log(actorDetail(output));
-      }
+      printActor(program, result.value, "Actor renamed:");
     });
 
   actor
@@ -119,14 +153,7 @@ export function registerActorCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
-      const output = normalizeActorForOutput(result.value);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(output));
-      } else {
-        console.log("Actor archived:");
-        console.log(actorDetail(output));
-      }
+      printActor(program, result.value, "Actor archived:");
     });
 
   actor
@@ -140,13 +167,6 @@ export function registerActorCommands(program: Command, invokeDaemon: CliDaemonI
         return;
       }
 
-      const output = normalizeActorForOutput(result.value);
-      const format = program.opts().format;
-      if (format === "json") {
-        console.log(formatJSON(output));
-      } else {
-        console.log("Actor unarchived:");
-        console.log(actorDetail(output));
-      }
+      printActor(program, result.value, "Actor unarchived:");
     });
 }

--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -68,6 +68,13 @@ export function createCoreNamespaceHandlers(
         };
         return todu.actor.create(input);
       }),
+      getOwner: method(async (_request, todu) => {
+        return todu.actor.getOwner();
+      }),
+      setOwner: method(async (request, todu) => {
+        const actorId = createActorId(getRequiredStringParam(request, "actorId"));
+        return todu.actor.setOwner(actorId);
+      }),
       rename: method(async (request, todu) => {
         const id = createActorId(getRequiredStringParam(request, "id"));
         const displayName = getRequiredStringParam(request, "displayName");

--- a/packages/daemon/src/rpc.ts
+++ b/packages/daemon/src/rpc.ts
@@ -30,7 +30,7 @@ export const DAEMON_BASE_METHODS = [
 export const DAEMON_CAPABILITY_EVENTS = ["data.changed", "sync.statusChanged"] as const;
 
 export const CORE_DAEMON_NAMESPACE_METHODS = {
-  actor: ["list", "create", "rename", "archive", "unarchive"],
+  actor: ["list", "create", "getOwner", "setOwner", "rename", "archive", "unarchive"],
   project: [
     "create",
     "list",

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -87,6 +87,8 @@ describe("createDaemonRuntime", () => {
     expect(DAEMON_CAPABILITY_METHODS).toEqual(
       expect.arrayContaining([
         "actor.create",
+        "actor.getOwner",
+        "actor.setOwner",
         "actor.rename",
         "actor.archive",
         "actor.unarchive",
@@ -108,7 +110,7 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
-  it("routes actor list/create/rename/archive/unarchive over UDS", async () => {
+  it("routes actor owner/list/create/rename/archive/unarchive over UDS", async () => {
     const runtime = createDaemonRuntime({
       storagePath: tmpDir,
       role: "authority",
@@ -132,6 +134,30 @@ describe("createDaemonRuntime", () => {
       displayName: "Reviewer",
     });
 
+    const ownerResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-owner-1",
+      method: "actor.getOwner",
+      params: {},
+    });
+
+    expect(ownerResponse.result).toEqual({
+      id: "actor-user",
+      displayName: "user",
+    });
+
+    const setOwnerResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-set-owner-1",
+      method: "actor.setOwner",
+      params: {
+        actorId: "actor-reviewer",
+      },
+    });
+
+    expect(setOwnerResponse.result).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+
     const renameResponse = await sendRequest(runtime.config().socketPath, {
       id: "actor-rename-1",
       method: "actor.rename",
@@ -144,6 +170,34 @@ describe("createDaemonRuntime", () => {
     expect(renameResponse.result).toEqual({
       id: "actor-reviewer",
       displayName: "Lead Reviewer",
+    });
+
+    const archiveOwnerResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-archive-owner-1",
+      method: "actor.archive",
+      params: {
+        id: "actor-reviewer",
+      },
+    });
+
+    expect(archiveOwnerResponse.error).toMatchObject({
+      code: "VALIDATION_ERROR",
+      details: {
+        field: "id",
+      },
+    });
+
+    const setOwnerBackResponse = await sendRequest(runtime.config().socketPath, {
+      id: "actor-set-owner-back-1",
+      method: "actor.setOwner",
+      params: {
+        actorId: "actor-user",
+      },
+    });
+
+    expect(setOwnerBackResponse.result).toEqual({
+      id: "actor-user",
+      displayName: "user",
     });
 
     const archiveResponse = await sendRequest(runtime.config().socketPath, {

--- a/packages/engine/src/actors.integration.test.ts
+++ b/packages/engine/src/actors.integration.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createActorId } from "@todu/core";
+import { createActorId, createIntegrationBindingId } from "@todu/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
@@ -27,6 +27,14 @@ describe("actor namespace", () => {
     if (!result.ok) return;
 
     expect(result.value).toEqual([{ id: "actor-user", displayName: "user" }]);
+  });
+
+  it("shows the default owner actor", async () => {
+    const result = await todu.actor.getOwner();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value).toEqual({ id: "actor-user", displayName: "user" });
   });
 
   it("creates an actor with normalized display name", async () => {
@@ -85,6 +93,77 @@ describe("actor namespace", () => {
     });
   });
 
+  it("sets owner actor without rewriting existing project authorization and updates future defaults", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const existingProject = await todu.project.create({ name: "Existing project" });
+    if (!existingProject.ok) throw new Error("existing project create failed");
+
+    const owner = await todu.actor.setOwner(createActorId("actor-reviewer"));
+    expect(owner.ok).toBe(true);
+    if (!owner.ok) return;
+    expect(owner.value).toEqual({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
+
+    const ownerShow = await todu.actor.getOwner();
+    expect(ownerShow.ok).toBe(true);
+    if (!ownerShow.ok) return;
+    expect(ownerShow.value.id).toBe("actor-reviewer");
+
+    const existingProjectAfter = await todu.project.get(existingProject.value.id);
+    expect(existingProjectAfter.ok).toBe(true);
+    if (!existingProjectAfter.ok) return;
+    expect(existingProjectAfter.value.authorizedAssigneeActorIds).toEqual(["actor-user"]);
+
+    const futureProject = await todu.project.create({ name: "Future project" });
+    expect(futureProject.ok).toBe(true);
+    if (!futureProject.ok) return;
+    expect(futureProject.value.authorizedAssigneeActorIds).toEqual(["actor-reviewer"]);
+  });
+
+  it("updates owner-based note and approval fallbacks after owner change", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const owner = await todu.actor.setOwner(createActorId("actor-reviewer"));
+    if (!owner.ok) throw new Error("owner set failed");
+
+    const project = await todu.project.create({
+      name: "Approvals",
+      authorizedAssigneeActorIds: [createActorId("actor-reviewer")],
+    });
+    if (!project.ok) throw new Error("project create failed");
+
+    const note = await todu.note.create({ content: "Owner fallback note" });
+    expect(note.ok).toBe(true);
+    if (!note.ok) return;
+    expect(note.value.authorActorId).toBe("actor-reviewer");
+
+    const task = await todu.task.create({
+      title: "Imported task",
+      projectId: project.value.id,
+      description: "Imported description",
+      descriptionApproval: {
+        state: "pendingApproval",
+        sourceBindingId: createIntegrationBindingId("ibind-owner-fallback"),
+        sourceActorId: createActorId("actor-reviewer"),
+      },
+    });
+    if (!task.ok) throw new Error("task create failed");
+
+    const approval = await todu.approval.approveTaskDescription(task.value.id);
+    expect(approval.ok).toBe(true);
+    if (!approval.ok) return;
+    expect(approval.value.reviewedByActorId).toBe("actor-reviewer");
+  });
+
   it("archives and unarchives actors", async () => {
     await todu.actor.create({
       id: createActorId("actor-reviewer"),
@@ -107,6 +186,39 @@ describe("actor namespace", () => {
       id: "actor-reviewer",
       displayName: "Reviewer",
     });
+  });
+
+  it("rejects archived or missing owner transitions", async () => {
+    await todu.actor.create({
+      id: createActorId("actor-reviewer"),
+      displayName: "Reviewer",
+    });
+
+    const archived = await todu.actor.archive(createActorId("actor-reviewer"));
+    if (!archived.ok) throw new Error("archive failed");
+
+    const archivedOwner = await todu.actor.setOwner(createActorId("actor-reviewer"));
+    expect(archivedOwner.ok).toBe(false);
+    if (archivedOwner.ok) return;
+    expect(archivedOwner.error.type).toBe("validation");
+    expect(archivedOwner.error.field).toBe("actorId");
+
+    const missingOwner = await todu.actor.setOwner(createActorId("actor-missing"));
+    expect(missingOwner.ok).toBe(false);
+    if (missingOwner.ok) return;
+    expect(missingOwner.error.type).toBe("not-found");
+    expect(missingOwner.error.entity).toBe("actor");
+    expect(missingOwner.error.id).toBe("actor-missing");
+  });
+
+  it("rejects archiving the current owner actor", async () => {
+    const result = await todu.actor.archive(createActorId("actor-user"));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.type).toBe("validation");
+    expect(result.error.field).toBe("id");
+    expect(result.error.message).toContain("Owner actor cannot be archived");
   });
 
   it("returns not-found for unknown actor ids on mutation", async () => {

--- a/packages/engine/src/actors.ts
+++ b/packages/engine/src/actors.ts
@@ -1,6 +1,7 @@
 import type { DocHandle } from "@automerge/automerge-repo/slim";
 import {
   type Actor,
+  type ActorId,
   type CatalogDocument,
   type CreateActorInput,
   createActorId,
@@ -9,6 +10,7 @@ import {
   ok,
   type Result,
   validateActorDisplayName,
+  validateActorId,
   validateCreateActorInput,
   validationError,
 } from "@todu/core";
@@ -26,6 +28,14 @@ function normalizeActorDisplayName(displayName: string): string {
   return displayName.trim();
 }
 
+function normalizeActorId(id: ActorId): ActorId {
+  return createActorId(id.trim());
+}
+
+function findActor(doc: CatalogDocument | undefined, id: ActorId): Actor | undefined {
+  return doc?.actors.find((actor) => actor.id === id);
+}
+
 export function createActorNamespace(catalog: DocHandle<CatalogDocument>): ActorNamespace {
   return {
     async list(): Promise<Result<Actor[]>> {
@@ -41,7 +51,7 @@ export function createActorNamespace(catalog: DocHandle<CatalogDocument>): Actor
         return err(notFound("catalog", "default"));
       }
 
-      const normalizedId = createActorId(input.id.trim());
+      const normalizedId = normalizeActorId(input.id);
       if (doc.actors.some((actor) => actor.id === normalizedId)) {
         return err(validationError("id", `Actor ID already exists: ${normalizedId}`));
       }
@@ -58,6 +68,46 @@ export function createActorNamespace(catalog: DocHandle<CatalogDocument>): Actor
       return ok(cloneActor(actor));
     },
 
+    async getOwner(): Promise<Result<Actor>> {
+      const doc = catalog.doc();
+      if (!doc) {
+        return err(notFound("catalog", "default"));
+      }
+
+      const ownerActorId = doc.ownerActorId;
+      const owner = ownerActorId ? findActor(doc, ownerActorId) : undefined;
+      if (!owner) {
+        return err(notFound("actor", ownerActorId ?? "owner"));
+      }
+
+      return ok(cloneActor(owner));
+    },
+
+    async setOwner(id): Promise<Result<Actor>> {
+      const actorIdError = validateActorId("actorId", id);
+      if (actorIdError) return err(actorIdError);
+
+      const doc = catalog.doc();
+      if (!doc) {
+        return err(notFound("catalog", "default"));
+      }
+
+      const normalizedId = normalizeActorId(id);
+      const owner = findActor(doc, normalizedId);
+      if (!owner) {
+        return err(notFound("actor", normalizedId));
+      }
+      if (owner.archived) {
+        return err(validationError("actorId", `Archived actor cannot be owner: ${normalizedId}`));
+      }
+
+      catalog.change((nextDoc) => {
+        nextDoc.ownerActorId = normalizedId;
+      });
+
+      return ok(cloneActor(owner));
+    },
+
     async rename(id, displayName): Promise<Result<Actor>> {
       const displayNameError = validateActorDisplayName("displayName", displayName);
       if (displayNameError) return err(displayNameError);
@@ -65,7 +115,7 @@ export function createActorNamespace(catalog: DocHandle<CatalogDocument>): Actor
       const doc = catalog.doc();
       if (!doc) return err(notFound("actor", id));
 
-      const normalizedId = createActorId(id.trim());
+      const normalizedId = normalizeActorId(id);
       const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
       if (index === -1) return err(notFound("actor", normalizedId));
 
@@ -81,9 +131,12 @@ export function createActorNamespace(catalog: DocHandle<CatalogDocument>): Actor
       const doc = catalog.doc();
       if (!doc) return err(notFound("actor", id));
 
-      const normalizedId = createActorId(id.trim());
+      const normalizedId = normalizeActorId(id);
       const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
       if (index === -1) return err(notFound("actor", normalizedId));
+      if (doc.ownerActorId === normalizedId) {
+        return err(validationError("id", `Owner actor cannot be archived: ${normalizedId}`));
+      }
 
       catalog.change((nextDoc) => {
         nextDoc.actors[index].archived = true;
@@ -96,7 +149,7 @@ export function createActorNamespace(catalog: DocHandle<CatalogDocument>): Actor
       const doc = catalog.doc();
       if (!doc) return err(notFound("actor", id));
 
-      const normalizedId = createActorId(id.trim());
+      const normalizedId = normalizeActorId(id);
       const index = doc.actors.findIndex((actor) => actor.id === normalizedId);
       if (index === -1) return err(notFound("actor", normalizedId));
 

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -41,6 +41,10 @@ async function readCatalogDocument(storagePath: string): Promise<CatalogDocument
 async function seedLegacyNoteIdentityData(
   storagePath: string,
   legacyAuthorsByNoteId: Record<string, string | null | undefined>,
+  owner: { id: string; displayName: string } = {
+    id: DEFAULT_OWNER_ACTOR_ID,
+    displayName: "user",
+  },
 ): Promise<void> {
   const markerPath = path.join(storagePath, "todu-catalog.id");
   const catalogId = fs.readFileSync(markerPath, "utf-8").trim() as DocumentId;
@@ -56,10 +60,10 @@ async function seedLegacyNoteIdentityData(
       doc.version = 1;
       doc.settings.schemaVersion = 1;
       doc.actors.splice(0, doc.actors.length, {
-        id: DEFAULT_OWNER_ACTOR_ID,
-        displayName: "user",
+        id: createActorId(owner.id),
+        displayName: owner.displayName,
       });
-      doc.ownerActorId = DEFAULT_OWNER_ACTOR_ID;
+      doc.ownerActorId = createActorId(owner.id);
     });
 
     const bucketDocIds = Object.values(catalogHandle.doc()?.notesBucketDocIds ?? {});
@@ -321,6 +325,40 @@ describe("note namespace", () => {
       if (!afterRestart.ok) return;
       expect(afterRestart.value.find((note) => note.id === first.value.id)?.authorActorId).toBe(
         migratedFirst?.authorActorId,
+      );
+    });
+
+    it("maps legacy missing or 'user' note authors to the current owner actor during migration", async () => {
+      const first = await todu.note.create({ content: "Legacy user note" });
+      const second = await todu.note.create({ content: "Legacy missing note" });
+      if (!first.ok || !second.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedLegacyNoteIdentityData(
+        tmpDir,
+        {
+          [first.value.id]: "user",
+          [second.value.id]: undefined,
+        },
+        {
+          id: "actor-reviewer",
+          displayName: "Reviewer",
+        },
+      );
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.note.list();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.find((note) => note.id === first.value.id)?.authorActorId).toBe(
+        "actor-reviewer",
+      );
+      expect(result.value.find((note) => note.id === second.value.id)?.authorActorId).toBe(
+        "actor-reviewer",
       );
     });
 

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -92,7 +92,11 @@ async function addCatalogActor(
     });
     await repo.flush();
   } finally {
-    await repo.shutdown();
+    try {
+      await repo.shutdown();
+    } catch {
+      // Safe to ignore in helper cleanup when repo still has requesting docs.
+    }
   }
 }
 
@@ -100,6 +104,10 @@ async function seedLegacyTaskIdentityData(
   storagePath: string,
   projectId: ProjectId,
   legacyAssigneesByTaskId: Record<string, string[]>,
+  owner: { id: string; displayName: string } = {
+    id: DEFAULT_OWNER_ACTOR_ID,
+    displayName: "user",
+  },
 ): Promise<void> {
   const markerPath = path.join(storagePath, "todu-catalog.id");
   const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
@@ -114,17 +122,17 @@ async function seedLegacyTaskIdentityData(
       doc.version = 1;
       doc.settings.schemaVersion = 1;
       doc.actors.splice(0, doc.actors.length, {
-        id: DEFAULT_OWNER_ACTOR_ID,
-        displayName: "user",
+        id: createActorId(owner.id),
+        displayName: owner.displayName,
       });
-      doc.ownerActorId = DEFAULT_OWNER_ACTOR_ID;
+      doc.ownerActorId = createActorId(owner.id);
 
       const project = doc.projects.find((entry) => entry.id === projectId);
       if (!project) throw new Error(`project not found: ${projectId}`);
       project.authorizedAssigneeActorIds.splice(
         0,
         project.authorizedAssigneeActorIds.length,
-        DEFAULT_OWNER_ACTOR_ID,
+        createActorId(owner.id),
       );
     });
 
@@ -488,6 +496,36 @@ describe("task namespace", () => {
       expect(
         afterRestart.value.find((task) => task.id === second.value.id)?.assigneeActorIds,
       ).toEqual(secondTask?.assigneeActorIds);
+    });
+
+    it("maps legacy task assignee 'user' to the current owner actor during migration", async () => {
+      const created = await todu.task.create({ title: "Legacy owner task", projectId });
+      if (!created.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedLegacyTaskIdentityData(
+        tmpDir,
+        projectId,
+        {
+          [created.value.id]: ["user"],
+        },
+        {
+          id: "actor-reviewer",
+          displayName: "Reviewer",
+        },
+      );
+
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const migrated = await todu.task.get(created.value.id);
+      expect(migrated.ok).toBe(true);
+      if (!migrated.ok) return;
+      expect(migrated.value.assigneeActorIds).toEqual(["actor-reviewer"]);
+
+      const catalog = await readCatalogDocument(tmpDir);
+      expect(catalog.ownerActorId).toBe("actor-reviewer");
     });
 
     it("repairs partially migrated task assignees on retry", async () => {

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -100,6 +100,8 @@ export interface ToduConfig {
 export interface ActorNamespace {
   list(): Promise<Result<Actor[]>>;
   create(input: CreateActorInput): Promise<Result<Actor>>;
+  getOwner(): Promise<Result<Actor>>;
+  setOwner(id: ActorId): Promise<Result<Actor>>;
   rename(id: ActorId, displayName: string): Promise<Result<Actor>>;
   archive(id: ActorId): Promise<Result<Actor>>;
   unarchive(id: ActorId): Promise<Result<Actor>>;
@@ -294,6 +296,8 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
     actor: {
       list: stub,
       create: stub,
+      getOwner: stub,
+      setOwner: stub,
       rename: stub,
       archive: stub,
       unarchive: stub,


### PR DESCRIPTION
## Summary
- add daemon-backed owner actor show/set operations and guard owner invariants
- add `todu actor owner show|set` with text and JSON output
- document owner semantics and add engine, daemon, and CLI coverage for default behavior and migration invariants

## Checks
- make pre-pr

Task: #task-6dd2228c