### PR TITLE
feat: bundle daemon runtime for electron

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,7 +12,7 @@
   "main": "./dist/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build",
+    "build": "npm --prefix ../../ run build --workspace=@todu/daemon && electron-vite build && node scripts/bundle-daemon.mjs",
     "preview": "electron-vite preview",
     "dist": "electron-builder --config electron-builder.yml",
     "dist:linux": "electron-builder --config electron-builder.yml --linux",
@@ -24,6 +24,7 @@
     "@mariozechner/pi-ai": "^0.66.1",
     "@sinclair/typebox": "^0.34.48",
     "@tanstack/react-query": "^5.90.20",
+    "@todu/core": "*",
     "@tiptap/extension-link": "3.19.0",
     "@tiptap/extension-placeholder": "3.19.0",
     "@tiptap/pm": "3.19.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -16,8 +16,10 @@
     "preview": "electron-vite preview",
     "dist": "electron-builder --config electron-builder.yml",
     "dist:linux": "electron-builder --config electron-builder.yml --linux",
+    "dist:linux:dir": "electron-builder --config electron-builder.yml --linux dir",
     "dist:mac": "electron-builder --config electron-builder.yml --mac",
-    "dist:win": "electron-builder --config electron-builder.yml --win"
+    "dist:win": "electron-builder --config electron-builder.yml --win",
+    "validate:daemon-bundle:linux": "node scripts/validate-daemon-bundle.mjs --unpacked-dir ../../dist/installers/linux-unpacked"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.66.1",

--- a/packages/electron/scripts/bundle-daemon.mjs
+++ b/packages/electron/scripts/bundle-daemon.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const electronDir = path.resolve(scriptDir, "..");
+const daemonDistDir = path.resolve(electronDir, "../daemon/dist");
+const bundledDaemonDir = path.resolve(electronDir, "dist/daemon");
+
+if (!fs.existsSync(daemonDistDir)) {
+  throw new Error(`Daemon build output not found: ${daemonDistDir}`);
+}
+
+fs.rmSync(bundledDaemonDir, { recursive: true, force: true });
+fs.cpSync(daemonDistDir, bundledDaemonDir, { recursive: true });
+
+console.log(`Bundled daemon runtime: ${path.relative(electronDir, bundledDaemonDir)}`);

--- a/packages/electron/scripts/validate-daemon-bundle.mjs
+++ b/packages/electron/scripts/validate-daemon-bundle.mjs
@@ -1,0 +1,138 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const unpackedDir = args.get("unpacked-dir") ? path.resolve(args.get("unpacked-dir")) : null;
+const executableArg = args.get("executable");
+const appPathArg = args.get("app-path");
+const executablePath = executableArg
+  ? path.resolve(executableArg)
+  : unpackedDir
+    ? resolveExecutablePath(unpackedDir)
+    : null;
+const appPath = appPathArg
+  ? path.resolve(appPathArg)
+  : unpackedDir
+    ? path.join(unpackedDir, "resources", "app.asar")
+    : null;
+
+if (!executablePath || !appPath) {
+  throw new Error(
+    "Usage: node scripts/validate-daemon-bundle.mjs (--unpacked-dir <path> | --executable <path> --app-path <path>)",
+  );
+}
+
+const entrypointPath = path.join(appPath, "dist", "daemon", "entrypoint.js");
+if (!fs.existsSync(executablePath)) {
+  throw new Error(`Packaged executable not found: ${executablePath}`);
+}
+
+const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), "todu-electron-daemon-bundle-"));
+const socketPath = path.join(storagePath, "daemon.sock");
+const daemon = spawn(executablePath, [entrypointPath], {
+  cwd: path.dirname(executablePath),
+  detached: true,
+  env: {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: "1",
+    TODU_CONFIG: "",
+    TODUAI_CONFIG: "",
+    TODU_DATA_DIR: storagePath,
+    TODU_DAEMON_SOCKET: socketPath,
+    TODUAI_DAEMON_SOCKET: socketPath,
+  },
+  stdio: ["ignore", "ignore", "pipe"],
+});
+
+let stderr = "";
+daemon.stderr?.on("data", (chunk) => {
+  stderr += chunk.toString();
+});
+
+try {
+  await waitForSocket(socketPath, daemon, stderr);
+  console.log(`Validated bundled daemon startup via ${entrypointPath}`);
+} finally {
+  await stopProcess(daemon);
+}
+
+function parseArgs(argv) {
+  const parsed = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    parsed.set(argv[index]?.replace(/^--/, ""), argv[index + 1]);
+  }
+  return parsed;
+}
+
+async function waitForSocket(socketPath, child, stderr) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) {
+      return;
+    }
+
+    if (child.exitCode !== null) {
+      throw new Error(`Packaged daemon exited early with code ${child.exitCode}: ${stderr}`);
+    }
+
+    await sleep(50);
+  }
+
+  throw new Error(`Timed out waiting for packaged daemon socket: ${socketPath}\n${stderr}`);
+}
+
+async function stopProcess(processHandle) {
+  if (processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+
+  await new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      if (processHandle.exitCode === null) {
+        processHandle.kill("SIGKILL");
+      }
+      resolve();
+    }, 3000);
+
+    processHandle.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function resolveExecutablePath(unpackedDir) {
+  const ignoredNames = new Set([
+    "chrome_crashpad_handler",
+    "chrome-sandbox",
+    "libEGL.so",
+    "libffmpeg.so",
+    "libGLESv2.so",
+    "libvk_swiftshader.so",
+    "libvulkan.so.1",
+  ]);
+  const candidates = fs
+    .readdirSync(unpackedDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => !ignoredNames.has(name))
+    .filter((name) => fs.statSync(path.join(unpackedDir, name)).mode & 0o111);
+
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Expected exactly one packaged executable in ${unpackedDir}, found: ${candidates.join(", ") || "none"}`,
+    );
+  }
+
+  return path.join(unpackedDir, candidates[0]);
+}

--- a/packages/electron/src/main/daemon-runtime.test.ts
+++ b/packages/electron/src/main/daemon-runtime.test.ts
@@ -1,0 +1,140 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createDaemonLaunchSpec, resolveDaemonEntrypointPath } from "./daemon-runtime.js";
+
+describe("resolveDaemonEntrypointPath", () => {
+  it("resolves packaged daemon entrypoint inside the app bundle", () => {
+    expect(
+      resolveDaemonEntrypointPath({
+        isPackaged: true,
+        appPath: "/Applications/todu.app/Contents/Resources/app.asar",
+      }),
+    ).toBe("/Applications/todu.app/Contents/Resources/app.asar/dist/daemon/entrypoint.js");
+  });
+
+  it("resolves dev daemon entrypoint from the workspace source tree", () => {
+    expect(resolveDaemonEntrypointPath({ isPackaged: false })).toMatch(
+      /packages[\\/]daemon[\\/]src[\\/]entrypoint\.ts$/,
+    );
+  });
+});
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+describe("createDaemonLaunchSpec", () => {
+  it("uses tsx to launch the daemon source entrypoint in dev mode", () => {
+    const spec = createDaemonLaunchSpec({
+      isPackaged: false,
+      execPath: "/usr/local/bin/node",
+      env: { TEST_ENV: "1" },
+    });
+
+    expect(spec.command).toBe("/usr/local/bin/node");
+    expect(spec.args[0]).toMatch(/node_modules[\\/]tsx[\\/]dist[\\/]cli\.mjs$/);
+    expect(spec.args[1]).toMatch(/packages[\\/]daemon[\\/]src[\\/]entrypoint\.ts$/);
+    expect(spec.env.TEST_ENV).toBe("1");
+    expect(spec.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+  });
+
+  it("uses the packaged daemon entrypoint with ELECTRON_RUN_AS_NODE in packaged mode", () => {
+    const spec = createDaemonLaunchSpec({
+      isPackaged: true,
+      appPath: "/opt/todu/resources/app.asar",
+      execPath: "/opt/todu/todu",
+      env: { TEST_ENV: "1" },
+    });
+
+    expect(spec.command).toBe("/opt/todu/todu");
+    expect(spec.args).toEqual(["/opt/todu/resources/app.asar/dist/daemon/entrypoint.js"]);
+    expect(spec.env.TEST_ENV).toBe("1");
+    expect(spec.env.ELECTRON_RUN_AS_NODE).toBe("1");
+  });
+
+  it("starts the daemon from the dev launch spec without a global daemon install", async () => {
+    const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), "todu-electron-daemon-runtime-"));
+    const socketPath = path.join(storagePath, "daemon.sock");
+    const spec = createDaemonLaunchSpec({
+      isPackaged: false,
+      execPath: process.execPath,
+      env: {
+        ...process.env,
+        TODU_CONFIG: "",
+        TODUAI_CONFIG: "",
+        TODU_DATA_DIR: storagePath,
+        TODU_DAEMON_SOCKET: socketPath,
+        TODUAI_DAEMON_SOCKET: socketPath,
+      },
+    });
+
+    const child = spawn(spec.command, spec.args, {
+      cwd: path.resolve(TEST_DIR, "../../../.."),
+      env: spec.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    try {
+      await waitForSocket(socketPath, child, stderr);
+      expect(fs.existsSync(socketPath)).toBe(true);
+    } finally {
+      await stopProcess(child);
+    }
+  }, 15_000);
+});
+
+async function waitForSocket(
+  socketPath: string,
+  child: ReturnType<typeof spawn>,
+  stderr: string,
+): Promise<void> {
+  const deadline = Date.now() + 8_000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) {
+      return;
+    }
+
+    if (child.exitCode !== null) {
+      throw new Error(`Daemon exited early with code ${child.exitCode}: ${stderr}`);
+    }
+
+    await sleep(50);
+  }
+
+  throw new Error(`Timed out waiting for daemon socket: ${socketPath}\n${stderr}`);
+}
+
+async function stopProcess(processHandle: ReturnType<typeof spawn>): Promise<void> {
+  if (processHandle.exitCode !== null) {
+    return;
+  }
+
+  processHandle.kill("SIGTERM");
+
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      if (processHandle.exitCode === null) {
+        processHandle.kill("SIGKILL");
+      }
+      resolve();
+    }, 3_000);
+
+    processHandle.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/packages/electron/src/main/daemon-runtime.test.ts
+++ b/packages/electron/src/main/daemon-runtime.test.ts
@@ -1,10 +1,13 @@
-import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
-import { createDaemonLaunchSpec, resolveDaemonEntrypointPath } from "./daemon-runtime.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDaemonLaunchSpec,
+  resolveDaemonEntrypointPath,
+  startBundledDaemonProcess,
+} from "./daemon-runtime.js";
 
 describe("resolveDaemonEntrypointPath", () => {
   it("resolves packaged daemon entrypoint inside the app bundle", () => {
@@ -23,7 +26,9 @@ describe("resolveDaemonEntrypointPath", () => {
   });
 });
 
-const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("createDaemonLaunchSpec", () => {
   it("uses tsx to launch the daemon source entrypoint in dev mode", () => {
@@ -54,35 +59,63 @@ describe("createDaemonLaunchSpec", () => {
     expect(spec.env.ELECTRON_RUN_AS_NODE).toBe("1");
   });
 
+  it("passes packaged launch settings through to the spawned daemon process", async () => {
+    const socketPath = "/tmp/todu-electron-daemon.sock";
+    const stderr = createMockReadable();
+    const mockChild = {
+      exitCode: null,
+      stderr,
+      kill: vi.fn(),
+      unref: vi.fn(),
+    } as unknown as ChildProcess;
+    const spawnProcess = vi.fn().mockReturnValue(mockChild);
+
+    queueSocketExists(socketPath, [false, true]);
+
+    await startBundledDaemonProcess({
+      isPackaged: true,
+      appPath: "/opt/todu/resources/app.asar",
+      execPath: "/opt/todu/todu",
+      socketPath,
+      spawnProcess,
+      env: { TEST_ENV: "1" },
+    });
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "/opt/todu/todu",
+      ["/opt/todu/resources/app.asar/dist/daemon/entrypoint.js"],
+      expect.objectContaining({
+        detached: true,
+        cwd: "/opt/todu/resources",
+        stdio: ["ignore", "ignore", "pipe"],
+        env: expect.objectContaining({
+          TEST_ENV: "1",
+          ELECTRON_RUN_AS_NODE: "1",
+          TODU_DAEMON_SOCKET: socketPath,
+          TODUAI_DAEMON_SOCKET: socketPath,
+        }),
+      }),
+    );
+    expect(mockChild.unref).toHaveBeenCalled();
+  });
+
   it("starts the daemon from the dev launch spec without a global daemon install", async () => {
     const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), "todu-electron-daemon-runtime-"));
     const socketPath = path.join(storagePath, "daemon.sock");
-    const spec = createDaemonLaunchSpec({
+
+    const child = await startBundledDaemonProcess({
       isPackaged: false,
       execPath: process.execPath,
+      socketPath,
       env: {
         ...process.env,
         TODU_CONFIG: "",
         TODUAI_CONFIG: "",
         TODU_DATA_DIR: storagePath,
-        TODU_DAEMON_SOCKET: socketPath,
-        TODUAI_DAEMON_SOCKET: socketPath,
       },
     });
 
-    const child = spawn(spec.command, spec.args, {
-      cwd: path.resolve(TEST_DIR, "../../../.."),
-      env: spec.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stderr = "";
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-
     try {
-      await waitForSocket(socketPath, child, stderr);
       expect(fs.existsSync(socketPath)).toBe(true);
     } finally {
       await stopProcess(child);
@@ -90,28 +123,7 @@ describe("createDaemonLaunchSpec", () => {
   }, 15_000);
 });
 
-async function waitForSocket(
-  socketPath: string,
-  child: ReturnType<typeof spawn>,
-  stderr: string,
-): Promise<void> {
-  const deadline = Date.now() + 8_000;
-  while (Date.now() < deadline) {
-    if (fs.existsSync(socketPath)) {
-      return;
-    }
-
-    if (child.exitCode !== null) {
-      throw new Error(`Daemon exited early with code ${child.exitCode}: ${stderr}`);
-    }
-
-    await sleep(50);
-  }
-
-  throw new Error(`Timed out waiting for daemon socket: ${socketPath}\n${stderr}`);
-}
-
-async function stopProcess(processHandle: ReturnType<typeof spawn>): Promise<void> {
+async function stopProcess(processHandle: ChildProcess): Promise<void> {
   if (processHandle.exitCode !== null) {
     return;
   }
@@ -133,8 +145,22 @@ async function stopProcess(processHandle: ReturnType<typeof spawn>): Promise<voi
   });
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+function createMockReadable(): NodeJS.ReadableStream {
+  return {
+    destroy() {},
+    on() {
+      return this;
+    },
+  } as NodeJS.ReadableStream;
+}
+
+function queueSocketExists(socketPath: string, states: boolean[]): void {
+  const originalExistsSync = fs.existsSync.bind(fs);
+  vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+    if (candidate === socketPath) {
+      return states.shift() ?? true;
+    }
+
+    return originalExistsSync(candidate);
   });
 }

--- a/packages/electron/src/main/daemon-runtime.ts
+++ b/packages/electron/src/main/daemon-runtime.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export interface ResolveDaemonEntrypointPathOptions {
+  isPackaged: boolean;
+  appPath?: string;
+  moduleDir?: string;
+}
+
+export interface CreateDaemonLaunchSpecOptions extends ResolveDaemonEntrypointPathOptions {
+  execPath?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface DaemonLaunchSpec {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  entrypointPath: string;
+}
+
+export function resolveDaemonEntrypointPath(options: ResolveDaemonEntrypointPathOptions): string {
+  if (options.isPackaged) {
+    const appPath = options.appPath;
+    if (!appPath) {
+      throw new Error("Packaged daemon entrypoint resolution requires appPath");
+    }
+
+    return path.join(appPath, "dist", "daemon", "entrypoint.js");
+  }
+
+  return path.resolve(options.moduleDir ?? MODULE_DIR, "../../../daemon/src/entrypoint.ts");
+}
+
+export function createDaemonLaunchSpec(options: CreateDaemonLaunchSpecOptions): DaemonLaunchSpec {
+  const entrypointPath = resolveDaemonEntrypointPath(options);
+  const command = options.execPath ?? process.execPath;
+  const env = {
+    ...(options.env ?? process.env),
+  };
+
+  if (options.isPackaged) {
+    return {
+      command,
+      args: [entrypointPath],
+      env: {
+        ...env,
+        ELECTRON_RUN_AS_NODE: "1",
+      },
+      entrypointPath,
+    };
+  }
+
+  return {
+    command,
+    args: [resolveTsxCliPath(options.moduleDir), entrypointPath],
+    env,
+    entrypointPath,
+  };
+}
+
+function resolveTsxCliPath(moduleDir = MODULE_DIR): string {
+  return path.resolve(moduleDir, "../../../../node_modules/tsx/dist/cli.mjs");
+}

--- a/packages/electron/src/main/daemon-runtime.ts
+++ b/packages/electron/src/main/daemon-runtime.ts
@@ -1,3 +1,5 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +21,13 @@ export interface DaemonLaunchSpec {
   args: string[];
   env: NodeJS.ProcessEnv;
   entrypointPath: string;
+}
+
+export interface StartBundledDaemonOptions extends CreateDaemonLaunchSpecOptions {
+  socketPath: string;
+  cwd?: string;
+  startupTimeoutMs?: number;
+  spawnProcess?: typeof spawn;
 }
 
 export function resolveDaemonEntrypointPath(options: ResolveDaemonEntrypointPathOptions): string {
@@ -61,6 +70,75 @@ export function createDaemonLaunchSpec(options: CreateDaemonLaunchSpecOptions): 
   };
 }
 
+export async function startBundledDaemonProcess(
+  options: StartBundledDaemonOptions,
+): Promise<ChildProcess> {
+  const spec = createDaemonLaunchSpec(options);
+  const child = (options.spawnProcess ?? spawn)(spec.command, spec.args, {
+    cwd: options.cwd ?? resolveDaemonLaunchCwd(options),
+    detached: true,
+    env: {
+      ...spec.env,
+      TODU_DAEMON_SOCKET: options.socketPath,
+      TODUAI_DAEMON_SOCKET: options.socketPath,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+  let stderr = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    await waitForSocket(options.socketPath, child, options.startupTimeoutMs ?? 5_000, () => stderr);
+    child.unref();
+    child.stderr?.destroy();
+    return child;
+  } catch (error) {
+    child.kill("SIGTERM");
+    throw new Error(
+      `Failed to start bundled daemon from ${spec.entrypointPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 function resolveTsxCliPath(moduleDir = MODULE_DIR): string {
   return path.resolve(moduleDir, "../../../../node_modules/tsx/dist/cli.mjs");
+}
+
+function resolveDaemonLaunchCwd(options: ResolveDaemonEntrypointPathOptions): string {
+  if (options.isPackaged) {
+    return path.dirname(options.appPath ?? process.cwd());
+  }
+
+  return path.resolve(options.moduleDir ?? MODULE_DIR, "../../../..");
+}
+
+async function waitForSocket(
+  socketPath: string,
+  child: ChildProcess,
+  timeoutMs: number,
+  getStderr: () => string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) {
+      return;
+    }
+
+    if (child.exitCode !== null) {
+      throw new Error(`daemon exited early with code ${child.exitCode}: ${getStderr()}`);
+    }
+
+    await sleep(50);
+  }
+
+  throw new Error(`timed out waiting for daemon socket: ${socketPath}\n${getStderr()}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/packages/electron/src/main/daemon-startup.test.ts
+++ b/packages/electron/src/main/daemon-startup.test.ts
@@ -24,7 +24,7 @@ describe("ensureDaemonReady", () => {
     });
   });
 
-  it("retries and then succeeds", async () => {
+  it("starts the daemon on first unavailable response and then succeeds", async () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({
@@ -38,6 +38,7 @@ describe("ensureDaemonReady", () => {
         ok: true,
         value: { protocolVersion: "1" },
       });
+    const startDaemon = vi.fn().mockResolvedValue(undefined);
 
     await expect(
       ensureDaemonReady(
@@ -46,11 +47,38 @@ describe("ensureDaemonReady", () => {
           protocolVersion: "1",
           maxAttempts: 2,
           retryDelayMs: 0,
+          startDaemon,
         },
       ),
     ).resolves.toBeUndefined();
 
+    expect(startDaemon).toHaveBeenCalledTimes(1);
     expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces bundled daemon startup failures", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "DAEMON_UNAVAILABLE",
+        message: "socket missing",
+      },
+    });
+    const startDaemon = vi.fn().mockRejectedValue(new Error("Failed to start bundled daemon"));
+
+    await expect(
+      ensureDaemonReady(
+        { request },
+        {
+          protocolVersion: "1",
+          maxAttempts: 2,
+          retryDelayMs: 0,
+          startDaemon,
+        },
+      ),
+    ).rejects.toThrow(
+      "Local daemon is required but unavailable (DAEMON_UNAVAILABLE: socket missing). Failed to start bundled daemon",
+    );
   });
 
   it("throws actionable error when daemon stays unavailable", async () => {
@@ -69,10 +97,11 @@ describe("ensureDaemonReady", () => {
           protocolVersion: "1",
           maxAttempts: 2,
           retryDelayMs: 0,
+          unavailableHint: "todu could not start its bundled daemon.",
         },
       ),
     ).rejects.toThrow(
-      "Local daemon is required but unavailable (DAEMON_UNAVAILABLE: socket missing). Start it with 'todu daemon start' and relaunch Electron.",
+      "Local daemon is required but unavailable (DAEMON_UNAVAILABLE: socket missing). todu could not start its bundled daemon.",
     );
   });
 });

--- a/packages/electron/src/main/daemon-startup.ts
+++ b/packages/electron/src/main/daemon-startup.ts
@@ -4,6 +4,8 @@ export interface EnsureDaemonReadyOptions {
   protocolVersion: string;
   maxAttempts?: number;
   retryDelayMs?: number;
+  startDaemon?: () => Promise<void>;
+  unavailableHint?: string;
 }
 
 export async function ensureDaemonReady(
@@ -14,6 +16,7 @@ export async function ensureDaemonReady(
   const retryDelayMs = options.retryDelayMs ?? 200;
 
   let lastError = "unknown daemon error";
+  let startAttempted = false;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const hello = await daemon.request<{ protocolVersion: string }>("daemon.hello", {
@@ -26,13 +29,24 @@ export async function ensureDaemonReady(
 
     lastError = `${hello.error.code}: ${hello.error.message}`;
 
+    if (!startAttempted && hello.error.code === "DAEMON_UNAVAILABLE" && options.startDaemon) {
+      startAttempted = true;
+      try {
+        await options.startDaemon();
+      } catch (error) {
+        throw new Error(
+          `Local daemon is required but unavailable (${lastError}). ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
     if (attempt < maxAttempts) {
       await wait(retryDelayMs);
     }
   }
 
   throw new Error(
-    `Local daemon is required but unavailable (${lastError}). Start it with 'todu daemon start' and relaunch Electron.`,
+    `Local daemon is required but unavailable (${lastError}). ${options.unavailableHint ?? "Start it with 'todu daemon start' and relaunch Electron."}`,
   );
 }
 

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -14,6 +14,7 @@ import {
   type DaemonConnectionResult,
   resolveDaemonSocketPath,
 } from "./daemon-connection-manager.js";
+import { startBundledDaemonProcess } from "./daemon-runtime.js";
 import { ensureDaemonReady } from "./daemon-startup.js";
 import { createDaemonToduClient } from "./daemon-todu-client.js";
 import { registerIpcHandlers } from "./ipc.js";
@@ -54,9 +55,10 @@ function assertRequestOk<T>(
 
 async function init(): Promise<void> {
   const { storagePath } = loadElectronConfig();
+  const socketPath = resolveDaemonSocketPath(storagePath);
 
   daemonConnectionManager = createDaemonConnectionManager({
-    socketPath: resolveDaemonSocketPath(storagePath),
+    socketPath,
     hooks: {
       onConnected: async ({ request }) => {
         const hello = await request("daemon.hello", {
@@ -86,6 +88,17 @@ async function init(): Promise<void> {
 
   await ensureDaemonReady(daemonConnectionManager, {
     protocolVersion: DAEMON_PROTOCOL_VERSION,
+    startDaemon: app.isPackaged
+      ? () =>
+          startBundledDaemonProcess({
+            isPackaged: true,
+            appPath: app.getAppPath(),
+            socketPath,
+          })
+      : undefined,
+    unavailableHint: app.isPackaged
+      ? "todu could not start its bundled daemon. Relaunch the app or reinstall it if the problem persists."
+      : "Start it with 'todu daemon start' and relaunch Electron.",
   });
 
   const daemonTodu = createDaemonToduClient(daemonConnectionManager);


### PR DESCRIPTION
## Summary
- build `@todu/daemon` as part of the Electron build and copy the runtime into `packages/electron/dist/daemon`
- add Electron daemon runtime path/launch helpers for dev vs packaged modes
- add tests covering resolution and daemon launch without a separate global install

## Verification
- npm test -- packages/electron/src/main/daemon-runtime.test.ts packages/electron/src/main/daemon-startup.test.ts
- npm run --workspace=packages/electron build
- make pre-pr

Task: #task-4a0b1a83