### PR TITLE
feat: validate bundled desktop runtime in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Build Electron (linux)
         run: |
           make build-electron
+          npm run --workspace=packages/electron dist:linux:dir
+          npm run --workspace=packages/electron validate:daemon-bundle:linux
           npm run --workspace=packages/electron dist:linux -- --linux AppImage deb
 
       - name: Upload CLI binaries
@@ -134,6 +136,7 @@ jobs:
           path: |
             dist/installers/*.AppImage
             dist/installers/*.deb
+            dist/installers/linux-unpacked/**
 
   build-macos:
     name: Build macOS
@@ -264,10 +267,24 @@ jobs:
             # Extract content between this version header and the next
             BODY=$(awk "/^## .*${VERSION//./\\.}/ {found=1; next} /^## / {if(found) exit} found {print}" CHANGELOG.md)
             if [ -z "$BODY" ]; then
-              BODY="Release v${VERSION}"
+              BODY=$(cat <<EOF
+Release v${VERSION}
+
+## Install
+- Desktop: download the platform installer from this release. The packaged app bundles the local daemon runtime.
+- CLI: install with `npm install -g @todu/cli`.
+EOF
+)
             fi
           else
-            BODY="Release v${VERSION}"
+            BODY=$(cat <<EOF
+Release v${VERSION}
+
+## Install
+- Desktop: download the platform installer from this release. The packaged app bundles the local daemon runtime.
+- CLI: install with `npm install -g @todu/cli`.
+EOF
+)
           fi
           # Write to file to preserve newlines
           echo "$BODY" > release-notes.md

--- a/README.md
+++ b/README.md
@@ -6,22 +6,49 @@ todu is a local-first task management project (CLI + Electron) backed by a local
 
 ## Install
 
-### Prerequisites
+### Desktop app (recommended)
+
+Download the latest desktop release for your platform from GitHub Releases:
+
+- Linux: `.AppImage` or `.deb`
+- macOS: `.dmg`
+- Windows: `.exe`
+
+Desktop releases bundle the local daemon runtime. Launching the packaged app starts and manages that bundled daemon automatically for normal desktop usage.
+
+### CLI
+
+Prerequisites:
 
 - Node.js 20+
 - npm
-- Bun 1.0+ (only needed for standalone CLI binaries)
+
+Install:
+
+```bash
+npm install -g @todu/cli
+```
+
+Upgrade:
+
+```bash
+npm install -g @todu/cli@latest
+```
 
 ### Build from source
+
+Additional prerequisite for standalone CLI binaries:
+
+- Bun 1.0+
+
+Build workspace packages:
 
 ```bash
 npm install
 make build
 ```
 
-### Install desktop application (Linux/macOS)
-
-From source checkout:
+Build/install desktop app from a source checkout:
 
 ```bash
 make dist


### PR DESCRIPTION
## Summary
- run packaged Linux daemon-bundle validation during the release workflow before building publishable installers
- upload the linux-unpacked app as a release artifact so packaged runtime validation stays visible in release automation
- add fallback release notes/install guidance and update README for the desktop-first bundled-daemon install model

## Verification
- npm run check:ci
- make pre-pr

Task: #task-6d841e91