### PR TITLE
feat: add Electron actor and project auth UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ make dev-electron
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - Dependency maintenance: [docs/dependency-maintenance.md](docs/dependency-maintenance.md)
 - Daemon CLI behavior: [docs/cli-daemon-usage.md](docs/cli-daemon-usage.md)
+- Electron actor and project authorization management: [docs/electron-actor-project-auth.md](docs/electron-actor-project-auth.md)
 
 ## License
 

--- a/docs/electron-actor-project-auth.md
+++ b/docs/electron-actor-project-auth.md
@@ -1,0 +1,34 @@
+# Electron actor and project authorization management
+
+The Electron app includes lightweight multi-user management surfaces backed by the local daemon.
+
+## Actors
+
+Open **Settings → Actors** to manage catalog-wide actors.
+
+Supported actions:
+- list actors with display name, actor ID, and active/archived state
+- create a new actor
+- rename an existing actor
+- archive an actor
+- unarchive an actor
+
+Behavior notes:
+- actor IDs stay stable after creation
+- archived actors remain visible for historical/admin context
+- archived actors are not offered for new project authorization choices
+
+## Project authorization
+
+Open any project detail view and use the **Authorized assignees** section to manage `authorizedAssigneeActorIds`.
+
+Supported actions:
+- inspect current authorized actors
+- add an active actor to the project authorization list
+- remove an actor from the project authorization list
+- review any stale or unauthorized task assignees still attached to tasks in that project
+
+Behavior notes:
+- existing stale or unauthorized assignees remain visible instead of being silently removed
+- task detail views also mark archived or unauthorized assignees clearly
+- all actions go through daemon-backed core actor and project APIs

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -2,20 +2,40 @@ import { describe, expect, it, vi } from "vitest";
 import { createDaemonToduClient } from "./daemon-todu-client.js";
 
 describe("createDaemonToduClient", () => {
-  it("routes actor.list to daemon RPC and preserves Result shape", async () => {
-    const request = vi.fn().mockResolvedValue({
-      ok: true,
-      value: [{ id: "actor-user", displayName: "user" }],
-    });
+  it("routes actor methods to daemon RPC and preserves Result shape", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [{ id: "actor-user", displayName: "user" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { id: "actor-reviewer", displayName: "Reviewer" },
+      });
 
     const client = createDaemonToduClient({ request });
 
-    const result = await client.actor.list();
+    const listResult = await client.actor.list();
+    const createResult = await client.actor.create({
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
 
-    expect(request).toHaveBeenCalledWith("actor.list", {});
-    expect(result).toEqual({
+    expect(request).toHaveBeenNthCalledWith(1, "actor.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "actor.create", {
+      input: {
+        id: "actor-reviewer",
+        displayName: "Reviewer",
+      },
+    });
+    expect(listResult).toEqual({
       ok: true,
       value: [{ id: "actor-user", displayName: "user" }],
+    });
+    expect(createResult).toEqual({
+      ok: true,
+      value: { id: "actor-reviewer", displayName: "Reviewer" },
     });
   });
 

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -6,6 +6,10 @@ import { mapDaemonErrorToToduError } from "./daemon-error-mapping.js";
 interface DaemonBackedToduMethods {
   actor: {
     list(): Promise<Result<unknown, ToduError>>;
+    create(input: unknown): Promise<Result<unknown, ToduError>>;
+    rename(id: string, displayName: string): Promise<Result<unknown, ToduError>>;
+    archive(id: string): Promise<Result<unknown, ToduError>>;
+    unarchive(id: string): Promise<Result<unknown, ToduError>>;
   };
   project: {
     list(filter?: unknown): Promise<Result<unknown, ToduError>>;
@@ -50,6 +54,10 @@ export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "re
   const client: DaemonBackedToduMethods = {
     actor: {
       list: () => invoke("actor.list", {}),
+      create: (input) => invoke("actor.create", { input }),
+      rename: (id, displayName) => invoke("actor.rename", { id, displayName }),
+      archive: (id) => invoke("actor.archive", { id }),
+      unarchive: (id) => invoke("actor.unarchive", { id }),
     },
     project: {
       list: (filter) => invoke("project.list", { filter }),

--- a/packages/electron/src/main/ipc.integration.test.ts
+++ b/packages/electron/src/main/ipc.integration.test.ts
@@ -4,10 +4,16 @@ import { createDaemonIpcHandlers, mapDaemonErrorToToduError } from "./ipc.js";
 describe("createDaemonIpcHandlers", () => {
   it("routes actor IPC handlers to daemon RPC and preserves Result contract", async () => {
     const daemon = {
-      request: vi.fn().mockResolvedValue({
-        ok: true,
-        value: [{ id: "actor-user", displayName: "user" }],
-      }),
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          value: [{ id: "actor-user", displayName: "user" }],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          value: { id: "actor-reviewer", displayName: "Reviewer" },
+        }),
     };
 
     const handlers = createDaemonIpcHandlers({
@@ -15,12 +21,26 @@ describe("createDaemonIpcHandlers", () => {
       storagePath: "/tmp/todu-ipc-test",
     });
 
-    const result = await handlers["todu:actor:list"](undefined);
+    const listResult = await handlers["todu:actor:list"](undefined);
+    const createResult = await handlers["todu:actor:create"](undefined, {
+      id: "actor-reviewer",
+      displayName: "Reviewer",
+    });
 
-    expect(daemon.request).toHaveBeenCalledWith("actor.list", {});
-    expect(result).toEqual({
+    expect(daemon.request).toHaveBeenNthCalledWith(1, "actor.list", {});
+    expect(daemon.request).toHaveBeenNthCalledWith(2, "actor.create", {
+      input: {
+        id: "actor-reviewer",
+        displayName: "Reviewer",
+      },
+    });
+    expect(listResult).toEqual({
       ok: true,
       value: [{ id: "actor-user", displayName: "user" }],
+    });
+    expect(createResult).toEqual({
+      ok: true,
+      value: { id: "actor-reviewer", displayName: "Reviewer" },
     });
   });
 

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -37,6 +37,11 @@ export function createDaemonIpcHandlers(
   return {
     // ── Actor ─────────────────────────────────────────────────────────────
     "todu:actor:list": () => invokeResult("actor.list"),
+    "todu:actor:create": (_event, input) => invokeResult("actor.create", { input }),
+    "todu:actor:rename": (_event, id, displayName) =>
+      invokeResult("actor.rename", { id, displayName }),
+    "todu:actor:archive": (_event, id) => invokeResult("actor.archive", { id }),
+    "todu:actor:unarchive": (_event, id) => invokeResult("actor.unarchive", { id }),
 
     // ── Project ───────────────────────────────────────────────────────────
     "todu:project:list": (_event, filter) => invokeResult("project.list", { filter }),

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -10,6 +10,11 @@ const api = {
   // ── Actor ──────────────────────────────────────────────────────────
   actor: {
     list: () => ipcRenderer.invoke("todu:actor:list"),
+    create: (input: unknown) => ipcRenderer.invoke("todu:actor:create", input),
+    rename: (id: string, displayName: string) =>
+      ipcRenderer.invoke("todu:actor:rename", id, displayName),
+    archive: (id: string) => ipcRenderer.invoke("todu:actor:archive", id),
+    unarchive: (id: string) => ipcRenderer.invoke("todu:actor:unarchive", id),
   },
 
   // ── Project ────────────────────────────────────────────────────────

--- a/packages/electron/src/renderer/hooks/useTodu.ts
+++ b/packages/electron/src/renderer/hooks/useTodu.ts
@@ -124,8 +124,10 @@ export function useUpdateProject() {
   return useMutation({
     mutationFn: async ({ id, input }: { id: ProjectId; input: UpdateProjectInput }) =>
       unwrap(await window.todu.project.update(id, input)),
-    onSuccess: () => {
+    onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+      queryClient.invalidateQueries({ queryKey: queryKeys.project(id) });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
     },
   });
 }

--- a/packages/electron/src/renderer/lib/actors.ts
+++ b/packages/electron/src/renderer/lib/actors.ts
@@ -1,33 +1,67 @@
 import type { Actor, ImportedContentApproval } from "@todu/core/browser";
 
+export interface ActorLabelOptions {
+  fallback?: string;
+  includeId?: boolean;
+  authorizedActorIds?: readonly string[];
+}
+
 export function createActorMap(actors?: Actor[]): Map<string, Actor> {
   return new Map((actors ?? []).map((actor) => [actor.id, actor]));
+}
+
+function actorStatusParts(
+  actorId: string,
+  actor: Actor | undefined,
+  options: ActorLabelOptions,
+): string[] {
+  const parts: string[] = [];
+
+  if (options.includeId && actor) {
+    parts.push(actorId);
+  }
+
+  if (actor?.archived) {
+    parts.push("archived");
+  }
+
+  if (options.authorizedActorIds && !options.authorizedActorIds.includes(actorId)) {
+    parts.push("unauthorized");
+  }
+
+  return parts;
 }
 
 export function getActorName(
   actorId: string | undefined,
   actorMap: Map<string, Actor>,
   fallback?: string,
+  options: Omit<ActorLabelOptions, "fallback"> = {},
 ): string {
   if (!actorId) {
     return fallback ?? "Unknown";
   }
 
   const actor = actorMap.get(actorId);
-  if (!actor) {
-    return fallback ?? actorId;
+  const baseLabel = actor?.displayName ?? fallback ?? actorId;
+  const statusParts = actorStatusParts(actorId, actor, options);
+
+  if (statusParts.length === 0) {
+    return baseLabel;
   }
 
-  return `${actor.displayName}${actor.archived ? " (archived)" : ""}`;
+  const uniqueStatusParts = [...new Set(statusParts)];
+  return `${baseLabel} (${uniqueStatusParts.join(", ")})`;
 }
 
 export function getActorNames(
   actorIds: readonly string[],
   actorMap: Map<string, Actor>,
   fallbackNames: readonly string[] = [],
+  options: Omit<ActorLabelOptions, "fallback"> = {},
 ): string[] {
   if (actorIds.length > 0) {
-    return actorIds.map((actorId) => getActorName(actorId, actorMap));
+    return actorIds.map((actorId) => getActorName(actorId, actorMap, undefined, options));
   }
 
   return [...fallbackNames];

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -39,6 +39,10 @@ import type { UpcomingOccurrence } from "@todu/engine";
 
 export interface ToduActorApi {
   list(): Promise<Result<Actor[]>>;
+  create(input: { id: string; displayName: string }): Promise<Result<Actor>>;
+  rename(id: string, displayName: string): Promise<Result<Actor>>;
+  archive(id: string): Promise<Result<Actor>>;
+  unarchive(id: string): Promise<Result<Actor>>;
 }
 
 export interface ToduProjectApi {

--- a/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
+++ b/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as hooks from "../hooks/useTodu.js";
@@ -92,10 +92,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     name: "Inbox",
     status: "active",
     priority: "medium",
-    authorizedAssigneeActorIds: [
-      "actor-user",
-      "actor-reviewer",
-    ] as Project["authorizedAssigneeActorIds"],
+    authorizedAssigneeActorIds: ["actor-user"] as Project["authorizedAssigneeActorIds"],
     createdAt: "2026-03-01T00:00:00.000Z",
     updatedAt: "2026-03-01T00:00:00.000Z",
     ...overrides,
@@ -131,7 +128,8 @@ beforeEach(() => {
   vi.mocked(hooks.useActors).mockReturnValue({
     data: [
       { id: "actor-user", displayName: "user" },
-      { id: "actor-reviewer", displayName: "Reviewer" },
+      { id: "actor-reviewer", displayName: "Reviewer", archived: true },
+      { id: "actor-collab", displayName: "Collaborator" },
     ],
   } as ReturnType<typeof hooks.useActors>);
 
@@ -174,7 +172,7 @@ beforeEach(() => {
   } as ReturnType<typeof hooks.useDeleteProject>);
 
   vi.mocked(hooks.useTasks).mockReturnValue({
-    data: [],
+    data: [makeTask()],
   } as ReturnType<typeof hooks.useTasks>);
 
   vi.mocked(hooks.useSearchTasks).mockReturnValue({
@@ -198,16 +196,21 @@ afterEach(() => {
 });
 
 describe("actor-aware renderer views", () => {
-  it("shows actor assignees and approval state in task detail", async () => {
+  it("shows archived and unauthorized actor assignees plus approval state in task detail", async () => {
     render(<TaskDetail taskId="task-1" onBack={() => {}} />);
 
     expect(screen.getByText("Assignees")).toBeDefined();
     expect(screen.getByText("user")).toBeDefined();
-    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("Reviewer (archived, unauthorized)")).toBeDefined();
     expect(screen.getByText("Approval needed")).toBeDefined();
   });
 
-  it("shows authorized assignee actors in project detail", async () => {
+  it("shows project authorization controls and stale unauthorized assignees", async () => {
+    const mutate = vi.fn();
+    vi.mocked(hooks.useUpdateProject).mockReturnValue({
+      mutate,
+    } as ReturnType<typeof hooks.useUpdateProject>);
+
     render(
       <ProjectDetail
         projectId="proj-1"
@@ -218,14 +221,38 @@ describe("actor-aware renderer views", () => {
     );
 
     expect(screen.getByText("Authorized assignees")).toBeDefined();
-    expect(screen.getByText("user")).toBeDefined();
-    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("user (actor-user)")).toBeDefined();
+    expect(screen.getByText("Unauthorized task assignees")).toBeDefined();
+    expect(
+      screen.getByText("Actor task: Reviewer (actor-reviewer, archived, unauthorized)"),
+    ).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("Add authorized actor"), {
+      target: { value: "actor-collab" },
+    });
+    fireEvent.click(screen.getByText("Add"));
+
+    expect(mutate).toHaveBeenCalledWith({
+      id: "proj-1",
+      input: {
+        authorizedAssigneeActorIds: ["actor-user", "actor-collab"],
+      },
+    });
+
+    fireEvent.click(screen.getByText("Remove"));
+
+    expect(mutate).toHaveBeenLastCalledWith({
+      id: "proj-1",
+      input: {
+        authorizedAssigneeActorIds: [],
+      },
+    });
   });
 
   it("shows actor-based note authors and approval state in note list", async () => {
     render(<NoteList onCreateNote={() => {}} onNavigateToEntity={() => {}} />);
 
-    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("Reviewer (archived)")).toBeDefined();
     expect(screen.getByText("Approval needed")).toBeDefined();
     expect(screen.getByText("Imported note")).toBeDefined();
   });

--- a/packages/electron/src/renderer/views/ProjectDetail.tsx
+++ b/packages/electron/src/renderer/views/ProjectDetail.tsx
@@ -91,6 +91,7 @@ export function ProjectDetail({
   const [editingDescription, setEditingDescription] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [activeTab, setActiveTab] = useState("tasks");
+  const [selectedAuthorizedActorId, setSelectedAuthorizedActorId] = useState("");
   const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   if (isLoading) {
@@ -134,9 +135,60 @@ export function ProjectDetail({
     deleteProject.mutate(project.id as ProjectId, { onSuccess: onBack });
   };
 
-  const authorizedActorNames = getActorNames(project.authorizedAssigneeActorIds, actorMap);
+  const handleAddAuthorizedActor = () => {
+    if (!selectedAuthorizedActorId) return;
+
+    updateProject.mutate({
+      id: project.id as ProjectId,
+      input: {
+        authorizedAssigneeActorIds: [
+          ...project.authorizedAssigneeActorIds,
+          selectedAuthorizedActorId,
+        ],
+      },
+    });
+    setSelectedAuthorizedActorId("");
+  };
+
+  const handleRemoveAuthorizedActor = (actorId: string) => {
+    updateProject.mutate({
+      id: project.id as ProjectId,
+      input: {
+        authorizedAssigneeActorIds: project.authorizedAssigneeActorIds.filter(
+          (id) => id !== actorId,
+        ),
+      },
+    });
+  };
+
+  const authorizedActorNames = getActorNames(project.authorizedAssigneeActorIds, actorMap, [], {
+    includeId: true,
+  });
   const taskCount = tasks?.length ?? 0;
   const displayTasks = searchQuery.length > 0 ? searchResults : tasks;
+  const availableAuthorizedActors = (actors ?? []).filter(
+    (actor) => !actor.archived && !project.authorizedAssigneeActorIds.includes(actor.id),
+  );
+  const staleUnauthorizedAssignees = (tasks ?? []).flatMap((task) => {
+    const unauthorizedActorIds = task.assigneeActorIds.filter(
+      (actorId) => !project.authorizedAssigneeActorIds.includes(actorId),
+    );
+
+    if (unauthorizedActorIds.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        taskId: task.id,
+        title: task.title,
+        assigneeNames: getActorNames(unauthorizedActorIds, actorMap, [], {
+          includeId: true,
+          authorizedActorIds: project.authorizedAssigneeActorIds,
+        }),
+      },
+    ];
+  });
 
   // Keep project filter locked
   const handleFilterChange = (newFilter: TaskFilter) => {
@@ -229,16 +281,59 @@ export function ProjectDetail({
         <div className="detail-meta-cell detail-meta-cell-wide">
           <span className="detail-meta-label">Authorized assignees</span>
           <div className="label-chips">
-            {authorizedActorNames.length > 0 ? (
-              authorizedActorNames.map((actorName) => (
-                <span key={actorName} className="chip chip-label">
-                  {actorName}
+            {project.authorizedAssigneeActorIds.length > 0 ? (
+              project.authorizedAssigneeActorIds.map((actorId, index) => (
+                <span key={actorId} className="chip chip-label">
+                  {authorizedActorNames[index]}
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => handleRemoveAuthorizedActor(actorId)}
+                  >
+                    Remove
+                  </button>
                 </span>
               ))
             ) : (
               <span className="empty-hint">None</span>
             )}
           </div>
+          <div className="settings-key-input-row">
+            <select
+              aria-label="Add authorized actor"
+              className="input inline-select"
+              value={selectedAuthorizedActorId}
+              onChange={(e) => setSelectedAuthorizedActorId(e.target.value)}
+            >
+              <option value="">Select actor</option>
+              {availableAuthorizedActors.map((actor) => (
+                <option key={actor.id} value={actor.id}>
+                  {actor.displayName} ({actor.id})
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={!selectedAuthorizedActorId}
+              onClick={handleAddAuthorizedActor}
+            >
+              Add
+            </button>
+          </div>
+          {availableAuthorizedActors.length === 0 && (
+            <span className="empty-hint">No active actors available to authorize.</span>
+          )}
+          {staleUnauthorizedAssignees.length > 0 && (
+            <div className="settings-hint">
+              <div>Unauthorized task assignees</div>
+              {staleUnauthorizedAssignees.map((entry) => (
+                <div key={entry.taskId}>
+                  {entry.title}: {entry.assigneeNames.join(", ")}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 

--- a/packages/electron/src/renderer/views/SettingsView.test.tsx
+++ b/packages/electron/src/renderer/views/SettingsView.test.tsx
@@ -2,10 +2,11 @@
  * @vitest-environment jsdom
  */
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Actor } from "@todu/core/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsView } from "./SettingsView.js";
 
-describe("SettingsView app version", () => {
+describe("SettingsView", () => {
   const settingsGet = vi.fn();
   const settingsStoredProviders = vi.fn();
   const settingsProviders = vi.fn();
@@ -15,9 +16,21 @@ describe("SettingsView app version", () => {
   const syncStatus = vi.fn();
   const syncCatalogId = vi.fn();
   const setModel = vi.fn();
+  const actorList = vi.fn();
+  const actorCreate = vi.fn();
+  const actorRename = vi.fn();
+  const actorArchive = vi.fn();
+  const actorUnarchive = vi.fn();
+
+  let actorState: Actor[];
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    actorState = [
+      { id: "actor-user", displayName: "user" },
+      { id: "actor-reviewer", displayName: "Reviewer" },
+    ];
 
     settingsGet.mockResolvedValue({
       provider: "anthropic",
@@ -40,9 +53,44 @@ describe("SettingsView app version", () => {
     });
     syncCatalogId.mockResolvedValue("");
 
+    actorList.mockImplementation(async () => ({ ok: true, value: [...actorState] }));
+    actorCreate.mockImplementation(async (input: { id: string; displayName: string }) => {
+      const actor = { id: input.id, displayName: input.displayName.trim() };
+      actorState = [...actorState, actor];
+      return { ok: true, value: actor };
+    });
+    actorRename.mockImplementation(async (id: string, displayName: string) => {
+      actorState = actorState.map((actor) =>
+        actor.id === id ? { ...actor, displayName: displayName.trim() } : actor,
+      );
+      const actor = actorState.find((entry) => entry.id === id);
+      return { ok: true, value: actor };
+    });
+    actorArchive.mockImplementation(async (id: string) => {
+      actorState = actorState.map((actor) =>
+        actor.id === id ? { ...actor, archived: true } : actor,
+      );
+      const actor = actorState.find((entry) => entry.id === id);
+      return { ok: true, value: actor };
+    });
+    actorUnarchive.mockImplementation(async (id: string) => {
+      actorState = actorState.map((actor) =>
+        actor.id === id ? { id: actor.id, displayName: actor.displayName } : actor,
+      );
+      const actor = actorState.find((entry) => entry.id === id);
+      return { ok: true, value: actor };
+    });
+
     Object.defineProperty(window, "todu", {
       configurable: true,
       value: {
+        actor: {
+          list: actorList,
+          create: actorCreate,
+          rename: actorRename,
+          archive: actorArchive,
+          unarchive: actorUnarchive,
+        },
         settings: {
           get: settingsGet,
           save: settingsSave.mockResolvedValue(undefined),
@@ -114,5 +162,59 @@ describe("SettingsView app version", () => {
       });
     });
     expect(setModel).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-20250514");
+  });
+
+  it("manages actors from settings", async () => {
+    render(<SettingsView themePreference="system" onThemeChange={() => {}} />);
+
+    expect(await screen.findByText("Actors")).toBeDefined();
+    expect(screen.getByText("Reviewer")).toBeDefined();
+    expect(screen.getByText("ID: actor-reviewer")).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("New actor ID"), {
+      target: { value: "actor-bot" },
+    });
+    fireEvent.change(screen.getByLabelText("New actor display name"), {
+      target: { value: "Automation Bot" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(actorCreate).toHaveBeenCalledWith({
+        id: "actor-bot",
+        displayName: "Automation Bot",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Automation Bot")).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByLabelText("Actor name actor-reviewer"), {
+      target: { value: "Lead Reviewer" },
+    });
+    fireEvent.click(screen.getAllByText("Rename")[1]);
+
+    await waitFor(() => {
+      expect(actorRename).toHaveBeenCalledWith("actor-reviewer", "Lead Reviewer");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Lead Reviewer")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getAllByText("Archive")[1]);
+    await waitFor(() => {
+      expect(actorArchive).toHaveBeenCalledWith("actor-reviewer");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Archived")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Unarchive"));
+    await waitFor(() => {
+      expect(actorUnarchive).toHaveBeenCalledWith("actor-reviewer");
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Archived")).toBeNull();
+    });
   });
 });

--- a/packages/electron/src/renderer/views/SettingsView.tsx
+++ b/packages/electron/src/renderer/views/SettingsView.tsx
@@ -1,3 +1,4 @@
+import type { Actor } from "@todu/core/browser";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import type { ThemePreference } from "../hooks/useTheme.js";
 import type {
@@ -8,6 +9,35 @@ import type {
   SyncJoinResult,
   SyncStatus,
 } from "../types/window.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatToduError(error: unknown): string {
+  if (typeof error !== "object" || error === null || !("type" in error)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  const typedError = error as {
+    type: string;
+    entity?: string;
+    id?: string;
+    field?: string;
+    message?: string;
+  };
+
+  switch (typedError.type) {
+    case "not-found":
+      return `${typedError.entity ?? "entity"} not found: ${typedError.id ?? "unknown"}`;
+    case "validation":
+      return typedError.message ?? `Invalid ${typedError.field ?? "input"}`;
+    case "storage":
+      return typedError.message ?? "Storage error";
+    default:
+      return typedError.message ?? typedError.type;
+  }
+}
 
 // ============================================================================
 // Component
@@ -26,6 +56,12 @@ export function SettingsView({
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [appVersion, setAppVersion] = useState<string | null>(null);
+  const [actors, setActors] = useState<Actor[]>([]);
+  const [actorsLoading, setActorsLoading] = useState(true);
+  const [actorError, setActorError] = useState<string | null>(null);
+  const [newActorId, setNewActorId] = useState("");
+  const [newActorName, setNewActorName] = useState("");
+  const [actorDraftNames, setActorDraftNames] = useState<Record<string, string>>({});
 
   // API key input state — one per provider
   const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
@@ -69,6 +105,28 @@ export function SettingsView({
     });
   }, []);
 
+  const loadActors = useCallback(async () => {
+    setActorsLoading(true);
+
+    try {
+      const result = await window.todu.actor.list();
+      if (!result.ok) {
+        setActorError(formatToduError(result.error));
+        return;
+      }
+
+      setActorError(null);
+      setActors(result.value);
+      setActorDraftNames(
+        Object.fromEntries(result.value.map((actor) => [actor.id, actor.displayName])),
+      );
+    } catch (error) {
+      setActorError(formatToduError(error));
+    } finally {
+      setActorsLoading(false);
+    }
+  }, []);
+
   // Load sync status and catalog ID separately — isolated so a failure
   // here doesn't blank the whole settings page.
   useEffect(() => {
@@ -81,6 +139,10 @@ export function SettingsView({
         // Sync data unavailable — the Sync section simply won't render
       });
   }, []);
+
+  useEffect(() => {
+    void loadActors();
+  }, [loadActors]);
 
   // Load app version separately so a metadata lookup failure does not
   // affect the rest of the settings page.
@@ -205,6 +267,54 @@ export function SettingsView({
     }
   }, []);
 
+  const handleCreateActor = useCallback(async () => {
+    const id = newActorId.trim();
+    const displayName = newActorName.trim();
+    if (!id || !displayName) return;
+
+    const result = await window.todu.actor.create({ id, displayName });
+    if (!result.ok) {
+      setActorError(formatToduError(result.error));
+      return;
+    }
+
+    setNewActorId("");
+    setNewActorName("");
+    await loadActors();
+  }, [loadActors, newActorId, newActorName]);
+
+  const handleRenameActor = useCallback(
+    async (actorId: string) => {
+      const displayName = actorDraftNames[actorId]?.trim();
+      if (!displayName) return;
+
+      const result = await window.todu.actor.rename(actorId, displayName);
+      if (!result.ok) {
+        setActorError(formatToduError(result.error));
+        return;
+      }
+
+      await loadActors();
+    },
+    [actorDraftNames, loadActors],
+  );
+
+  const handleToggleActorArchive = useCallback(
+    async (actor: Actor) => {
+      const result = actor.archived
+        ? await window.todu.actor.unarchive(actor.id)
+        : await window.todu.actor.archive(actor.id);
+
+      if (!result.ok) {
+        setActorError(formatToduError(result.error));
+        return;
+      }
+
+      await loadActors();
+    },
+    [loadActors],
+  );
+
   // ── OAuth handlers ───────────────────────────────────────────────
 
   const handleOAuthLogin = useCallback(async (providerId: string) => {
@@ -303,6 +413,13 @@ export function SettingsView({
 
   // Providers that have a stored key or are currently selected
   const keyProviders = providers.filter((p) => storedKeys[p.id] || p.id === settings.provider);
+  const sortedActors = [...actors].sort((left, right) => {
+    if ((left.archived ?? false) !== (right.archived ?? false)) {
+      return Number(left.archived ?? false) - Number(right.archived ?? false);
+    }
+
+    return left.displayName.localeCompare(right.displayName) || left.id.localeCompare(right.id);
+  });
 
   return (
     <div className="view-container">
@@ -394,6 +511,98 @@ export function SettingsView({
             </span>
           )}
         </div>
+      </div>
+
+      {/* ── Actors ─────────────────────────────────────────────────── */}
+      <div className="settings-section">
+        <h3 className="section-title">Actors</h3>
+        <p className="settings-hint">
+          Manage catalog-wide actors and archived state. Actor IDs remain stable and archived actors
+          stay visible for historical context.
+        </p>
+
+        {actorError && <div className="settings-oauth-error">{actorError}</div>}
+
+        <div className="settings-key-row">
+          <div className="settings-key-header">
+            <span className="settings-key-label">Create actor</span>
+          </div>
+          <div className="settings-key-input-row">
+            <input
+              aria-label="New actor ID"
+              type="text"
+              className="input settings-key-input"
+              placeholder="actor-reviewer"
+              value={newActorId}
+              onChange={(e) => setNewActorId(e.target.value)}
+            />
+            <input
+              aria-label="New actor display name"
+              type="text"
+              className="input settings-key-input"
+              placeholder="Reviewer"
+              value={newActorName}
+              onChange={(e) => setNewActorName(e.target.value)}
+            />
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={!newActorId.trim() || !newActorName.trim()}
+              onClick={() => void handleCreateActor()}
+            >
+              Create
+            </button>
+          </div>
+        </div>
+
+        {actorsLoading ? (
+          <div className="loading-state">Loading actors...</div>
+        ) : (
+          sortedActors.map((actor) => {
+            const draftName = actorDraftNames[actor.id] ?? actor.displayName;
+            const renameDisabled = !draftName.trim() || draftName.trim() === actor.displayName;
+
+            return (
+              <div key={actor.id} className="settings-key-row">
+                <div className="settings-key-header">
+                  <span className="settings-key-label">{actor.displayName}</span>
+                  <span
+                    className={`settings-key-status ${actor.archived ? "settings-key-missing" : "settings-key-stored"}`}
+                  >
+                    {actor.archived ? "Archived" : "Active"}
+                  </span>
+                </div>
+                <p className="settings-hint">ID: {actor.id}</p>
+                <div className="settings-key-input-row">
+                  <input
+                    aria-label={`Actor name ${actor.id}`}
+                    type="text"
+                    className="input settings-key-input"
+                    value={draftName}
+                    onChange={(e) =>
+                      setActorDraftNames((prev) => ({ ...prev, [actor.id]: e.target.value }))
+                    }
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    disabled={renameDisabled}
+                    onClick={() => void handleRenameActor(actor.id)}
+                  >
+                    Rename
+                  </button>
+                  <button
+                    type="button"
+                    className={`btn btn-sm ${actor.archived ? "btn-primary" : "btn-danger"}`}
+                    onClick={() => void handleToggleActorArchive(actor)}
+                  >
+                    {actor.archived ? "Unarchive" : "Archive"}
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
       </div>
 
       {/* ── Subscriptions ───────────────────────────────────────────── */}

--- a/packages/electron/src/renderer/views/TaskDetail.tsx
+++ b/packages/electron/src/renderer/views/TaskDetail.tsx
@@ -144,7 +144,10 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
     moveTask.mutate({ id: task.id as TaskId, projectId: createProjectId(projectId) });
   };
 
-  const assigneeNames = getActorNames(task.assigneeActorIds, actorMap, task.assignees);
+  const currentProject = projects?.find((project) => project.id === task.projectId);
+  const assigneeNames = getActorNames(task.assigneeActorIds, actorMap, task.assignees, {
+    authorizedActorIds: currentProject?.authorizedAssigneeActorIds,
+  });
   const descriptionApprovalLabel = getApprovalLabel(task.descriptionApproval);
 
   return (


### PR DESCRIPTION
## Summary
- add a lightweight Settings-based actor management surface in Electron
- add project authorized-assignee editing plus stale unauthorized assignee visibility in project/task views
- extend Electron daemon client/preload/IPC coverage and add user-facing docs

## Checks
- npm run --workspace=packages/electron build
- make pre-pr

Task: #task-5e966abe