### PR TITLE
feat: finish install flow validation and guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
       - name: Build Electron (macOS)
         run: |
           make build-electron
+          npm run --workspace=packages/electron dist:mac:dir
+          npm run --workspace=packages/electron validate:daemon-bundle:mac
           npm run --workspace=packages/electron dist:mac
 
       - name: Upload CLI binaries
@@ -186,7 +188,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: electron-macos
-          path: dist/installers/*.dmg
+          path: |
+            dist/installers/*.dmg
+            dist/installers/mac/**
 
   build-windows:
     name: Build Windows
@@ -222,6 +226,8 @@ jobs:
       - name: Build Electron (Windows)
         run: |
           make build-electron
+          npm run --workspace=packages/electron dist:win:dir
+          npm run --workspace=packages/electron validate:daemon-bundle:win
           npm run --workspace=packages/electron dist:win
         shell: bash
 
@@ -235,7 +241,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: electron-windows
-          path: dist/installers/*.exe
+          path: |
+            dist/installers/*.exe
+            dist/installers/win-unpacked/**
 
   # ===========================================================================
   # Release: create GitHub Release with all artifacts

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -18,8 +18,12 @@
     "dist:linux": "electron-builder --config electron-builder.yml --linux",
     "dist:linux:dir": "electron-builder --config electron-builder.yml --linux dir",
     "dist:mac": "electron-builder --config electron-builder.yml --mac",
+    "dist:mac:dir": "electron-builder --config electron-builder.yml --mac dir",
     "dist:win": "electron-builder --config electron-builder.yml --win",
-    "validate:daemon-bundle:linux": "node scripts/validate-daemon-bundle.mjs --unpacked-dir ../../dist/installers/linux-unpacked"
+    "dist:win:dir": "electron-builder --config electron-builder.yml --win dir",
+    "validate:daemon-bundle:linux": "node scripts/validate-daemon-bundle.mjs --unpacked-dir ../../dist/installers/linux-unpacked",
+    "validate:daemon-bundle:mac": "node scripts/validate-daemon-bundle.mjs --app-bundle ../../dist/installers/mac/todu.app",
+    "validate:daemon-bundle:win": "node scripts/validate-daemon-bundle.mjs --unpacked-dir ../../dist/installers/win-unpacked"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.66.1",

--- a/packages/electron/scripts/validate-daemon-bundle.mjs
+++ b/packages/electron/scripts/validate-daemon-bundle.mjs
@@ -5,28 +5,36 @@ import path from "node:path";
 
 const args = parseArgs(process.argv.slice(2));
 const unpackedDir = args.get("unpacked-dir") ? path.resolve(args.get("unpacked-dir")) : null;
+const appBundle = args.get("app-bundle") ? path.resolve(args.get("app-bundle")) : null;
 const executableArg = args.get("executable");
 const appPathArg = args.get("app-path");
 const executablePath = executableArg
   ? path.resolve(executableArg)
-  : unpackedDir
-    ? resolveExecutablePath(unpackedDir)
-    : null;
+  : appBundle
+    ? path.join(appBundle, "Contents", "MacOS", "todu")
+    : unpackedDir
+      ? resolveExecutablePath(unpackedDir)
+      : null;
 const appPath = appPathArg
   ? path.resolve(appPathArg)
-  : unpackedDir
-    ? path.join(unpackedDir, "resources", "app.asar")
-    : null;
+  : appBundle
+    ? path.join(appBundle, "Contents", "Resources", "app.asar")
+    : unpackedDir
+      ? path.join(unpackedDir, "resources", "app.asar")
+      : null;
 
 if (!executablePath || !appPath) {
   throw new Error(
-    "Usage: node scripts/validate-daemon-bundle.mjs (--unpacked-dir <path> | --executable <path> --app-path <path>)",
+    "Usage: node scripts/validate-daemon-bundle.mjs (--unpacked-dir <path> | --app-bundle <path> | --executable <path> --app-path <path>)",
   );
 }
 
 const entrypointPath = path.join(appPath, "dist", "daemon", "entrypoint.js");
 if (!fs.existsSync(executablePath)) {
   throw new Error(`Packaged executable not found: ${executablePath}`);
+}
+if (!fs.existsSync(entrypointPath)) {
+  throw new Error(`Bundled daemon entrypoint not found: ${entrypointPath}`);
 }
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), "todu-electron-daemon-bundle-"));
@@ -120,6 +128,7 @@ function resolveExecutablePath(unpackedDir) {
     "libGLESv2.so",
     "libvk_swiftshader.so",
     "libvulkan.so.1",
+    "vk_swiftshader_icd.json",
   ]);
   const candidates = fs
     .readdirSync(unpackedDir, { withFileTypes: true })

--- a/packages/electron/src/main/daemon-startup.test.ts
+++ b/packages/electron/src/main/daemon-startup.test.ts
@@ -56,6 +56,30 @@ describe("ensureDaemonReady", () => {
     expect(request).toHaveBeenCalledTimes(2);
   });
 
+  it("surfaces protocol mismatch with actionable guidance", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "PROTOCOL_MISMATCH",
+        message: "daemon protocol 2 does not match client protocol 1",
+      },
+    });
+
+    await expect(
+      ensureDaemonReady(
+        { request },
+        {
+          protocolVersion: "1",
+          maxAttempts: 2,
+          retryDelayMs: 0,
+          protocolMismatchHint: "Install matching desktop and CLI versions.",
+        },
+      ),
+    ).rejects.toThrow(
+      "Local daemon is incompatible (PROTOCOL_MISMATCH: daemon protocol 2 does not match client protocol 1). Install matching desktop and CLI versions.",
+    );
+  });
+
   it("surfaces bundled daemon startup failures", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/electron/src/main/daemon-startup.ts
+++ b/packages/electron/src/main/daemon-startup.ts
@@ -6,6 +6,7 @@ export interface EnsureDaemonReadyOptions {
   retryDelayMs?: number;
   startDaemon?: () => Promise<void>;
   unavailableHint?: string;
+  protocolMismatchHint?: string;
 }
 
 export async function ensureDaemonReady(
@@ -28,6 +29,12 @@ export async function ensureDaemonReady(
     }
 
     lastError = `${hello.error.code}: ${hello.error.message}`;
+
+    if (hello.error.code === "PROTOCOL_MISMATCH") {
+      throw new Error(
+        `Local daemon is incompatible (${lastError}). ${options.protocolMismatchHint ?? "Update todu so the desktop app and local daemon use matching versions."}`,
+      );
+    }
 
     if (!startAttempted && hello.error.code === "DAEMON_UNAVAILABLE" && options.startDaemon) {
       startAttempted = true;

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -105,6 +105,9 @@ async function init(): Promise<void> {
     unavailableHint:
       packagedDaemonLifecycle?.unavailableHint ??
       "Start it with 'todu daemon start' and relaunch Electron.",
+    protocolMismatchHint: app.isPackaged
+      ? "The bundled desktop app could not talk to the local daemon because their versions do not match. Reinstall or relaunch todu so the desktop app and daemon are updated together."
+      : "Update todu so the desktop app and local daemon use matching versions.",
   });
 
   const daemonTodu = createDaemonToduClient(daemonConnectionManager);


### PR DESCRIPTION
## Summary
- add explicit packaged-app protocol mismatch guidance so compatibility failures show actionable desktop-facing instructions
- extend bundled daemon validation setup to macOS and Windows alongside existing Linux validation
- add Electron package scripts for macOS and Windows dir/unpacked validation flows

## Verification
- npm test -- packages/electron/src/main/daemon-startup.test.ts
- npm run check:ci
- make pre-pr

Task: #task-55515a83