### PR TITLE
feat: add Electron approval actions and views

### DIFF
--- a/docs/electron-actor-project-auth.md
+++ b/docs/electron-actor-project-auth.md
@@ -1,4 +1,4 @@
-# Electron multi-user actor, project authorization, and task assignee management
+# Electron multi-user actor, project authorization, task assignee, and approval management
 
 The Electron app includes lightweight multi-user management surfaces backed by the local daemon.
 
@@ -49,3 +49,20 @@ Behavior notes:
 - new assignment choices are limited to non-archived actors authorized for the task's current project
 - when a task moves between projects, the available assignee choices refresh to match the new project's authorization list
 - existing archived or unauthorized assignees remain visible until the user removes or replaces them
+
+## Imported content approvals
+
+Open **Notes** to review the **Approval Needed** section for pending imported task descriptions and note/comment content.
+
+Supported actions:
+- discover all currently pending approvals in one visible list
+- open the related task or note/comment context from that list
+- explicitly approve imported task descriptions
+- explicitly approve imported note/comment content from the approval list, note rows, and comment threads
+
+Behavior notes:
+- approval actions are explicit; editing does not implicitly approve imported content
+- task detail views show an approve action for pending imported descriptions
+- note list rows and comment threads show approve actions for pending imported note/comment content
+- approval actions use daemon-backed core approval APIs and refresh task/note views after success
+- already-approved or invalid approval actions surface visible errors instead of silently doing nothing

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -59,6 +59,49 @@ describe("createDaemonToduClient", () => {
     });
   });
 
+  it("routes approval methods to daemon RPC and preserves Result shape", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [{ kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { kind: "noteContent", noteId: "note-1", contentPreview: "Imported note" },
+      });
+
+    const client = createDaemonToduClient({ request });
+
+    const listResult = await client.approval.list();
+    const taskResult = await client.approval.approveTaskDescription("task-1");
+    const noteResult = await client.approval.approveNoteContent("note-1");
+
+    expect(request).toHaveBeenNthCalledWith(1, "approval.list", { filter: undefined });
+    expect(request).toHaveBeenNthCalledWith(2, "approval.approveTaskDescription", {
+      id: "task-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "approval.approveNoteContent", {
+      id: "note-1",
+    });
+    expect(listResult).toEqual({
+      ok: true,
+      value: [{ kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" }],
+    });
+    expect(taskResult).toEqual({
+      ok: true,
+      value: { kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" },
+    });
+    expect(noteResult).toEqual({
+      ok: true,
+      value: { kind: "noteContent", noteId: "note-1", contentPreview: "Imported note" },
+    });
+  });
+
   it("maps daemon NOT_FOUND errors to not-found ToduError", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -83,10 +83,10 @@ describe("createDaemonToduClient", () => {
 
     expect(request).toHaveBeenNthCalledWith(1, "approval.list", { filter: undefined });
     expect(request).toHaveBeenNthCalledWith(2, "approval.approveTaskDescription", {
-      id: "task-1",
+      taskId: "task-1",
     });
     expect(request).toHaveBeenNthCalledWith(3, "approval.approveNoteContent", {
-      id: "note-1",
+      noteId: "note-1",
     });
     expect(listResult).toEqual({
       ok: true,

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -25,6 +25,11 @@ interface DaemonBackedToduMethods {
     move(id: string, projectId: string): Promise<Result<unknown, ToduError>>;
     search(query: string): Promise<Result<unknown, ToduError>>;
   };
+  approval: {
+    list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    approveTaskDescription(taskId: string): Promise<Result<unknown, ToduError>>;
+    approveNoteContent(noteId: string): Promise<Result<unknown, ToduError>>;
+  };
   label: {
     list(): Promise<Result<unknown, ToduError>>;
     create(input: unknown): Promise<Result<unknown, ToduError>>;
@@ -72,6 +77,11 @@ export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "re
       update: (id, input) => invoke("task.update", { id, input }),
       move: (id, projectId) => invoke("task.move", { id, projectId }),
       search: (query) => invoke("task.search", { query }),
+    },
+    approval: {
+      list: (filter) => invoke("approval.list", { filter }),
+      approveTaskDescription: (taskId) => invoke("approval.approveTaskDescription", { id: taskId }),
+      approveNoteContent: (noteId) => invoke("approval.approveNoteContent", { id: noteId }),
     },
     label: {
       list: () => invoke("label.list", {}),

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -80,8 +80,8 @@ export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "re
     },
     approval: {
       list: (filter) => invoke("approval.list", { filter }),
-      approveTaskDescription: (taskId) => invoke("approval.approveTaskDescription", { id: taskId }),
-      approveNoteContent: (noteId) => invoke("approval.approveNoteContent", { id: noteId }),
+      approveTaskDescription: (taskId) => invoke("approval.approveTaskDescription", { taskId }),
+      approveNoteContent: (noteId) => invoke("approval.approveNoteContent", { noteId }),
     },
     label: {
       list: () => invoke("label.list", {}),

--- a/packages/electron/src/main/ipc.integration.test.ts
+++ b/packages/electron/src/main/ipc.integration.test.ts
@@ -98,10 +98,10 @@ describe("createDaemonIpcHandlers", () => {
 
     expect(daemon.request).toHaveBeenNthCalledWith(1, "approval.list", { filter: undefined });
     expect(daemon.request).toHaveBeenNthCalledWith(2, "approval.approveTaskDescription", {
-      id: "task-1",
+      taskId: "task-1",
     });
     expect(daemon.request).toHaveBeenNthCalledWith(3, "approval.approveNoteContent", {
-      id: "note-1",
+      noteId: "note-1",
     });
     expect(listResult).toEqual({
       ok: true,

--- a/packages/electron/src/main/ipc.integration.test.ts
+++ b/packages/electron/src/main/ipc.integration.test.ts
@@ -66,6 +66,57 @@ describe("createDaemonIpcHandlers", () => {
     });
   });
 
+  it("routes approval IPC handlers to daemon RPC and preserves Result contract", async () => {
+    const daemon = {
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          value: [{ kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" }],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          value: { kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          value: { kind: "noteContent", noteId: "note-1", contentPreview: "Imported note" },
+        }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+    });
+
+    const listResult = await handlers["todu:approval:list"](undefined);
+    const taskResult = await handlers["todu:approval:approve-task-description"](
+      undefined,
+      "task-1",
+    );
+    const noteResult = await handlers["todu:approval:approve-note-content"](undefined, "note-1");
+
+    expect(daemon.request).toHaveBeenNthCalledWith(1, "approval.list", { filter: undefined });
+    expect(daemon.request).toHaveBeenNthCalledWith(2, "approval.approveTaskDescription", {
+      id: "task-1",
+    });
+    expect(daemon.request).toHaveBeenNthCalledWith(3, "approval.approveNoteContent", {
+      id: "note-1",
+    });
+    expect(listResult).toEqual({
+      ok: true,
+      value: [{ kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" }],
+    });
+    expect(taskResult).toEqual({
+      ok: true,
+      value: { kind: "taskDescription", taskId: "task-1", contentPreview: "Imported task" },
+    });
+    expect(noteResult).toEqual({
+      ok: true,
+      value: { kind: "noteContent", noteId: "note-1", contentPreview: "Imported note" },
+    });
+  });
+
   it("maps daemon NOT_FOUND errors to renderer-consumable not-found Result errors", async () => {
     const daemon = {
       request: vi.fn().mockResolvedValue({

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -62,9 +62,9 @@ export function createDaemonIpcHandlers(
     // ── Approval ──────────────────────────────────────────────────────────
     "todu:approval:list": (_event, filter) => invokeResult("approval.list", { filter }),
     "todu:approval:approve-task-description": (_event, taskId) =>
-      invokeResult("approval.approveTaskDescription", { id: taskId }),
+      invokeResult("approval.approveTaskDescription", { taskId }),
     "todu:approval:approve-note-content": (_event, noteId) =>
-      invokeResult("approval.approveNoteContent", { id: noteId }),
+      invokeResult("approval.approveNoteContent", { noteId }),
 
     // ── Label ─────────────────────────────────────────────────────────────
     "todu:label:list": () => invokeResult("label.list"),

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -59,6 +59,13 @@ export function createDaemonIpcHandlers(
     "todu:task:move": (_event, id, projectId) => invokeResult("task.move", { id, projectId }),
     "todu:task:search": (_event, query) => invokeResult("task.search", { query }),
 
+    // ── Approval ──────────────────────────────────────────────────────────
+    "todu:approval:list": (_event, filter) => invokeResult("approval.list", { filter }),
+    "todu:approval:approve-task-description": (_event, taskId) =>
+      invokeResult("approval.approveTaskDescription", { id: taskId }),
+    "todu:approval:approve-note-content": (_event, noteId) =>
+      invokeResult("approval.approveNoteContent", { id: noteId }),
+
     // ── Label ─────────────────────────────────────────────────────────────
     "todu:label:list": () => invokeResult("label.list"),
     "todu:label:create": (_event, input) => invokeResult("label.create", { input }),

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -37,6 +37,15 @@ const api = {
     search: (query: string) => ipcRenderer.invoke("todu:task:search", query),
   },
 
+  // ── Approval ───────────────────────────────────────────────────────
+  approval: {
+    list: (filter?: unknown) => ipcRenderer.invoke("todu:approval:list", filter),
+    approveTaskDescription: (taskId: string) =>
+      ipcRenderer.invoke("todu:approval:approve-task-description", taskId),
+    approveNoteContent: (noteId: string) =>
+      ipcRenderer.invoke("todu:approval:approve-note-content", noteId),
+  },
+
   // ── Label ──────────────────────────────────────────────────────────
   label: {
     list: () => ipcRenderer.invoke("todu:label:list"),

--- a/packages/electron/src/renderer/components/CommentThread.test.tsx
+++ b/packages/electron/src/renderer/components/CommentThread.test.tsx
@@ -9,6 +9,7 @@ import { CommentThread } from "./CommentThread.js";
 
 vi.mock("../hooks/useTodu.js", () => ({
   useActors: vi.fn(),
+  useApproveNoteContent: vi.fn(),
   useCreateNote: vi.fn(),
   useDeleteNote: vi.fn(),
   useNotes: vi.fn(),
@@ -29,6 +30,7 @@ function makeNote(overrides: Partial<Note> = {}): Note {
   };
 }
 
+const approveNoteContentMutate = vi.fn();
 const createNoteMutate = vi.fn();
 const deleteNoteMutate = vi.fn();
 
@@ -43,6 +45,11 @@ beforeEach(() => {
     data: [makeNote()],
     isLoading: false,
   } as ReturnType<typeof hooks.useNotes>);
+
+  vi.mocked(hooks.useApproveNoteContent).mockReturnValue({
+    mutate: approveNoteContentMutate,
+    isPending: false,
+  } as ReturnType<typeof hooks.useApproveNoteContent>);
 
   vi.mocked(hooks.useCreateNote).mockReturnValue({
     mutate: createNoteMutate,
@@ -65,6 +72,27 @@ describe("CommentThread", () => {
     expect(screen.getByText("Reviewer")).toBeDefined();
     expect(screen.getByText("Approved import")).toBeDefined();
     expect(screen.getByText("Imported comment")).toBeDefined();
+  });
+
+  it("shows explicit approve actions for pending imported comments", async () => {
+    vi.mocked(hooks.useNotes).mockReturnValue({
+      data: [makeNote({ contentApproval: { state: "pendingApproval" } })],
+      isLoading: false,
+    } as ReturnType<typeof hooks.useNotes>);
+
+    render(<CommentThread entityType="task" entityId="task-1" />);
+
+    fireEvent.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(approveNoteContentMutate).toHaveBeenCalledWith(
+        "note-1",
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        }),
+      );
+    });
   });
 
   it("creates comments without legacy author strings", async () => {

--- a/packages/electron/src/renderer/components/CommentThread.tsx
+++ b/packages/electron/src/renderer/components/CommentThread.tsx
@@ -1,5 +1,11 @@
 import { type ReactNode, useMemo, useState } from "react";
-import { useActors, useCreateNote, useDeleteNote, useNotes } from "../hooks/useTodu.js";
+import {
+  useActors,
+  useApproveNoteContent,
+  useCreateNote,
+  useDeleteNote,
+  useNotes,
+} from "../hooks/useTodu.js";
 import { createActorMap, getActorName, getApprovalLabel } from "../lib/actors.js";
 
 export function CommentThread({
@@ -13,7 +19,9 @@ export function CommentThread({
   const { data: actors } = useActors();
   const createNote = useCreateNote();
   const deleteNote = useDeleteNote();
+  const approveNoteContent = useApproveNoteContent();
   const [newComment, setNewComment] = useState("");
+  const [approvalMessage, setApprovalMessage] = useState("");
   const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   const handleSubmit = () => {
@@ -27,6 +35,7 @@ export function CommentThread({
   return (
     <div className="comment-thread">
       <h3 className="section-title">Comments</h3>
+      {approvalMessage && <div className="settings-hint">{approvalMessage}</div>}
       {isLoading && <div className="loading-state">Loading comments…</div>}
       {notes && notes.length === 0 && <div className="empty-hint">No comments yet</div>}
       {notes?.map((note) => {
@@ -38,6 +47,24 @@ export function CommentThread({
                 {getActorName(note.authorActorId, actorMap, note.author)}
               </span>
               {approvalLabel && <span className="chip chip-label">{approvalLabel}</span>}
+              {note.contentApproval?.state === "pendingApproval" && (
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  onClick={() =>
+                    approveNoteContent.mutate(note.id, {
+                      onSuccess: () => setApprovalMessage("Comment approved."),
+                      onError: (err) =>
+                        setApprovalMessage(
+                          err instanceof Error ? err.message : "Failed to approve comment",
+                        ),
+                    })
+                  }
+                  disabled={approveNoteContent.isPending}
+                >
+                  {approveNoteContent.isPending ? "Approving…" : "Approve"}
+                </button>
+              )}
               <span className="comment-date">{note.createdAt.slice(0, 16).replace("T", " ")}</span>
               <button
                 type="button"

--- a/packages/electron/src/renderer/hooks/useTodu.ts
+++ b/packages/electron/src/renderer/hooks/useTodu.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
+  ApprovalItem,
+  ApprovalListFilter,
   CreateHabitInput,
   CreateLabelInput,
   CreateNoteInput,
@@ -38,6 +40,7 @@ export const queryKeys = {
   project: (id: string) => ["projects", id] as const,
   tasks: (filter?: unknown, sort?: unknown) => ["tasks", filter, sort] as const,
   task: (id: string) => ["tasks", id] as const,
+  approvals: (filter?: unknown) => ["approvals", filter] as const,
   labels: ["labels"] as const,
   notes: (filter?: unknown) => ["notes", filter] as const,
   recurring: (filter?: unknown) => ["recurring", filter] as const,
@@ -210,6 +213,48 @@ export function useSearchTasks(query: string) {
     queryKey: ["tasks", "search", query],
     queryFn: async () => unwrap(await window.todu.task.search(query)),
     enabled: query.length > 0,
+  });
+}
+
+// ============================================================================
+// Approval Hooks
+// ============================================================================
+
+export function useApprovals(filter?: ApprovalListFilter) {
+  return useQuery({
+    queryKey: queryKeys.approvals(filter),
+    queryFn: async () => unwrap(await window.todu.approval.list(filter)),
+  });
+}
+
+export function useApproveTaskDescription() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (taskId: TaskId) =>
+      unwrap(await window.todu.approval.approveTaskDescription(taskId)),
+    onSuccess: (item: ApprovalItem, taskId) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.approvals() });
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.task(taskId) });
+      if (item.projectId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.project(item.projectId) });
+      }
+    },
+  });
+}
+
+export function useApproveNoteContent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (noteId: NoteId) =>
+      unwrap(await window.todu.approval.approveNoteContent(noteId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.approvals() });
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      queryClient.invalidateQueries({ queryKey: ["notes"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
   });
 }
 

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -20,6 +20,8 @@ import type {
   Project,
   ProjectFilter,
   ProjectId,
+  ApprovalItem,
+  ApprovalListFilter,
   RecurringFilter,
   RecurringId,
   RecurringTemplate,
@@ -31,6 +33,7 @@ import type {
   TaskWithDetail,
   UpdateHabitInput,
   UpdateLabelInput,
+  UpdateNoteInput,
   UpdateProjectInput,
   UpdateRecurringInput,
   UpdateTaskInput,
@@ -63,6 +66,12 @@ export interface ToduTaskApi {
   search(query: string): Promise<Result<Task[]>>;
 }
 
+export interface ToduApprovalApi {
+  list(filter?: ApprovalListFilter): Promise<Result<ApprovalItem[]>>;
+  approveTaskDescription(taskId: TaskId): Promise<Result<ApprovalItem>>;
+  approveNoteContent(noteId: NoteId): Promise<Result<ApprovalItem>>;
+}
+
 export interface ToduLabelApi {
   list(): Promise<Result<Label[]>>;
   create(input: CreateLabelInput): Promise<Result<Label>>;
@@ -73,6 +82,7 @@ export interface ToduLabelApi {
 export interface ToduNoteApi {
   list(filter?: NoteFilter): Promise<Result<Note[]>>;
   create(input: CreateNoteInput): Promise<Result<Note>>;
+  update(id: NoteId, input: UpdateNoteInput): Promise<Result<Note>>;
   delete(id: NoteId): Promise<Result<void>>;
 }
 
@@ -197,6 +207,7 @@ export interface ToduApi {
   actor: ToduActorApi;
   project: ToduProjectApi;
   task: ToduTaskApi;
+  approval: ToduApprovalApi;
   label: ToduLabelApi;
   note: ToduNoteApi;
   recurring: ToduRecurringApi;

--- a/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
+++ b/packages/electron/src/renderer/views/ActorAwareViews.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { Actor, Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Actor, ApprovalItem, Note, Project, Task, TaskWithDetail } from "@todu/core/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as hooks from "../hooks/useTodu.js";
 import { NoteList } from "./NoteList.js";
@@ -11,6 +11,9 @@ import { TaskDetail } from "./TaskDetail.js";
 
 vi.mock("../hooks/useTodu.js", () => ({
   useActors: vi.fn(),
+  useApprovals: vi.fn(),
+  useApproveNoteContent: vi.fn(),
+  useApproveTaskDescription: vi.fn(),
   useDeleteNote: vi.fn(),
   useDeleteProject: vi.fn(),
   useDeleteTask: vi.fn(),
@@ -106,8 +109,22 @@ function makeNote(overrides: Partial<Note> = {}): Note {
     author: "legacy-reviewer",
     authorActorId: "actor-reviewer" as NonNullable<Note["authorActorId"]>,
     contentApproval: { state: "pendingApproval" },
+    entityType: "task",
+    entityId: "task-1",
     tags: [],
     createdAt: "2026-03-14T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeApproval(overrides: Partial<ApprovalItem> = {}): ApprovalItem {
+  return {
+    kind: "taskDescription",
+    state: "pendingApproval",
+    taskId: "task-1" as ApprovalItem["taskId"],
+    taskTitle: "Actor task",
+    projectId: "proj-1" as ApprovalItem["projectId"],
+    contentPreview: "Imported task",
     ...overrides,
   };
 }
@@ -119,8 +136,12 @@ describe("actor-aware renderer views", () => {
   const moveTaskMutate = vi.fn();
   const updateProjectMutate = vi.fn();
   const updateTaskMutate = vi.fn();
+  const approveTaskDescriptionMutate = vi.fn();
+  const approveNoteContentMutate = vi.fn();
+  const onNavigateToEntity = vi.fn();
 
   let actorsData: Actor[];
+  let approvalsData: ApprovalItem[];
   let notesData: Note[];
   let projectData: Project;
   let projectsData: Project[];
@@ -129,11 +150,32 @@ describe("actor-aware renderer views", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    deleteNoteMutate.mockReset();
+    deleteProjectMutate.mockReset();
+    deleteTaskMutate.mockReset();
+    moveTaskMutate.mockReset();
+    updateProjectMutate.mockReset();
+    updateTaskMutate.mockReset();
+    approveTaskDescriptionMutate.mockReset();
+    approveNoteContentMutate.mockReset();
+    onNavigateToEntity.mockReset();
 
     actorsData = [
       { id: "actor-user", displayName: "user" },
       { id: "actor-reviewer", displayName: "Reviewer", archived: true },
       { id: "actor-collab", displayName: "Collaborator" },
+    ];
+    approvalsData = [
+      makeApproval(),
+      makeApproval({
+        kind: "noteContent",
+        noteId: "note-1" as ApprovalItem["noteId"],
+        taskId: undefined,
+        taskTitle: undefined,
+        entityType: "task",
+        entityId: "task-1",
+        contentPreview: "Imported note",
+      }),
     ];
     projectData = makeProject();
     projectsData = [
@@ -161,6 +203,20 @@ describe("actor-aware renderer views", () => {
     vi.mocked(hooks.useActors).mockImplementation(
       () => ({ data: actorsData }) as ReturnType<typeof hooks.useActors>,
     );
+
+    vi.mocked(hooks.useApprovals).mockImplementation(
+      () => ({ data: approvalsData }) as ReturnType<typeof hooks.useApprovals>,
+    );
+
+    vi.mocked(hooks.useApproveTaskDescription).mockReturnValue({
+      mutate: approveTaskDescriptionMutate,
+      isPending: false,
+    } as ReturnType<typeof hooks.useApproveTaskDescription>);
+
+    vi.mocked(hooks.useApproveNoteContent).mockReturnValue({
+      mutate: approveNoteContentMutate,
+      isPending: false,
+    } as ReturnType<typeof hooks.useApproveNoteContent>);
 
     vi.mocked(hooks.useProjects).mockImplementation(
       () => ({ data: projectsData }) as ReturnType<typeof hooks.useProjects>,
@@ -233,7 +289,7 @@ describe("actor-aware renderer views", () => {
     cleanup();
   });
 
-  it("shows archived and unauthorized actor assignees plus approval state in task detail", async () => {
+  it("shows assignees, approval state, and explicit task approval actions in task detail", async () => {
     render(<TaskDetail taskId="task-1" onBack={() => {}} />);
 
     expect(screen.getByText("Assignees")).toBeDefined();
@@ -241,6 +297,30 @@ describe("actor-aware renderer views", () => {
     expect(screen.getByText("Reviewer (actor-reviewer, archived, unauthorized)")).toBeDefined();
     expect(screen.getByText("Approval needed")).toBeDefined();
     expect(screen.getByText("All authorized active actors are already assigned.")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Approve"));
+
+    expect(approveTaskDescriptionMutate).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it("shows task approval errors visibly in task detail", async () => {
+    approveTaskDescriptionMutate.mockImplementation((_taskId, options) => {
+      options?.onError?.(new Error("description: already approved"));
+    });
+
+    render(<TaskDetail taskId="task-1" onBack={() => {}} />);
+
+    fireEvent.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("description: already approved")).toBeDefined();
+    });
   });
 
   it("adds actor assignees from the current project's authorized active actors", async () => {
@@ -378,11 +458,35 @@ describe("actor-aware renderer views", () => {
     });
   });
 
-  it("shows actor-based note authors and approval state in note list", async () => {
-    render(<NoteList onCreateNote={() => {}} onNavigateToEntity={() => {}} />);
+  it("shows approval-needed discovery plus explicit note approval actions in note list", async () => {
+    render(<NoteList onCreateNote={() => {}} onNavigateToEntity={onNavigateToEntity} />);
 
+    expect(screen.getByText("Approval Needed (2)")).toBeDefined();
+    expect(screen.getByText("Task description")).toBeDefined();
+    expect(screen.getByText("Note content")).toBeDefined();
     expect(screen.getByText("Reviewer (archived)")).toBeDefined();
     expect(screen.getByText("Approval needed")).toBeDefined();
-    expect(screen.getByText("Imported note")).toBeDefined();
+    expect(screen.getAllByText("Imported note").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getAllByText("Approve")[0]);
+    expect(approveTaskDescriptionMutate).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+
+    fireEvent.click(screen.getAllByText("Approve")[1]);
+    expect(approveNoteContentMutate).toHaveBeenCalledWith(
+      "note-1",
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+
+    fireEvent.click(screen.getAllByText("task: Actor task")[0]);
+    expect(onNavigateToEntity).toHaveBeenCalledWith("task", "task-1");
   });
 });

--- a/packages/electron/src/renderer/views/NoteList.tsx
+++ b/packages/electron/src/renderer/views/NoteList.tsx
@@ -1,7 +1,16 @@
 import type { NoteEntityType, NoteFilter, NoteId } from "@todu/core/browser";
 import { type ReactNode, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
-import { useActors, useDeleteNote, useNotes, useProjects, useTasks } from "../hooks/useTodu.js";
+import {
+  useActors,
+  useApprovals,
+  useApproveNoteContent,
+  useApproveTaskDescription,
+  useDeleteNote,
+  useNotes,
+  useProjects,
+  useTasks,
+} from "../hooks/useTodu.js";
 import { createActorMap, getActorName, getApprovalLabel } from "../lib/actors.js";
 
 export function NoteList({
@@ -24,11 +33,15 @@ export function NoteList({
   };
 
   const { data: notes, isLoading, isError, error } = useNotes(filter);
+  const { data: approvals } = useApprovals();
   const { data: projects } = useProjects();
   const { data: tasks } = useTasks();
   const { data: actors } = useActors();
+  const approveTaskDescription = useApproveTaskDescription();
+  const approveNoteContent = useApproveNoteContent();
   const deleteNote = useDeleteNote();
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; preview: string } | null>(null);
+  const [approvalMessage, setApprovalMessage] = useState("");
 
   const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
@@ -109,6 +122,94 @@ export function NoteList({
         </button>
       </div>
 
+      {approvalMessage && <div className="settings-hint">{approvalMessage}</div>}
+
+      {(approvals?.length ?? 0) > 0 && (
+        <div className="settings-section">
+          <h3 className="section-title">Approval Needed ({approvals?.length ?? 0})</h3>
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Kind</th>
+                <th>Preview</th>
+                <th>Attached To</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {approvals?.map((approval) => (
+                <tr
+                  key={`${approval.kind}:${approval.taskId ?? approval.noteId ?? approval.contentPreview}`}
+                >
+                  <td>
+                    {approval.kind === "taskDescription" ? "Task description" : "Note content"}
+                  </td>
+                  <td className="cell-content">{approval.contentPreview}</td>
+                  <td>
+                    {approval.kind === "taskDescription" && approval.taskId ? (
+                      <button
+                        type="button"
+                        className="entity-link"
+                        onClick={() => onNavigateToEntity("task", approval.taskId as string)}
+                      >
+                        task: {approval.taskTitle ?? approval.taskId}
+                      </button>
+                    ) : approval.entityType && approval.entityId ? (
+                      entityLabel(approval.entityType, approval.entityId)
+                    ) : (
+                      <span className="empty-hint">Unknown</span>
+                    )}
+                  </td>
+                  <td className="cell-actions">
+                    {approval.kind === "taskDescription" && approval.taskId ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        disabled={approveTaskDescription.isPending}
+                        onClick={() =>
+                          approveTaskDescription.mutate(approval.taskId!, {
+                            onSuccess: () => setApprovalMessage("Task description approved."),
+                            onError: (err) =>
+                              setApprovalMessage(
+                                err instanceof Error
+                                  ? err.message
+                                  : "Failed to approve task description",
+                              ),
+                          })
+                        }
+                      >
+                        {approveTaskDescription.isPending ? "Approving…" : "Approve"}
+                      </button>
+                    ) : approval.kind === "noteContent" && approval.noteId ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        disabled={approveNoteContent.isPending}
+                        onClick={() =>
+                          approveNoteContent.mutate(approval.noteId!, {
+                            onSuccess: () => setApprovalMessage("Note content approved."),
+                            onError: (err) =>
+                              setApprovalMessage(
+                                err instanceof Error
+                                  ? err.message
+                                  : "Failed to approve note content",
+                              ),
+                          })
+                        }
+                      >
+                        {approveNoteContent.isPending ? "Approving…" : "Approve"}
+                      </button>
+                    ) : (
+                      <span className="empty-hint">-</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
       <div className="filter-bar">
         <div className="filter-row">
           <select
@@ -176,6 +277,24 @@ export function NoteList({
                   </div>
                 </td>
                 <td className="cell-actions">
+                  {note.contentApproval?.state === "pendingApproval" && (
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm"
+                      onClick={() =>
+                        approveNoteContent.mutate(note.id, {
+                          onSuccess: () => setApprovalMessage("Note content approved."),
+                          onError: (err) =>
+                            setApprovalMessage(
+                              err instanceof Error ? err.message : "Failed to approve note content",
+                            ),
+                        })
+                      }
+                      disabled={approveNoteContent.isPending}
+                    >
+                      {approveNoteContent.isPending ? "Approving…" : "Approve"}
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="btn btn-danger btn-sm"

--- a/packages/electron/src/renderer/views/TaskDetail.tsx
+++ b/packages/electron/src/renderer/views/TaskDetail.tsx
@@ -14,6 +14,7 @@ import { StatusChip } from "../components/StatusChip.js";
 import { TabBar } from "../components/TabBar.js";
 import {
   useActors,
+  useApproveTaskDescription,
   useDeleteTask,
   useMoveTask,
   useProjects,
@@ -78,6 +79,7 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   const { data: projects } = useProjects();
   const { data: actors } = useActors();
   const updateTask = useUpdateTask();
+  const approveTaskDescription = useApproveTaskDescription();
   const deleteTask = useDeleteTask();
   const moveTask = useMoveTask();
   // Focus entity context for agent
@@ -97,6 +99,7 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
   const [replacementAssigneeActorIds, setReplacementAssigneeActorIds] = useState<
     Record<string, string>
   >({});
+  const [approvalMessage, setApprovalMessage] = useState("");
   const actorMap = useMemo(() => createActorMap(actors), [actors]);
 
   if (isLoading) {
@@ -443,9 +446,30 @@ export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => v
 
         {activeTab === "description" && (
           <div className="detail-tab-content">
+            {approvalMessage && <div className="settings-hint">{approvalMessage}</div>}
             {descriptionApprovalLabel && (
               <div className="detail-approval-row">
                 <span className="chip chip-label">{descriptionApprovalLabel}</span>
+                {task.descriptionApproval?.state === "pendingApproval" && (
+                  <button
+                    type="button"
+                    className="btn btn-primary btn-sm"
+                    onClick={() =>
+                      approveTaskDescription.mutate(task.id as TaskId, {
+                        onSuccess: () => setApprovalMessage("Task description approved."),
+                        onError: (err) =>
+                          setApprovalMessage(
+                            err instanceof Error
+                              ? err.message
+                              : "Failed to approve task description",
+                          ),
+                      })
+                    }
+                    disabled={approveTaskDescription.isPending}
+                  >
+                    {approveTaskDescription.isPending ? "Approving…" : "Approve"}
+                  </button>
+                )}
               </div>
             )}
             {editingDescription ? (


### PR DESCRIPTION
## Summary
- add Electron approval API plumbing and React Query hooks for daemon-backed approval flows
- add approval-needed discovery plus explicit approve actions for imported task descriptions and note/comment content
- update Electron docs and add IPC/client/renderer coverage for approval actions and refresh/error behavior

## Checks
- npx vitest run packages/electron/src/main/daemon-todu-client.test.ts packages/electron/src/main/ipc.integration.test.ts packages/electron/src/renderer/components/CommentThread.test.tsx packages/electron/src/renderer/views/ActorAwareViews.test.tsx
- npm run --workspace=packages/electron build
- make pre-pr

Task: #task-5d712e5c