### PR TITLE
fix: publish daemon package for cli installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,7 @@ jobs:
           }
           publish_package packages/core
           publish_package packages/engine
+          publish_package packages/daemon
           publish_package packages/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -368,7 +369,15 @@ jobs:
             echo "::error::${pkg}@${VERSION} not found on registry after 5 attempts"
             return 1
           }
+
           verify_package @todu/core
           verify_package @todu/engine
+          verify_package @todu/daemon
           verify_package @todu/cli
-          echo "✅ All packages published at ${VERSION}"
+
+          CLI_WORKSPACE_DEPS=$(node -p 'const pkg=require("./packages/cli/package.json"); Object.keys(pkg.dependencies ?? {}).filter((name) => name.startsWith("@todu/")).join(" ")')
+          for pkg in $CLI_WORKSPACE_DEPS; do
+            verify_package "$pkg"
+          done
+
+          echo "✅ All published CLI workspace dependencies are available at ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
           VERSION="${TAG#v}"
           echo "Tag: $TAG, Version: $VERSION"
 
-          # Check all package.json versions match
-          for pkg in packages/core packages/engine packages/cli; do
+          # Check all published package.json versions match
+          for pkg in packages/core packages/engine packages/daemon packages/cli; do
             PKG_VERSION=$(node -p "require('./$pkg/package.json').version")
             if [ "$PKG_VERSION" != "$VERSION" ]; then
               echo "::error::Version mismatch: $pkg has $PKG_VERSION, expected $VERSION"

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -71,6 +71,7 @@ PACKAGES=(
   "package.json"
   "packages/core/package.json"
   "packages/engine/package.json"
+  "packages/daemon/package.json"
   "packages/cli/package.json"
   "packages/electron/package.json"
 )

--- a/Makefile
+++ b/Makefile
@@ -183,19 +183,21 @@ version: ## Show current version of all packages
 	@echo "Versions:"
 	@echo "  core:     $$(node -p "require('./packages/core/package.json').version")"
 	@echo "  engine:   $$(node -p "require('./packages/engine/package.json').version")"
+	@echo "  daemon:   $$(node -p "require('./packages/daemon/package.json').version")"
 	@echo "  cli:      $$(node -p "require('./packages/cli/package.json').version")"
 	@echo "  electron: $$(node -p "require('./packages/electron/package.json').version")"
 
 version-check: ## Verify all package versions match, including generated CLI version source
 	@V1=$$(node -p "require('./packages/core/package.json').version") && \
 	V2=$$(node -p "require('./packages/engine/package.json').version") && \
-	V3=$$(node -p "require('./packages/cli/package.json').version") && \
-	V4=$$(node -p "require('./packages/electron/package.json').version") && \
-	V5=$$(node -e "const fs=require('fs'); const src=fs.readFileSync('./packages/cli/src/version.ts','utf8'); const m=src.match(/VERSION = \\\"([^\\\"]+)\\\"/); if (!m) { process.exit(1); } process.stdout.write(m[1]);") && \
-	if [ "$$V1" = "$$V2" ] && [ "$$V2" = "$$V3" ] && [ "$$V3" = "$$V4" ] && [ "$$V4" = "$$V5" ]; then \
+	V3=$$(node -p "require('./packages/daemon/package.json').version") && \
+	V4=$$(node -p "require('./packages/cli/package.json').version") && \
+	V5=$$(node -p "require('./packages/electron/package.json').version") && \
+	V6=$$(node -e "const fs=require('fs'); const src=fs.readFileSync('./packages/cli/src/version.ts','utf8'); const m=src.match(/VERSION = \\\"([^\\\"]+)\\\"/); if (!m) { process.exit(1); } process.stdout.write(m[1]);") && \
+	if [ "$$V1" = "$$V2" ] && [ "$$V2" = "$$V3" ] && [ "$$V3" = "$$V4" ] && [ "$$V4" = "$$V5" ] && [ "$$V5" = "$$V6" ]; then \
 		echo "✅ All versions in sync at $$V1"; \
 	else \
-		echo "❌ Version mismatch: core=$$V1 engine=$$V2 cli=$$V3 electron=$$V4 cli_src=$$V5"; \
+		echo "❌ Version mismatch: core=$$V1 engine=$$V2 daemon=$$V3 cli=$$V4 electron=$$V5 cli_src=$$V6"; \
 		exit 1; \
 	fi
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@todu/daemon",
-  "version": "0.1.1",
+  "version": "0.18.0",
   "description": "Daemon runtime foundation for todu",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- publish `packages/daemon` in the npm release workflow before publishing the CLI
- verify `@todu/daemon` is available on npm for the release version
- verify all `@todu/*` workspace dependencies declared by the CLI are available after publish

## Verification
- $(go env GOPATH)/bin/actionlint .github/workflows/release.yml
- npm run check:ci
- make pre-pr

Task: #task-5c7af69e