### PR TITLE
feat: manage daemon lifecycle in electron

### DIFF
--- a/packages/electron/src/main/daemon-lifecycle.test.ts
+++ b/packages/electron/src/main/daemon-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPackagedDaemonLifecycle } from "./daemon-lifecycle.js";
+
+describe("createPackagedDaemonLifecycle", () => {
+  it("starts the bundled daemon with packaged app settings", async () => {
+    const startDaemon = vi.fn().mockResolvedValue(undefined);
+    const lifecycle = createPackagedDaemonLifecycle({
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+      startDaemon,
+    });
+
+    await lifecycle.startIfNeeded();
+
+    expect(startDaemon).toHaveBeenCalledWith({
+      isPackaged: true,
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+    });
+  });
+
+  it("deduplicates concurrent start attempts", async () => {
+    let resolveStart: (() => void) | null = null;
+    const startDaemon = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const lifecycle = createPackagedDaemonLifecycle({
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+      startDaemon,
+    });
+
+    const first = lifecycle.startIfNeeded();
+    const second = lifecycle.startIfNeeded();
+    resolveStart?.();
+
+    await Promise.all([first, second]);
+
+    expect(startDaemon).toHaveBeenCalledTimes(1);
+  });
+
+  it("tries to restart the daemon when reconnect is scheduled for daemon-unavailable errors", async () => {
+    const startDaemon = vi.fn().mockResolvedValue(undefined);
+    const lifecycle = createPackagedDaemonLifecycle({
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+      startDaemon,
+    });
+
+    lifecycle.handleReconnectScheduled({
+      attempt: 1,
+      delayMs: 250,
+      reason: new Error("Daemon unavailable at socket: /tmp/daemon.sock"),
+    });
+
+    await vi.waitFor(() => {
+      expect(startDaemon).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not restart the daemon for non-availability reconnect reasons", async () => {
+    const startDaemon = vi.fn().mockResolvedValue(undefined);
+    const lifecycle = createPackagedDaemonLifecycle({
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+      startDaemon,
+    });
+
+    lifecycle.handleReconnectScheduled({
+      attempt: 1,
+      delayMs: 250,
+      reason: new Error("Protocol version mismatch"),
+    });
+
+    await Promise.resolve();
+
+    expect(startDaemon).not.toHaveBeenCalled();
+  });
+
+  it("reports actionable restart failures", async () => {
+    const onError = vi.fn();
+    const startDaemon = vi.fn().mockRejectedValue(new Error("spawn failed"));
+    const lifecycle = createPackagedDaemonLifecycle({
+      appPath: "/opt/todu/resources/app.asar",
+      socketPath: "/tmp/daemon.sock",
+      startDaemon,
+      onError,
+    });
+
+    lifecycle.handleReconnectScheduled({
+      attempt: 1,
+      delayMs: 250,
+      reason: new Error("DAEMON_UNAVAILABLE: socket missing"),
+    });
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(
+        "todu lost connection to its local daemon and could not restart it. Relaunch the app or reinstall it if the problem persists. spawn failed",
+      );
+    });
+  });
+});

--- a/packages/electron/src/main/daemon-lifecycle.ts
+++ b/packages/electron/src/main/daemon-lifecycle.ts
@@ -1,0 +1,73 @@
+import type { DaemonReconnectInfo } from "./daemon-connection-manager.js";
+import { startBundledDaemonProcess } from "./daemon-runtime.js";
+
+export interface PackagedDaemonLifecycleOptions {
+  appPath: string;
+  socketPath: string;
+  onError?: (message: string) => void;
+  startDaemon?: typeof startBundledDaemonProcess;
+}
+
+export interface PackagedDaemonLifecycle {
+  startIfNeeded(): Promise<void>;
+  handleReconnectScheduled(info: DaemonReconnectInfo): void;
+  unavailableHint: string;
+}
+
+const PACKAGED_DAEMON_UNAVAILABLE_HINT =
+  "todu could not start its bundled daemon. Relaunch the app or reinstall it if the problem persists.";
+const PACKAGED_DAEMON_RESTART_FAILED_HINT =
+  "todu lost connection to its local daemon and could not restart it. Relaunch the app or reinstall it if the problem persists.";
+
+export function createPackagedDaemonLifecycle(
+  options: PackagedDaemonLifecycleOptions,
+): PackagedDaemonLifecycle {
+  let startupPromise: Promise<void> | null = null;
+  const startDaemon = options.startDaemon ?? startBundledDaemonProcess;
+
+  const startIfNeeded = async (): Promise<void> => {
+    if (startupPromise) {
+      return startupPromise;
+    }
+
+    startupPromise = startDaemon({
+      isPackaged: true,
+      appPath: options.appPath,
+      socketPath: options.socketPath,
+    }).then(() => undefined);
+
+    try {
+      await startupPromise;
+    } finally {
+      startupPromise = null;
+    }
+  };
+
+  const handleReconnectScheduled = (info: DaemonReconnectInfo): void => {
+    if (!isDaemonUnavailableReason(info.reason)) {
+      return;
+    }
+
+    void startIfNeeded().catch((error) => {
+      options.onError?.(
+        `${PACKAGED_DAEMON_RESTART_FAILED_HINT} ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  };
+
+  return {
+    startIfNeeded,
+    handleReconnectScheduled,
+    unavailableHint: PACKAGED_DAEMON_UNAVAILABLE_HINT,
+  };
+}
+
+function isDaemonUnavailableReason(reason: unknown): boolean {
+  if (!(reason instanceof Error)) {
+    return false;
+  }
+
+  return (
+    reason.message.includes("DAEMON_UNAVAILABLE") || reason.message.includes("Daemon unavailable")
+  );
+}

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import { setupAgent, teardownAgent } from "./agent.js";
 import {
   buildReconnectRefreshEvents,
@@ -14,7 +14,7 @@ import {
   type DaemonConnectionResult,
   resolveDaemonSocketPath,
 } from "./daemon-connection-manager.js";
-import { startBundledDaemonProcess } from "./daemon-runtime.js";
+import { createPackagedDaemonLifecycle } from "./daemon-lifecycle.js";
 import { ensureDaemonReady } from "./daemon-startup.js";
 import { createDaemonToduClient } from "./daemon-todu-client.js";
 import { registerIpcHandlers } from "./ipc.js";
@@ -57,6 +57,16 @@ async function init(): Promise<void> {
   const { storagePath } = loadElectronConfig();
   const socketPath = resolveDaemonSocketPath(storagePath);
 
+  const packagedDaemonLifecycle = app.isPackaged
+    ? createPackagedDaemonLifecycle({
+        appPath: app.getAppPath(),
+        socketPath,
+        onError: (message) => {
+          dialog.showErrorBox("todu daemon error", message);
+        },
+      })
+    : null;
+
   daemonConnectionManager = createDaemonConnectionManager({
     socketPath,
     hooks: {
@@ -74,6 +84,9 @@ async function init(): Promise<void> {
           dispatchRendererEvent(getMainWindow(), event);
         }
       },
+      onReconnectScheduled: (info) => {
+        packagedDaemonLifecycle?.handleReconnectScheduled(info);
+      },
       onEvent: (event) => {
         const rendererEvent = mapDaemonEventToRendererEvent(event);
         if (!rendererEvent) {
@@ -88,17 +101,10 @@ async function init(): Promise<void> {
 
   await ensureDaemonReady(daemonConnectionManager, {
     protocolVersion: DAEMON_PROTOCOL_VERSION,
-    startDaemon: app.isPackaged
-      ? () =>
-          startBundledDaemonProcess({
-            isPackaged: true,
-            appPath: app.getAppPath(),
-            socketPath,
-          })
-      : undefined,
-    unavailableHint: app.isPackaged
-      ? "todu could not start its bundled daemon. Relaunch the app or reinstall it if the problem persists."
-      : "Start it with 'todu daemon start' and relaunch Electron.",
+    startDaemon: packagedDaemonLifecycle?.startIfNeeded,
+    unavailableHint:
+      packagedDaemonLifecycle?.unavailableHint ??
+      "Start it with 'todu daemon start' and relaunch Electron.",
   });
 
   const daemonTodu = createDaemonToduClient(daemonConnectionManager);
@@ -149,7 +155,9 @@ app
   .whenReady()
   .then(init)
   .catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
     console.error(error);
+    dialog.showErrorBox("todu startup failed", message);
     app.quit();
   });
 


### PR DESCRIPTION
## Summary
- add a packaged Electron daemon lifecycle helper that deduplicates startup and retries bundled daemon startup on daemon-unavailable reconnects
- wire packaged startup and reconnect scheduling through the lifecycle helper
- surface packaged daemon startup/runtime failures with desktop dialogs instead of CLI-oriented instructions

## Verification
- npm test -- packages/electron/src/main/daemon-lifecycle.test.ts packages/electron/src/main/daemon-startup.test.ts packages/electron/src/main/daemon-runtime.test.ts
- make pre-pr

Task: #task-31d020fb