### PR TITLE
fix: release windows CLI without desktop bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
             dist/installers/mac/**
 
   build-windows:
-    name: Build Windows
+    name: Build Windows CLI
     needs: validate
     runs-on: windows-latest
     steps:
@@ -223,27 +223,11 @@ jobs:
           cp dist/cli/todu-cli-windows-x64.exe dist/cli/todu.exe
         shell: bash
 
-      - name: Build Electron (Windows)
-        run: |
-          make build-electron
-          npm run --workspace=packages/electron dist:win:dir
-          npm run --workspace=packages/electron validate:daemon-bundle:win
-          npm run --workspace=packages/electron dist:win
-        shell: bash
-
       - name: Upload CLI binary
         uses: actions/upload-artifact@v4
         with:
           name: cli-windows
           path: dist/cli/todu-cli-windows-x64.exe
-
-      - name: Upload Electron installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-windows
-          path: |
-            dist/installers/*.exe
-            dist/installers/win-unpacked/**
 
   # ===========================================================================
   # Release: create GitHub Release with all artifacts

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ todu is a local-first task management project (CLI + Electron) backed by a local
 
 ## Install
 
-### Desktop app (recommended)
+### Desktop app (recommended on Linux and macOS)
 
 Download the latest desktop release for your platform from GitHub Releases:
 
 - Linux: `.AppImage` or `.deb`
 - macOS: `.dmg`
-- Windows: `.exe`
 
 Desktop releases bundle the local daemon runtime. Launching the packaged app starts and manages that bundled daemon automatically for normal desktop usage.
+
+Windows desktop packaging is not released yet because the local daemon transport is currently implemented for Unix domain sockets. Windows users should use the CLI companion for now.
 
 ### CLI companion (optional)
 


### PR DESCRIPTION
## Summary
- stop blocking releases on Windows Electron packaging while daemon transport remains Unix-only
- keep publishing the Windows CLI binary from the release workflow
- update install docs so Windows users are directed to the CLI companion for now

## Verification
- $(go env GOPATH)/bin/actionlint .github/workflows/release.yml
- npm run check:ci
- make pre-pr