### PR TITLE
feat: add bootstrap owner actor config

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -14,6 +14,22 @@ For always-on daemon startup (recommended), use OS service manager setup from [`
 - Absolute legacy config values under `~/.config/toduai/...` or `.toduai/...` are normalized to `todu` paths when config is loaded.
 - `TODU_*` env vars are primary; legacy `TODUAI_*` env vars remain supported temporarily as fallback.
 
+### Bootstrap owner actor config
+
+To override the default migrated owner actor (`actor-user` / `user`), set this in config **before the first startup that creates or migrates the dataset**:
+
+```yaml
+identity:
+  ownerActor:
+    id: erik
+    displayName: Erik
+```
+
+Notes:
+- This applies to fresh catalog creation and the first legacy-to-actor migration.
+- If the dataset is already migrated, changing this config later does not rewrite existing actor IDs.
+- Development remains isolated when you use `make dev`, `make run`, or `make dev-electron`, because those flows point at `.dev/config.yaml` instead of the home config.
+
 ## Start/stop/restart the local daemon
 
 Recommended for persistent operation:

--- a/docs/daemon-service-operations.md
+++ b/docs/daemon-service-operations.md
@@ -24,6 +24,19 @@ todu --format json daemon status
 - `TODU_*` env vars are primary; legacy `TODUAI_*` env vars remain supported temporarily as fallback.
 - The current compatibility daemon binary/service name remains `toduai-daemon` during the transition.
 
+### Bootstrap owner actor config
+
+To override the default migrated owner actor (`actor-user` / `user`), set this in `~/.config/todu/config.yaml` **before the first daemon startup that creates or migrates the dataset**:
+
+```yaml
+identity:
+  ownerActor:
+    id: erik
+    displayName: Erik
+```
+
+After the dataset is already migrated, changing this config later does not rewrite existing actor IDs.
+
 ## CLI lifecycle wrappers (`daemon start|stop|restart`)
 
 `todu daemon start`, `todu daemon stop`, and `todu daemon restart` follow this deterministic order:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todu",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todu",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "workspaces": [
         "packages/*"
       ],
@@ -12567,7 +12567,7 @@
     },
     "packages/cli": {
       "name": "@todu/cli",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@todu/daemon": "*",
@@ -12586,7 +12586,7 @@
     },
     "packages/core": {
       "name": "@todu/core",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -12598,7 +12598,8 @@
       "license": "MIT",
       "dependencies": {
         "@todu/core": "*",
-        "@todu/engine": "*"
+        "@todu/engine": "*",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "toduai-daemon": "dist/entrypoint.js"
@@ -12609,7 +12610,7 @@
     },
     "packages/electron": {
       "name": "@todu/electron",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.66.1",
         "@mariozechner/pi-ai": "^0.66.1",
@@ -12642,7 +12643,7 @@
     },
     "packages/engine": {
       "name": "@todu/engine",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "^3.2.4",

--- a/packages/cli/src/commands/daemon.integration.test.ts
+++ b/packages/cli/src/commands/daemon.integration.test.ts
@@ -52,6 +52,10 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
       cwd: rootDir,
       env: {
         ...process.env,
+        TODU_CONFIG: "",
+        TODUAI_CONFIG: "",
+        TODU_DAEMON_SOCKET: "",
+        TODUAI_DAEMON_SOCKET: "",
         TODU_DATA_DIR: tmpDir,
         TODUAI_NO_SYNC: "1",
         TODU_DAEMON_LIFECYCLE_MODE: "direct",
@@ -111,6 +115,10 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
       cwd: rootDir,
       env: {
         ...process.env,
+        TODU_CONFIG: "",
+        TODUAI_CONFIG: "",
+        TODU_DAEMON_SOCKET: "",
+        TODUAI_DAEMON_SOCKET: "",
         TODU_DATA_DIR: tmpDir,
         TODUAI_NO_SYNC: "1",
         HOME: homeDir,

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -64,6 +64,7 @@ interface DaemonLifecycleResult {
 }
 
 interface DaemonCommandContext {
+  configPath: string;
   storagePath: string;
   socketPath: string;
   daemonPidPath: string;
@@ -834,13 +835,14 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
   const configOpt = program.opts().config as string | undefined;
   const configPath = getConfigPath(configOpt);
   const fileConfig = loadConfig(configPath);
-  const storagePath = resolveDataDir(configPath, fileConfig);
-  const remoteSync = resolveRemoteSyncConfig(fileConfig);
+  const storagePath = resolveDataDir(configPath, fileConfig, { env: process.env });
+  const remoteSync = resolveRemoteSyncConfig(fileConfig, { env: process.env });
   const assignedWorkers = resolveDaemonAssignedWorkers(fileConfig);
   const pluginPaths = resolveDaemonPluginPaths(configPath, fileConfig);
   const pluginConfig = resolveDaemonPluginConfig(fileConfig);
 
   return {
+    configPath,
     storagePath,
     socketPath: resolveDaemonSocketPath(storagePath),
     daemonPidPath: path.join(storagePath, DIRECT_PID_FILENAME),
@@ -854,9 +856,11 @@ function resolveDaemonCommandContext(program: Command): DaemonCommandContext {
 function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
+    TODU_CONFIG: context.configPath,
     TODU_DATA_DIR: context.storagePath,
   };
 
+  delete childEnv.TODUAI_CONFIG;
   delete childEnv.TODUAI_DATA_DIR;
 
   if (context.remoteSyncServer) {

--- a/packages/cli/src/test-helpers/daemon-process.ts
+++ b/packages/cli/src/test-helpers/daemon-process.ts
@@ -16,6 +16,8 @@ export async function startDaemonForTests(
     cwd: rootDir,
     env: {
       ...process.env,
+      TODU_CONFIG: "",
+      TODUAI_CONFIG: "",
       TODU_DATA_DIR: storagePath,
       TODU_DAEMON_SOCKET: socketPath,
       TODUAI_DAEMON_SOCKET: socketPath,

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -11,6 +11,7 @@ import {
   LEGACY_DEFAULT_DATA_DIR,
   migrateLegacyDefaultConfigDirectory,
   normalizeConfigPaths,
+  resolveBootstrapOwnerActor,
   resolveConfigPath,
   resolveConfigSources,
   resolveDataDir,
@@ -203,6 +204,59 @@ describe("config resolution", () => {
       );
 
       expect(normalized.data_dir).toBe(path.join(tmpHome, "workspace", ".todu", "data"));
+    });
+  });
+
+  describe("resolveBootstrapOwnerActor", () => {
+    it("returns null when owner bootstrap config is absent", () => {
+      expect(resolveBootstrapOwnerActor({})).toEqual({ ok: true, value: null });
+    });
+
+    it("returns trimmed owner bootstrap config when present", () => {
+      expect(
+        resolveBootstrapOwnerActor({
+          identity: {
+            ownerActor: {
+              id: "  erik  ",
+              displayName: "  Erik  ",
+            },
+          },
+        }),
+      ).toEqual({
+        ok: true,
+        value: {
+          id: "erik",
+          displayName: "Erik",
+        },
+      });
+    });
+
+    it("rejects missing owner actor id", () => {
+      const result = resolveBootstrapOwnerActor({
+        identity: { ownerActor: { displayName: "Erik" } },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        type: "validation",
+        field: "identity.ownerActor.id",
+        message: "Actor ID must be a non-empty string",
+      });
+    });
+
+    it("rejects missing owner actor display name", () => {
+      const result = resolveBootstrapOwnerActor({
+        identity: { ownerActor: { id: "erik" } },
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        type: "validation",
+        field: "identity.ownerActor.displayName",
+        message: "Actor display name must be a non-empty string",
+      });
     });
   });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,15 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  type ActorId,
+  createActorId,
+  err,
+  ok,
+  type Result,
+  type ValidationError,
+} from "./types.js";
+import { validateActorDisplayName, validateActorId } from "./validation.js";
 
 const CURRENT_CONFIG_DIRNAME = "todu";
 const LEGACY_CONFIG_DIRNAME = "toduai";
@@ -57,9 +66,21 @@ export const LEGACY_DEFAULT_CONFIG_DIR = getLegacyDefaultConfigDir();
 export const LEGACY_DEFAULT_CONFIG_FILE = getLegacyDefaultConfigFile();
 export const LEGACY_DEFAULT_DATA_DIR = getLegacyDefaultDataDir();
 
+export interface BootstrapOwnerActor {
+  id: ActorId;
+  displayName: string;
+}
+
 export interface ToduFileConfig {
   /** Path to data directory (absolute or relative to config file) */
   data_dir?: string;
+  /** Bootstrap identity for fresh catalog creation and pre-actor migration. */
+  identity?: {
+    ownerActor?: {
+      id?: string;
+      displayName?: string;
+    };
+  };
   /** Remote multi-device sync configuration */
   sync?: {
     remote?: {
@@ -120,6 +141,33 @@ interface ResolvedEnvValue {
  * IMPORTANT: Never use wss://sync.todu.sh in development or tests.
  * Use the local dev sync server (ws://localhost:3030) via `make dev`.
  */
+export function resolveBootstrapOwnerActor(
+  config: ToduFileConfig,
+): Result<BootstrapOwnerActor | null, ValidationError> {
+  const configuredOwner = config.identity?.ownerActor;
+  if (!configuredOwner) {
+    return ok(null);
+  }
+
+  const actorIdError = validateActorId("identity.ownerActor.id", configuredOwner.id ?? "");
+  if (actorIdError) {
+    return err(actorIdError);
+  }
+
+  const displayNameError = validateActorDisplayName(
+    "identity.ownerActor.displayName",
+    configuredOwner.displayName ?? "",
+  );
+  if (displayNameError) {
+    return err(displayNameError);
+  }
+
+  return ok({
+    id: createActorId(configuredOwner.id!.trim()),
+    displayName: configuredOwner.displayName!.trim(),
+  });
+}
+
 export function resolveRemoteSyncConfig(
   config: ToduFileConfig,
   options: ConfigResolutionOptions = {},

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -38,6 +38,12 @@ describe("schema", () => {
       expect(catalog.ownerActorId).toBe(DEFAULT_OWNER_ACTOR_ID);
     });
 
+    it("creates a catalog with a configured owner actor", () => {
+      const catalog = createEmptyCatalog({ id: createActorId("erik"), displayName: "Erik" });
+      expect(catalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
+      expect(catalog.ownerActorId).toBe("erik");
+    });
+
     it("creates a catalog with empty taskListDocIds", () => {
       const catalog = createEmptyCatalog();
       expect(catalog.taskListDocIds).toEqual({});

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,3 +1,4 @@
+import type { BootstrapOwnerActor } from "./config.js";
 import {
   type Actor,
   type ActorId,
@@ -160,18 +161,25 @@ export interface HabitLogDocument {
 
 export const SCHEMA_VERSION = 2;
 export const DEFAULT_OWNER_ACTOR_ID = createActorId("actor-user");
+export const DEFAULT_OWNER_ACTOR_DISPLAY_NAME = "user";
+export const DEFAULT_OWNER_ACTOR: BootstrapOwnerActor = {
+  id: DEFAULT_OWNER_ACTOR_ID,
+  displayName: DEFAULT_OWNER_ACTOR_DISPLAY_NAME,
+};
 
 // ============================================================================
 // Factory functions
 // ============================================================================
 
-export function createEmptyCatalog(): CatalogDocument {
+export function createEmptyCatalog(
+  ownerActor: BootstrapOwnerActor = DEFAULT_OWNER_ACTOR,
+): CatalogDocument {
   return {
     version: SCHEMA_VERSION,
     projects: [],
     labels: [],
-    actors: [{ id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" }],
-    ownerActorId: DEFAULT_OWNER_ACTOR_ID,
+    actors: [{ id: ownerActor.id, displayName: ownerActor.displayName }],
+    ownerActorId: ownerActor.id,
     taskListDocIds: {},
     notesBucketDocIds: {},
     noteBucketByNoteId: {},

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@todu/core": "*",
-    "@todu/engine": "*"
+    "@todu/engine": "*",
+    "yaml": "^2.8.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import {
+  type BootstrapOwnerActor,
+  normalizeConfigPaths,
+  type RemoteSyncConfig,
+  resolveBootstrapOwnerActor,
+  resolveConfigPath,
+  resolveRemoteSyncConfig,
+  type ToduFileConfig,
+} from "@todu/core";
+import { parse } from "yaml";
+
+export interface DaemonFileConfig {
+  fileConfig: ToduFileConfig;
+  remoteSync: RemoteSyncConfig | null;
+  bootstrapOwnerActor: BootstrapOwnerActor | null;
+}
+
+/**
+ * Load daemon file config from the standard resolved config path.
+ *
+ * Returns defaults when the file is missing or unreadable.
+ * Throws when YAML is malformed or bootstrap owner config is invalid.
+ */
+export function loadDaemonFileConfig(): DaemonFileConfig {
+  const configPath = resolveConfigPath();
+
+  let fileConfig: ToduFileConfig = {};
+  try {
+    const content = fs.readFileSync(configPath, "utf-8");
+    fileConfig = normalizeConfigPaths((parse(content) as ToduFileConfig) ?? {}, configPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const bootstrapOwnerActor = resolveBootstrapOwnerActor(fileConfig);
+  if (!bootstrapOwnerActor.ok) {
+    throw new Error(
+      `Invalid bootstrap owner actor config (${bootstrapOwnerActor.error.field}): ${bootstrapOwnerActor.error.message}`,
+    );
+  }
+
+  return {
+    fileConfig,
+    remoteSync: resolveRemoteSyncConfig(fileConfig),
+    bootstrapOwnerActor: bootstrapOwnerActor.value,
+  };
+}

--- a/packages/daemon/src/run-daemon.ts
+++ b/packages/daemon/src/run-daemon.ts
@@ -1,4 +1,4 @@
-import { resolveRemoteSyncConfig } from "@todu/core";
+import { loadDaemonFileConfig } from "./config.js";
 import { createDaemonLogger, resolveDaemonLogLevelFromEnv } from "./logger.js";
 import { parseDaemonPluginConfigFromEnv, TODU_DAEMON_PLUGIN_CONFIG_ENV } from "./plugin-config.js";
 import { parseDaemonPluginPathsFromEnv, TODU_DAEMON_PLUGIN_PATHS_ENV } from "./plugin-paths.js";
@@ -40,7 +40,8 @@ export async function runDaemonEntrypoint(): Promise<void> {
   );
   const daemonSocketPath =
     process.env[TODU_DAEMON_SOCKET_ENV] ?? process.env[TODUAI_DAEMON_SOCKET_ENV];
-  const remoteSync = resolveRemoteSyncConfig({});
+  const fileConfig = loadDaemonFileConfig();
+  const remoteSync = fileConfig.remoteSync;
   const assignmentConfig = parseAssignedWorkerTypesFromEnv(process.env);
   const pluginPathsConfig = parseDaemonPluginPathsFromEnv(process.env);
   const pluginConfig = parseDaemonPluginConfigFromEnv(process.env);
@@ -93,6 +94,7 @@ export async function runDaemonEntrypoint(): Promise<void> {
       role: daemonRole,
       socketPath: daemonSocketPath,
       remoteSync: remoteSync ?? undefined,
+      bootstrapOwnerActor: fileConfig.bootstrapOwnerActor ?? undefined,
       logLevel: daemonLogLevel,
       assignedWorkerTypes: assignmentConfig.assignedWorkerTypes,
       syncPluginModulePaths: pluginPathsConfig.modulePaths,

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,5 +1,12 @@
 import type { DocumentId } from "@automerge/automerge-repo";
-import { err, ok, type RemoteSyncConfig, type Result, resolveStoragePath } from "@todu/core";
+import {
+  type BootstrapOwnerActor,
+  err,
+  ok,
+  type RemoteSyncConfig,
+  type Result,
+  resolveStoragePath,
+} from "@todu/core";
 import {
   beginCatalogJoinSwitch,
   createTodu,
@@ -67,6 +74,7 @@ export interface DaemonRuntimeConfig {
   storagePath?: string;
   role?: DaemonRole;
   remoteSync?: RemoteSyncConfig;
+  bootstrapOwnerActor?: BootstrapOwnerActor;
   socketPath?: string;
   socketMode?: number;
   daemonVersion?: string;
@@ -86,6 +94,7 @@ export interface ResolvedDaemonRuntimeConfig {
   storagePath: string;
   role: DaemonRole;
   remoteSync?: RemoteSyncConfig;
+  bootstrapOwnerActor?: BootstrapOwnerActor;
   socketPath: string;
   socketMode: number;
   daemonVersion: string;
@@ -143,6 +152,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     storagePath: resolvedStoragePath,
     role: config.role ?? "node",
     remoteSync: config.remoteSync,
+    bootstrapOwnerActor: config.bootstrapOwnerActor,
     socketPath: resolvedSocketPath,
     socketMode: config.socketMode ?? 0o600,
     daemonVersion:
@@ -761,6 +771,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
     return createTodu({
       storagePath: resolvedConfig.storagePath,
       remoteSync: resolvedConfig.remoteSync,
+      bootstrapOwnerActor: resolvedConfig.bootstrapOwnerActor,
       startupTemplateProcessing: {
         enabled: true,
       },
@@ -1090,6 +1101,8 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       const validationStorage = await initJoinStorage(
         resolvedConfig.storagePath,
         targetCatalogId as DocumentId,
+        undefined,
+        resolvedConfig.bootstrapOwnerActor,
       );
       await validationStorage.close();
     } catch (error) {
@@ -1277,6 +1290,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
         storagePath: resolvedConfig.storagePath,
         role: resolvedConfig.role,
         remoteSync: resolvedConfig.remoteSync,
+        bootstrapOwnerActor: resolvedConfig.bootstrapOwnerActor,
         socketPath: resolvedConfig.socketPath,
         socketMode: resolvedConfig.socketMode,
         daemonVersion: resolvedConfig.daemonVersion,

--- a/packages/engine/src/index.integration.test.ts
+++ b/packages/engine/src/index.integration.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
-import type { CatalogDocument } from "@todu/core";
+import { type CatalogDocument, createActorId } from "@todu/core";
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
@@ -85,6 +85,21 @@ describe("createTodu", () => {
     expect(docId.length).toBeGreaterThan(0);
   });
 
+  it("creates a fresh catalog with the configured bootstrap owner actor", async () => {
+    todu = await createTodu({
+      storagePath: tmpDir,
+      bootstrapOwnerActor: { id: createActorId("erik"), displayName: "Erik" },
+    });
+
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const catalog = await readCatalogDocument(tmpDir);
+    expect(catalog.ownerActorId).toBe("erik");
+    expect(catalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
+  });
+
   it("loads existing catalog on subsequent runs", async () => {
     // First run — creates catalog
     todu = await createTodu({ storagePath: tmpDir });
@@ -98,6 +113,28 @@ describe("createTodu", () => {
     const secondDocId = fs.readFileSync(markerPath, "utf-8").trim();
 
     expect(secondDocId).toBe(firstDocId);
+  });
+
+  it("does not rewrite an already migrated catalog when bootstrap owner config changes", async () => {
+    todu = await createTodu({
+      storagePath: tmpDir,
+      bootstrapOwnerActor: { id: createActorId("erik"), displayName: "Erik" },
+    });
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    todu = await createTodu({
+      storagePath: tmpDir,
+      bootstrapOwnerActor: { id: createActorId("reviewer"), displayName: "Reviewer" },
+    });
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const catalog = await readCatalogDocument(tmpDir);
+    expect(catalog.ownerActorId).toBe("erik");
+    expect(catalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
   });
 
   it("returns config via config.get()", async () => {
@@ -192,6 +229,35 @@ describe("createTodu", () => {
     expect(migratedCatalog.integrationStatusDocIds).toEqual({});
     expect(migratedCatalog.recurringTemplates).toEqual([]);
     expect(migratedCatalog.habits).toEqual([]);
+    expect(migratedCatalog.settings.schemaVersion).toBe(2);
+  });
+
+  it("migrates old catalogs with the configured bootstrap owner actor", async () => {
+    const repo = new Repo({
+      storage: new NodeFSStorageAdapter(tmpDir),
+    });
+    const handle = repo.create<Partial<CatalogDocument>>();
+    handle.change((doc) => {
+      doc.version = 1;
+      doc.projects = [];
+    });
+    const markerPath = path.join(tmpDir, "todu-catalog.id");
+    fs.writeFileSync(markerPath, handle.documentId, "utf-8");
+    await repo.flush();
+    await repo.shutdown();
+    await new Promise((r) => setTimeout(r, 50));
+
+    todu = await createTodu({
+      storagePath: tmpDir,
+      bootstrapOwnerActor: { id: createActorId("erik"), displayName: "Erik" },
+    });
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    const migratedCatalog = await readCatalogDocument(tmpDir);
+    expect(migratedCatalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
+    expect(migratedCatalog.ownerActorId).toBe("erik");
     expect(migratedCatalog.settings.schemaVersion).toBe(2);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -90,6 +90,7 @@ export async function createTodu(
 ): Promise<Todu> {
   const resolvedConfig: ToduConfig = {
     storagePath: config.storagePath,
+    bootstrapOwnerActor: config.bootstrapOwnerActor,
   };
 
   await ensureAutomergeWasmInitialized();
@@ -123,7 +124,11 @@ export async function createTodu(
     if (config?.remoteSync) {
       initialRemoteAdapter = addRemoteSyncAdapter(repo, config.remoteSync.server);
     }
-    storage = await initBootstrapStorage(resolvedConfig.storagePath, repo);
+    storage = await initBootstrapStorage(
+      resolvedConfig.storagePath,
+      repo,
+      resolvedConfig.bootstrapOwnerActor,
+    );
 
     if (config?.syncServer) {
       syncServer = startSyncServer(storage.repo, config.syncPort);

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -41,7 +41,10 @@ async function readCatalogDocument(storagePath: string): Promise<CatalogDocument
 async function seedLegacyNoteIdentityData(
   storagePath: string,
   legacyAuthorsByNoteId: Record<string, string | null | undefined>,
-  owner: { id: string; displayName: string } = {
+  owner: {
+    id: string;
+    displayName: string;
+  } | null = {
     id: DEFAULT_OWNER_ACTOR_ID,
     displayName: "user",
   },
@@ -59,11 +62,16 @@ async function seedLegacyNoteIdentityData(
     catalogHandle.change((doc) => {
       doc.version = 1;
       doc.settings.schemaVersion = 1;
-      doc.actors.splice(0, doc.actors.length, {
-        id: createActorId(owner.id),
-        displayName: owner.displayName,
-      });
-      doc.ownerActorId = createActorId(owner.id);
+      doc.actors.splice(0, doc.actors.length);
+      if (owner) {
+        doc.actors.push({
+          id: createActorId(owner.id),
+          displayName: owner.displayName,
+        });
+        doc.ownerActorId = createActorId(owner.id);
+      } else {
+        delete doc.ownerActorId;
+      }
     });
 
     const bucketDocIds = Object.values(catalogHandle.doc()?.notesBucketDocIds ?? {});
@@ -107,7 +115,7 @@ describe("note namespace", () => {
   });
 
   afterEach(async () => {
-    await todu.close();
+    await todu?.close();
     await new Promise((r) => setTimeout(r, 50));
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -360,6 +368,44 @@ describe("note namespace", () => {
       expect(result.value.find((note) => note.id === second.value.id)?.authorActorId).toBe(
         "actor-reviewer",
       );
+    });
+
+    it("maps legacy missing or 'user' note authors to the configured bootstrap owner actor", async () => {
+      const first = await todu.note.create({ content: "Legacy user note" });
+      const second = await todu.note.create({ content: "Legacy missing note" });
+      if (!first.ok || !second.ok) throw new Error("create failed");
+
+      await todu.close();
+      await new Promise((r) => setTimeout(r, 50));
+
+      await seedLegacyNoteIdentityData(
+        tmpDir,
+        {
+          [first.value.id]: "user",
+          [second.value.id]: undefined,
+        },
+        null,
+      );
+
+      todu = await createTodu({
+        storagePath: tmpDir,
+        bootstrapOwnerActor: { id: createActorId("erik"), displayName: "Erik" },
+      });
+
+      const result = await todu.note.list();
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.find((note) => note.id === first.value.id)?.authorActorId).toBe("erik");
+      expect(result.value.find((note) => note.id === second.value.id)?.authorActorId).toBe("erik");
+
+      await todu.close();
+      todu = null;
+      await new Promise((r) => setTimeout(r, 50));
+
+      const catalog = await readCatalogDocument(tmpDir);
+      expect(catalog.ownerActorId).toBe("erik");
+      expect(catalog.actors).toContainEqual({ id: "erik", displayName: "Erik" });
     });
 
     it("filters by entityType", async () => {

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -6,6 +6,7 @@ import { Repo } from "@automerge/automerge-repo/slim";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type Actor,
+  type BootstrapOwnerActor,
   CATALOG_DOC_KEY,
   type CatalogDocument,
   createActorId,
@@ -266,7 +267,11 @@ export function beginCatalogJoinSwitch(
  * - Existing marker: load that catalog
  * - Existing but unreachable marker: fail (do not implicitly create a new catalog)
  */
-export async function initBootstrapStorage(storagePath: string, repo?: Repo): Promise<Storage> {
+export async function initBootstrapStorage(
+  storagePath: string,
+  repo?: Repo,
+  bootstrapOwnerActor?: BootstrapOwnerActor,
+): Promise<Storage> {
   await ensureAutomergeWasmInitialized();
   fs.mkdirSync(storagePath, { recursive: true });
 
@@ -278,7 +283,7 @@ export async function initBootstrapStorage(storagePath: string, repo?: Repo): Pr
     });
 
   try {
-    const catalog = await loadOrBootstrapCatalog(actualRepo, storagePath);
+    const catalog = await loadOrBootstrapCatalog(actualRepo, storagePath, bootstrapOwnerActor);
     return createPersistentStorage(actualRepo, catalog);
   } catch (error) {
     if (ownsRepo) {
@@ -299,6 +304,7 @@ export async function initJoinStorage(
   storagePath: string,
   targetCatalogId: DocumentId,
   repo?: Repo,
+  bootstrapOwnerActor?: BootstrapOwnerActor,
 ): Promise<Storage> {
   await ensureAutomergeWasmInitialized();
   fs.mkdirSync(storagePath, { recursive: true });
@@ -311,7 +317,7 @@ export async function initJoinStorage(
     });
 
   try {
-    const catalog = await loadCatalogById(actualRepo, targetCatalogId, "join");
+    const catalog = await loadCatalogById(actualRepo, targetCatalogId, "join", bootstrapOwnerActor);
     return createPersistentStorage(actualRepo, catalog);
   } catch (error) {
     if (ownsRepo) {
@@ -457,15 +463,16 @@ function createPersistentStorage(repo: Repo, catalog: DocHandle<CatalogDocument>
 async function loadOrBootstrapCatalog(
   repo: Repo,
   storagePath: string,
+  bootstrapOwnerActor?: BootstrapOwnerActor,
 ): Promise<DocHandle<CatalogDocument>> {
   const markerPath = getCatalogMarkerPath(storagePath);
 
   if (fs.existsSync(markerPath)) {
     const docId = fs.readFileSync(markerPath, "utf-8").trim() as DocumentId;
-    return loadCatalogById(repo, docId, "bootstrap");
+    return loadCatalogById(repo, docId, "bootstrap", bootstrapOwnerActor);
   }
 
-  return createBootstrapCatalog(repo, markerPath);
+  return createBootstrapCatalog(repo, markerPath, bootstrapOwnerActor);
 }
 
 /**
@@ -476,12 +483,13 @@ async function loadCatalogById(
   repo: Repo,
   docId: DocumentId,
   mode: "bootstrap" | "join",
+  bootstrapOwnerActor?: BootstrapOwnerActor,
 ): Promise<DocHandle<CatalogDocument>> {
   try {
     const handle = await repo.find<CatalogDocument>(docId, {
       signal: AbortSignal.timeout(CATALOG_LOAD_TIMEOUT_MS),
     });
-    migrateCatalog(handle);
+    migrateCatalog(handle, bootstrapOwnerActor);
     await migrateLegacyIdentityModel(handle, repo);
     return handle;
   } catch {
@@ -494,10 +502,14 @@ async function loadCatalogById(
 /**
  * Create a new catalog and persist its marker.
  */
-function createBootstrapCatalog(repo: Repo, markerPath: string): DocHandle<CatalogDocument> {
+function createBootstrapCatalog(
+  repo: Repo,
+  markerPath: string,
+  bootstrapOwnerActor?: BootstrapOwnerActor,
+): DocHandle<CatalogDocument> {
   const handle = repo.create<CatalogDocument>();
   handle.change((doc: CatalogDocument) => {
-    const empty = createEmptyCatalog();
+    const empty = createEmptyCatalog(bootstrapOwnerActor);
     doc.version = empty.version;
     doc.projects = empty.projects;
     doc.labels = empty.labels;
@@ -523,17 +535,20 @@ function createBootstrapCatalog(repo: Repo, markerPath: string): DocHandle<Catal
  * Backfills any missing fields that were added in later versions.
  * This ensures engine code can always assume catalog fields exist.
  */
-function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
+function migrateCatalog(
+  handle: DocHandle<CatalogDocument>,
+  bootstrapOwnerActor?: BootstrapOwnerActor,
+): void {
   const doc = handle.doc();
   if (!doc) return;
 
-  const defaults = createEmptyCatalog();
+  const defaults = createEmptyCatalog(bootstrapOwnerActor);
   let needsMigration = false;
 
   // Check for missing fields
   if (!Array.isArray(doc.projects)) needsMigration = true;
   if (!Array.isArray(doc.labels)) needsMigration = true;
-  if (!Array.isArray(doc.actors)) needsMigration = true;
+  if (!Array.isArray(doc.actors) || doc.actors.length === 0) needsMigration = true;
   if (doc.ownerActorId === undefined || doc.ownerActorId === null) needsMigration = true;
   if (!Array.isArray(doc.recurringTemplates)) needsMigration = true;
   if (!Array.isArray(doc.habits)) needsMigration = true;
@@ -558,7 +573,7 @@ function migrateCatalog(handle: DocHandle<CatalogDocument>): void {
   handle.change((d) => {
     if (!Array.isArray(d.projects)) d.projects = defaults.projects;
     if (!Array.isArray(d.labels)) d.labels = defaults.labels;
-    if (!Array.isArray(d.actors)) d.actors = defaults.actors;
+    if (!Array.isArray(d.actors) || d.actors.length === 0) d.actors = defaults.actors;
     if (d.ownerActorId === undefined || d.ownerActorId === null) {
       d.ownerActorId = defaults.ownerActorId;
     }

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -3,6 +3,7 @@ import type {
   ActorId,
   ApprovalItem,
   ApprovalListFilter,
+  BootstrapOwnerActor,
   CreateActorInput,
   CreateHabitInput,
   CreateIntegrationBindingInput,
@@ -67,6 +68,9 @@ export interface ToduConfig {
 
   /** Try to connect to a running sync server (used by CLI) */
   syncClient?: boolean;
+
+  /** Optional owner actor bootstrap used for fresh catalogs and pre-actor migration. */
+  bootstrapOwnerActor?: BootstrapOwnerActor;
 
   /**
    * Startup template processing policy.


### PR DESCRIPTION
## Summary
- add `identity.ownerActor` config support for fresh catalogs and pre-actor migration
- thread bootstrap owner config through daemon startup into engine storage/migration
- add regression coverage for fresh catalogs, migration fallback, and already-migrated datasets

## Testing
- `npx vitest run --config vitest.all.config.ts packages/core/src/config.test.ts packages/core/src/schema.test.ts packages/engine/src/index.integration.test.ts packages/engine/src/notes.integration.test.ts packages/cli/src/commands/daemon.integration.test.ts`
- `make pre-pr`

Task: #task-c1346403