### PR TITLE
feat: define cli companion install flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ Release v${VERSION}
 
 ## Install
 - Desktop: download the platform installer from this release. The packaged app bundles the local daemon runtime.
-- CLI: install with `npm install -g @todu/cli`.
+- CLI (optional power-user companion): install the matching version with `npm install -g @todu/cli@${VERSION}` or use `npm install -g @todu/cli` for latest.
 EOF
 )
             fi
@@ -282,7 +282,7 @@ Release v${VERSION}
 
 ## Install
 - Desktop: download the platform installer from this release. The packaged app bundles the local daemon runtime.
-- CLI: install with `npm install -g @todu/cli`.
+- CLI (optional power-user companion): install the matching version with `npm install -g @todu/cli@${VERSION}` or use `npm install -g @todu/cli` for latest.
 EOF
 )
           fi

--- a/README.md
+++ b/README.md
@@ -16,17 +16,32 @@ Download the latest desktop release for your platform from GitHub Releases:
 
 Desktop releases bundle the local daemon runtime. Launching the packaged app starts and manages that bundled daemon automatically for normal desktop usage.
 
-### CLI
+### CLI companion (optional)
+
+Most desktop users do **not** need the CLI for normal app usage. The packaged desktop app bundles and manages the local daemon on its own.
+
+Use the CLI when you want power-user workflows like:
+
+- `todu daemon status`
+- `todu daemon start|stop|restart`
+- scripting or automation
+- plugin or daemon-oriented local operations
 
 Prerequisites:
 
 - Node.js 20+
 - npm
 
-Install:
+Install the latest CLI:
 
 ```bash
 npm install -g @todu/cli
+```
+
+Install the CLI version matching a desktop release:
+
+```bash
+npm install -g @todu/cli@<desktop-version>
 ```
 
 Upgrade:
@@ -34,6 +49,12 @@ Upgrade:
 ```bash
 npm install -g @todu/cli@latest
 ```
+
+Compatibility guidance:
+
+- Preferred: keep the CLI version aligned with your desktop app version.
+- The desktop app version is shown in Settings and in release notes.
+- The CLI and desktop app both use the same default user-local config and data paths, so the CLI targets the same local daemon and dataset unless you override paths with env vars.
 
 ### Build from source
 
@@ -94,6 +115,8 @@ If you are working on Electron UI:
 ```bash
 make dev-electron
 ```
+
+For daemon path details and overrides, see [docs/cli-daemon-usage.md](docs/cli-daemon-usage.md).
 
 ## Key docs
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -6,6 +6,29 @@ The legacy `todu serve` path has been removed.
 
 For always-on daemon startup (recommended), use OS service manager setup from [`daemon-service-operations.md`](daemon-service-operations.md).
 
+## Desktop companion CLI guidance
+
+The desktop app does not require a separate CLI install for normal use. Packaged desktop releases bundle and manage the local daemon automatically.
+
+Use the CLI as an optional companion for power-user workflows such as:
+
+- checking daemon state (`todu daemon status`)
+- explicit daemon lifecycle control (`todu daemon start|stop|restart`)
+- automation and scripting
+- plugin-oriented local operations
+
+Recommended install paths:
+
+- latest CLI: `npm install -g @todu/cli`
+- CLI version matching desktop app version: `npm install -g @todu/cli@<desktop-version>`
+
+Compatibility expectations:
+
+- Preferred: use a CLI version that matches your installed desktop app version.
+- Desktop app version is shown in Settings and in release notes.
+- CLI and desktop app both use the same default user-local config and data paths, so they target the same local daemon and dataset by default.
+- If needed, you can point the CLI at a different daemon socket with `TODU_DAEMON_SOCKET`.
+
 ## Config/data migration defaults
 
 - Default home config path is now `~/.config/todu/config.yaml`.


### PR DESCRIPTION
## Summary
- document the CLI as an optional power-user companion instead of a required desktop install
- add matching-version install guidance and same-daemon/same-dataset expectations
- update release-note fallback text so desktop releases explain how to obtain a matching CLI version

## Verification
- npm run check:ci
- make pre-pr

Task: #task-8b1863c0