### PR TITLE
feat: add Electron task assignee management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make dev-electron
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - Dependency maintenance: [docs/dependency-maintenance.md](docs/dependency-maintenance.md)
 - Daemon CLI behavior: [docs/cli-daemon-usage.md](docs/cli-daemon-usage.md)
-- Electron actor and project authorization management: [docs/electron-actor-project-auth.md](docs/electron-actor-project-auth.md)
+- Electron multi-user management: [docs/electron-actor-project-auth.md](docs/electron-actor-project-auth.md)
 
 ## License
 

--- a/docs/electron-actor-project-auth.md
+++ b/docs/electron-actor-project-auth.md
@@ -1,4 +1,4 @@
-# Electron actor and project authorization management
+# Electron multi-user actor, project authorization, and task assignee management
 
 The Electron app includes lightweight multi-user management surfaces backed by the local daemon.
 
@@ -32,3 +32,20 @@ Behavior notes:
 - existing stale or unauthorized assignees remain visible instead of being silently removed
 - task detail views also mark archived or unauthorized assignees clearly
 - all actions go through daemon-backed core actor and project APIs
+
+## Task assignees
+
+Open any task detail view and use the **Assignees** section to manage `assigneeActorIds`.
+
+Supported actions:
+- inspect current task assignees with actor IDs and archived/unauthorized markers
+- add an assignee from the current project's authorized active actors
+- remove an existing assignee
+- replace one assignee with another authorized active actor without typing raw IDs
+- review clear empty states when a project has no currently authorized active actors available for new assignment
+
+Behavior notes:
+- multi-actor assignment is supported directly in the shipped UI
+- new assignment choices are limited to non-archived actors authorized for the task's current project
+- when a task moves between projects, the available assignee choices refresh to match the new project's authorization list
+- existing archived or unauthorized assignees remain visible until the user removes or replaces them

--- a/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
+++ b/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
+import type { Actor, Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as hooks from "../hooks/useTodu.js";
 import { NoteList } from "./NoteList.js";
@@ -112,105 +112,234 @@ function makeNote(overrides: Partial<Note> = {}): Note {
   };
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
+describe("actor-aware renderer views", () => {
+  const deleteNoteMutate = vi.fn();
+  const deleteProjectMutate = vi.fn();
+  const deleteTaskMutate = vi.fn();
+  const moveTaskMutate = vi.fn();
+  const updateProjectMutate = vi.fn();
+  const updateTaskMutate = vi.fn();
 
-  Object.defineProperty(window, "todu", {
-    configurable: true,
-    value: {
-      agent: {
-        focusEntity: vi.fn().mockResolvedValue(undefined),
-        clearFocusedEntity: vi.fn().mockResolvedValue(undefined),
-      },
-    },
-  });
+  let actorsData: Actor[];
+  let notesData: Note[];
+  let projectData: Project;
+  let projectsData: Project[];
+  let taskData: TaskWithDetail;
+  let tasksData: Task[];
 
-  vi.mocked(hooks.useActors).mockReturnValue({
-    data: [
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    actorsData = [
       { id: "actor-user", displayName: "user" },
       { id: "actor-reviewer", displayName: "Reviewer", archived: true },
       { id: "actor-collab", displayName: "Collaborator" },
-    ],
-  } as ReturnType<typeof hooks.useActors>);
+    ];
+    projectData = makeProject();
+    projectsData = [
+      projectData,
+      makeProject({
+        id: "proj-2" as Project["id"],
+        name: "Ops",
+        authorizedAssigneeActorIds: ["actor-collab"] as Project["authorizedAssigneeActorIds"],
+      }),
+    ];
+    taskData = makeTask();
+    tasksData = [taskData];
+    notesData = [makeNote()];
 
-  vi.mocked(hooks.useProjects).mockReturnValue({
-    data: [makeProject()],
-  } as ReturnType<typeof hooks.useProjects>);
+    Object.defineProperty(window, "todu", {
+      configurable: true,
+      value: {
+        agent: {
+          focusEntity: vi.fn().mockResolvedValue(undefined),
+          clearFocusedEntity: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
 
-  vi.mocked(hooks.useTask).mockReturnValue({
-    data: makeTask(),
-    isLoading: false,
-    isError: false,
-    error: null,
-  } as ReturnType<typeof hooks.useTask>);
+    vi.mocked(hooks.useActors).mockImplementation(
+      () => ({ data: actorsData }) as ReturnType<typeof hooks.useActors>,
+    );
 
-  vi.mocked(hooks.useUpdateTask).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useUpdateTask>);
+    vi.mocked(hooks.useProjects).mockImplementation(
+      () => ({ data: projectsData }) as ReturnType<typeof hooks.useProjects>,
+    );
 
-  vi.mocked(hooks.useDeleteTask).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useDeleteTask>);
+    vi.mocked(hooks.useTask).mockImplementation(
+      () =>
+        ({
+          data: taskData,
+          isLoading: false,
+          isError: false,
+          error: null,
+        }) as ReturnType<typeof hooks.useTask>,
+    );
 
-  vi.mocked(hooks.useMoveTask).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useMoveTask>);
+    vi.mocked(hooks.useUpdateTask).mockReturnValue({
+      mutate: updateTaskMutate,
+    } as ReturnType<typeof hooks.useUpdateTask>);
 
-  vi.mocked(hooks.useProject).mockReturnValue({
-    data: makeProject(),
-    isLoading: false,
-    isError: false,
-    error: null,
-  } as ReturnType<typeof hooks.useProject>);
+    vi.mocked(hooks.useDeleteTask).mockReturnValue({
+      mutate: deleteTaskMutate,
+    } as ReturnType<typeof hooks.useDeleteTask>);
 
-  vi.mocked(hooks.useUpdateProject).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useUpdateProject>);
+    vi.mocked(hooks.useMoveTask).mockReturnValue({
+      mutate: moveTaskMutate,
+    } as ReturnType<typeof hooks.useMoveTask>);
 
-  vi.mocked(hooks.useDeleteProject).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useDeleteProject>);
+    vi.mocked(hooks.useProject).mockImplementation(
+      () =>
+        ({
+          data: projectData,
+          isLoading: false,
+          isError: false,
+          error: null,
+        }) as ReturnType<typeof hooks.useProject>,
+    );
 
-  vi.mocked(hooks.useTasks).mockReturnValue({
-    data: [makeTask()],
-  } as ReturnType<typeof hooks.useTasks>);
+    vi.mocked(hooks.useUpdateProject).mockReturnValue({
+      mutate: updateProjectMutate,
+    } as ReturnType<typeof hooks.useUpdateProject>);
 
-  vi.mocked(hooks.useSearchTasks).mockReturnValue({
-    data: [],
-  } as ReturnType<typeof hooks.useSearchTasks>);
+    vi.mocked(hooks.useDeleteProject).mockReturnValue({
+      mutate: deleteProjectMutate,
+    } as ReturnType<typeof hooks.useDeleteProject>);
 
-  vi.mocked(hooks.useNotes).mockReturnValue({
-    data: [makeNote()],
-    isLoading: false,
-    isError: false,
-    error: null,
-  } as ReturnType<typeof hooks.useNotes>);
+    vi.mocked(hooks.useTasks).mockImplementation(
+      () => ({ data: tasksData }) as ReturnType<typeof hooks.useTasks>,
+    );
 
-  vi.mocked(hooks.useDeleteNote).mockReturnValue({
-    mutate: vi.fn(),
-  } as ReturnType<typeof hooks.useDeleteNote>);
-});
+    vi.mocked(hooks.useSearchTasks).mockReturnValue({
+      data: [],
+    } as ReturnType<typeof hooks.useSearchTasks>);
 
-afterEach(() => {
-  cleanup();
-});
+    vi.mocked(hooks.useNotes).mockImplementation(
+      () =>
+        ({
+          data: notesData,
+          isLoading: false,
+          isError: false,
+          error: null,
+        }) as ReturnType<typeof hooks.useNotes>,
+    );
 
-describe("actor-aware renderer views", () => {
+    vi.mocked(hooks.useDeleteNote).mockReturnValue({
+      mutate: deleteNoteMutate,
+    } as ReturnType<typeof hooks.useDeleteNote>);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("shows archived and unauthorized actor assignees plus approval state in task detail", async () => {
     render(<TaskDetail taskId="task-1" onBack={() => {}} />);
 
     expect(screen.getByText("Assignees")).toBeDefined();
-    expect(screen.getByText("user")).toBeDefined();
-    expect(screen.getByText("Reviewer (archived, unauthorized)")).toBeDefined();
+    expect(screen.getByText("user (actor-user)")).toBeDefined();
+    expect(screen.getByText("Reviewer (actor-reviewer, archived, unauthorized)")).toBeDefined();
     expect(screen.getByText("Approval needed")).toBeDefined();
+    expect(screen.getByText("All authorized active actors are already assigned.")).toBeDefined();
+  });
+
+  it("adds actor assignees from the current project's authorized active actors", async () => {
+    projectData = makeProject({
+      authorizedAssigneeActorIds: [
+        "actor-user",
+        "actor-reviewer",
+        "actor-collab",
+      ] as Project["authorizedAssigneeActorIds"],
+    });
+    projectsData = [projectData, projectsData[1]];
+    taskData = makeTask({
+      assigneeActorIds: ["actor-user"] as Task["assigneeActorIds"],
+    });
+    tasksData = [taskData];
+
+    render(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Add assignee actor"), {
+      target: { value: "actor-collab" },
+    });
+    fireEvent.click(screen.getByText("Add"));
+
+    expect(updateTaskMutate).toHaveBeenCalledWith({
+      id: "task-1",
+      input: {
+        assigneeActorIds: ["actor-user", "actor-collab"],
+      },
+    });
+  });
+
+  it("removes and replaces actor assignees without raw id editing", async () => {
+    projectData = makeProject({
+      authorizedAssigneeActorIds: [
+        "actor-user",
+        "actor-collab",
+      ] as Project["authorizedAssigneeActorIds"],
+    });
+    projectsData = [projectData, projectsData[1]];
+
+    render(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Replace assignee actor-reviewer"), {
+      target: { value: "actor-collab" },
+    });
+    fireEvent.click(screen.getAllByText("Replace")[1]);
+
+    expect(updateTaskMutate).toHaveBeenCalledWith({
+      id: "task-1",
+      input: {
+        assigneeActorIds: ["actor-user", "actor-collab"],
+      },
+    });
+
+    fireEvent.click(screen.getAllByText("Remove")[0]);
+
+    expect(updateTaskMutate).toHaveBeenLastCalledWith({
+      id: "task-1",
+      input: {
+        assigneeActorIds: ["actor-reviewer"],
+      },
+    });
+  });
+
+  it("updates project-change behavior and shows a no-authorized-actors state", async () => {
+    const { rerender } = render(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    fireEvent.change(screen.getByDisplayValue("Inbox"), {
+      target: { value: "proj-2" },
+    });
+
+    expect(moveTaskMutate).toHaveBeenCalledWith({
+      id: "task-1",
+      projectId: "proj-2",
+    });
+
+    taskData = makeTask({
+      projectId: "proj-2" as TaskWithDetail["projectId"],
+      assigneeActorIds: ["actor-reviewer"] as Task["assigneeActorIds"],
+    });
+    tasksData = [taskData];
+    projectsData = [
+      projectsData[0],
+      makeProject({
+        id: "proj-2" as Project["id"],
+        name: "Ops",
+        authorizedAssigneeActorIds: [] as Project["authorizedAssigneeActorIds"],
+      }),
+    ];
+
+    rerender(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    expect(screen.getByText("Reviewer (actor-reviewer, archived, unauthorized)")).toBeDefined();
+    expect(
+      screen.getByText("No authorized active actors available for this project."),
+    ).toBeDefined();
   });
 
   it("shows project authorization controls and stale unauthorized assignees", async () => {
-    const mutate = vi.fn();
-    vi.mocked(hooks.useUpdateProject).mockReturnValue({
-      mutate,
-    } as ReturnType<typeof hooks.useUpdateProject>);
-
     render(
       <ProjectDetail
         projectId="proj-1"
@@ -232,7 +361,7 @@ describe("actor-aware renderer views", () => {
     });
     fireEvent.click(screen.getByText("Add"));
 
-    expect(mutate).toHaveBeenCalledWith({
+    expect(updateProjectMutate).toHaveBeenCalledWith({
       id: "proj-1",
       input: {
         authorizedAssigneeActorIds: ["actor-user", "actor-collab"],
@@ -241,7 +370,7 @@ describe("actor-aware renderer views", () => {
 
     fireEvent.click(screen.getByText("Remove"));
 
-    expect(mutate).toHaveBeenLastCalledWith({
+    expect(updateProjectMutate).toHaveBeenLastCalledWith({
       id: "proj-1",
       input: {
         authorizedAssigneeActorIds: [],

--- a/packages/electron/src/renderer/views/TaskDetail.tsx
+++ b/packages/electron/src/renderer/views/TaskDetail.tsx
@@ -20,7 +20,7 @@ import {
   useTask,
   useUpdateTask,
 } from "../hooks/useTodu.js";
-import { createActorMap, getActorNames, getApprovalLabel } from "../lib/actors.js";
+import { createActorMap, getActorName, getActorNames, getApprovalLabel } from "../lib/actors.js";
 
 // ============================================================================
 // Status Shortcuts
@@ -93,6 +93,10 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   const [titleValue, setTitleValue] = useState("");
   const [editingDescription, setEditingDescription] = useState(false);
   const [activeTab, setActiveTab] = useState("description");
+  const [selectedAssigneeActorId, setSelectedAssigneeActorId] = useState("");
+  const [replacementAssigneeActorIds, setReplacementAssigneeActorIds] = useState<
+    Record<string, string>
+  >({});
   const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   if (isLoading) {
@@ -145,10 +149,73 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   };
 
   const currentProject = projects?.find((project) => project.id === task.projectId);
-  const assigneeNames = getActorNames(task.assigneeActorIds, actorMap, task.assignees, {
-    authorizedActorIds: currentProject?.authorizedAssigneeActorIds,
-  });
+  const authorizedActorIds = currentProject?.authorizedAssigneeActorIds ?? [];
+  const activeAuthorizedActors = (actors ?? []).filter(
+    (actor) => !actor.archived && authorizedActorIds.includes(actor.id),
+  );
+  const addableAssigneeActors = activeAuthorizedActors.filter(
+    (actor) => !task.assigneeActorIds.includes(actor.id),
+  );
+  const assigneeEntries = task.assigneeActorIds.map((actorId) => ({
+    actorId,
+    label: getActorName(actorId, actorMap, undefined, {
+      includeId: true,
+      authorizedActorIds,
+    }),
+    replacementOptions: addableAssigneeActors,
+  }));
+  const legacyAssigneeNames =
+    task.assigneeActorIds.length === 0
+      ? getActorNames(task.assigneeActorIds, actorMap, task.assignees, {
+          authorizedActorIds,
+        })
+      : [];
   const descriptionApprovalLabel = getApprovalLabel(task.descriptionApproval);
+  const validatedSelectedAssigneeActorId = addableAssigneeActors.some(
+    (actor) => actor.id === selectedAssigneeActorId,
+  )
+    ? selectedAssigneeActorId
+    : "";
+
+  const updateAssignees = (assigneeActorIds: string[]) => {
+    updateTask.mutate({
+      id: task.id as TaskId,
+      input: { assigneeActorIds },
+    });
+  };
+
+  const handleAddAssignee = () => {
+    if (!validatedSelectedAssigneeActorId) return;
+
+    updateAssignees([...task.assigneeActorIds, validatedSelectedAssigneeActorId]);
+    setSelectedAssigneeActorId("");
+  };
+
+  const handleRemoveAssignee = (actorId: string) => {
+    updateAssignees(task.assigneeActorIds.filter((currentActorId) => currentActorId !== actorId));
+    setReplacementAssigneeActorIds((prev) => {
+      const next = { ...prev };
+      delete next[actorId];
+      return next;
+    });
+  };
+
+  const handleReplaceAssignee = (actorId: string) => {
+    const replacementActorId = replacementAssigneeActorIds[actorId];
+    const validatedReplacementActorId = addableAssigneeActors.some(
+      (actor) => actor.id === replacementActorId,
+    )
+      ? replacementActorId
+      : "";
+    if (!validatedReplacementActorId) return;
+
+    updateAssignees(
+      task.assigneeActorIds.map((currentActorId) =>
+        currentActorId === actorId ? validatedReplacementActorId : currentActorId,
+      ),
+    );
+    setReplacementAssigneeActorIds((prev) => ({ ...prev, [actorId]: "" }));
+  };
 
   return (
     <div className="view-container">
@@ -268,17 +335,105 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
       <div className="detail-meta-row">
         <div className="detail-meta-cell detail-meta-cell-wide">
           <span className="detail-meta-label">Assignees</span>
-          <div className="label-chips">
-            {assigneeNames.length > 0 ? (
-              assigneeNames.map((assignee) => (
+
+          {assigneeEntries.length > 0 ? (
+            assigneeEntries.map((entry) => (
+              <div key={entry.actorId} className="settings-key-row">
+                <div className="settings-key-header">
+                  <span className="settings-key-label">{entry.label}</span>
+                </div>
+                <div className="settings-key-input-row">
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => handleRemoveAssignee(entry.actorId)}
+                  >
+                    Remove
+                  </button>
+                  <select
+                    aria-label={`Replace assignee ${entry.actorId}`}
+                    className="input inline-select"
+                    value={
+                      entry.replacementOptions.some(
+                        (actor) => actor.id === replacementAssigneeActorIds[entry.actorId],
+                      )
+                        ? (replacementAssigneeActorIds[entry.actorId] ?? "")
+                        : ""
+                    }
+                    onChange={(e) =>
+                      setReplacementAssigneeActorIds((prev) => ({
+                        ...prev,
+                        [entry.actorId]: e.target.value,
+                      }))
+                    }
+                  >
+                    <option value="">Replace with…</option>
+                    {entry.replacementOptions.map((actor) => (
+                      <option key={actor.id} value={actor.id}>
+                        {actor.displayName} ({actor.id})
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    disabled={
+                      !entry.replacementOptions.some(
+                        (actor) => actor.id === replacementAssigneeActorIds[entry.actorId],
+                      )
+                    }
+                    onClick={() => handleReplaceAssignee(entry.actorId)}
+                  >
+                    Replace
+                  </button>
+                </div>
+              </div>
+            ))
+          ) : legacyAssigneeNames.length > 0 ? (
+            <div className="label-chips">
+              {legacyAssigneeNames.map((assignee) => (
                 <span key={assignee} className="chip chip-label">
                   {assignee}
                 </span>
-              ))
-            ) : (
-              <span className="empty-hint">None</span>
-            )}
+              ))}
+            </div>
+          ) : (
+            <span className="empty-hint">None</span>
+          )}
+
+          <div className="settings-key-input-row">
+            <select
+              aria-label="Add assignee actor"
+              className="input inline-select"
+              value={validatedSelectedAssigneeActorId}
+              onChange={(e) => setSelectedAssigneeActorId(e.target.value)}
+            >
+              <option value="">Add assignee…</option>
+              {addableAssigneeActors.map((actor) => (
+                <option key={actor.id} value={actor.id}>
+                  {actor.displayName} ({actor.id})
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={!validatedSelectedAssigneeActorId}
+              onClick={handleAddAssignee}
+            >
+              Add
+            </button>
           </div>
+
+          {!currentProject ? (
+            <span className="empty-hint">Task project is unavailable.</span>
+          ) : activeAuthorizedActors.length === 0 ? (
+            <span className="empty-hint">
+              No authorized active actors available for this project.
+            </span>
+          ) : addableAssigneeActors.length === 0 ? (
+            <span className="empty-hint">All authorized active actors are already assigned.</span>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add daemon-backed task assignee editing controls in Electron task detail views
- keep archived or unauthorized assignees visible while limiting new choices to authorized active actors
- update Electron multi-user docs and add renderer coverage for add/remove/replace and project-change states

## Checks
- npx vitest run packages/electron/src/renderer/views/ActorAwareViews.test.tsx
- npm run --workspace=packages/electron build
- make pre-pr

Task: #task-cba33fce