### PR TITLE
feat: add desktop installer helper scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,11 @@ jobs:
           cp artifacts/electron-macos/*.dmg release-assets/ 2>/dev/null || true
           cp artifacts/electron-windows/*.exe release-assets/ 2>/dev/null || true
 
+          # Desktop installer helpers
+          cp scripts/install-linux.sh release-assets/install-todu-linux.sh
+          cp scripts/install-mac.sh release-assets/install-todu-mac.sh
+          chmod +x release-assets/install-todu-linux.sh release-assets/install-todu-mac.sh
+
           echo "Release assets:"
           ls -lh release-assets/
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install a specific version:
 curl -fsSL https://github.com/evcraddock/todu/releases/download/v0.18.0/install-todu-linux.sh | bash -s -- 0.18.0
 ```
 
-This installs `todu.AppImage` into `~/Applications` and creates a desktop launcher in `~/.local/share/applications`.
+This installs `todu.AppImage` into `~/.local/bin` and creates a desktop launcher in `~/.local/share/applications`.
 
 #### macOS install
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,39 @@ todu is a local-first task management project (CLI + Electron) backed by a local
 
 ### Desktop app (recommended on Linux and macOS)
 
-Download the latest desktop release for your platform from GitHub Releases:
-
-- Linux: `.AppImage` or `.deb`
-- macOS: `.dmg`
-
 Desktop releases bundle the local daemon runtime. Launching the packaged app starts and manages that bundled daemon automatically for normal desktop usage.
+
+#### Linux install
+
+Install the latest Linux desktop build with AppImage integration and a launcher entry:
+
+```bash
+curl -fsSL https://github.com/evcraddock/todu/releases/latest/download/install-todu-linux.sh | bash
+```
+
+Install a specific version:
+
+```bash
+curl -fsSL https://github.com/evcraddock/todu/releases/download/v0.18.0/install-todu-linux.sh | bash -s -- 0.18.0
+```
+
+This installs `todu.AppImage` into `~/Applications` and creates a desktop launcher in `~/.local/share/applications`.
+
+#### macOS install
+
+Install the latest macOS desktop build into `/Applications`:
+
+```bash
+curl -fsSL https://github.com/evcraddock/todu/releases/latest/download/install-todu-mac.sh | bash
+```
+
+Install a specific version:
+
+```bash
+curl -fsSL https://github.com/evcraddock/todu/releases/download/v0.18.0/install-todu-mac.sh | bash -s -- 0.18.0
+```
+
+This downloads the release DMG, mounts it, copies `todu.app` into `/Applications`, and unmounts the DMG.
 
 Windows desktop packaging is not released yet because the local daemon transport is currently implemented for Unix domain sockets. Windows users should use the CLI companion for now.
 

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 REPO="evcraddock/todu"
 VERSION="${1:-latest}"
-INSTALL_DIR="${HOME}/Applications"
+INSTALL_DIR="${HOME}/.local/bin"
 ICON_DIR="${HOME}/.local/share/icons"
 DESKTOP_DIR="${HOME}/.local/share/applications"
 ARCH=$(uname -m)

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -20,15 +20,19 @@ case "$ARCH" in
 esac
 
 if [[ "$VERSION" == "latest" ]]; then
-  BASE_URL="https://github.com/${REPO}/releases/latest/download"
-  APPIMAGE_NAME="todu-linux-${APPIMAGE_ARCH}.AppImage"
+  TAG=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" | sed 's#/$##' | awk -F/ '{print $NF}')
+  if [[ -z "$TAG" ]]; then
+    echo "error: failed to resolve latest todu release tag"
+    exit 1
+  fi
+  VERSION="${TAG#v}"
 else
   TAG="v${VERSION#v}"
   VERSION="${VERSION#v}"
-  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-  APPIMAGE_NAME="todu-${VERSION}-linux-${APPIMAGE_ARCH}.AppImage"
 fi
 
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+APPIMAGE_NAME="todu-${VERSION}-linux-${APPIMAGE_ARCH}.AppImage"
 APPIMAGE_URL="${BASE_URL}/${APPIMAGE_NAME}"
 TMP_DIR=$(mktemp -d)
 APPIMAGE_PATH="${TMP_DIR}/${APPIMAGE_NAME}"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,33 +1,50 @@
 #!/usr/bin/env bash
-# Install todu on Linux via AppImage + .desktop integration.
-# Run from the project root after `make dist`.
+# Install todu on Linux via GitHub release AppImage + .desktop integration.
 set -euo pipefail
 
-APPIMAGE=$(find dist/installers -name 'todu-*-linux-x86_64.AppImage' 2>/dev/null | sort -V | tail -1 || true)
-if [[ -z "$APPIMAGE" ]]; then
-  echo "error: no AppImage found in dist/installers/ — run 'make dist' first"
-  exit 1
+REPO="evcraddock/todu"
+VERSION="${1:-latest}"
+INSTALL_DIR="${HOME}/Applications"
+ICON_DIR="${HOME}/.local/share/icons"
+DESKTOP_DIR="${HOME}/.local/share/applications"
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64)
+    APPIMAGE_ARCH="x64"
+    ;;
+  *)
+    echo "error: unsupported Linux desktop architecture '$ARCH' (currently supported: x86_64)"
+    exit 1
+    ;;
+esac
+
+if [[ "$VERSION" == "latest" ]]; then
+  BASE_URL="https://github.com/${REPO}/releases/latest/download"
+  APPIMAGE_NAME="todu-linux-${APPIMAGE_ARCH}.AppImage"
+else
+  TAG="v${VERSION#v}"
+  VERSION="${VERSION#v}"
+  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+  APPIMAGE_NAME="todu-${VERSION}-linux-${APPIMAGE_ARCH}.AppImage"
 fi
 
-ICON_SRC="packages/electron/build/icons/256x256.png"
-INSTALL_DIR="$HOME/Applications"
-ICON_DIR="$HOME/.local/share/icons"
-DESKTOP_DIR="$HOME/.local/share/applications"
+APPIMAGE_URL="${BASE_URL}/${APPIMAGE_NAME}"
+TMP_DIR=$(mktemp -d)
+APPIMAGE_PATH="${TMP_DIR}/${APPIMAGE_NAME}"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "Installing todu from $APPIMAGE..."
+echo "Downloading ${APPIMAGE_URL}..."
+curl -fL --progress-bar "$APPIMAGE_URL" -o "$APPIMAGE_PATH"
 
 mkdir -p "$INSTALL_DIR" "$ICON_DIR" "$DESKTOP_DIR"
+install -m 755 "$APPIMAGE_PATH" "$INSTALL_DIR/todu.AppImage"
 
-cp "$APPIMAGE" "$INSTALL_DIR/todu.AppImage"
-chmod +x "$INSTALL_DIR/todu.AppImage"
-
-cp "$ICON_SRC" "$ICON_DIR/todu.png"
-
-cat > "$DESKTOP_DIR/todu.desktop" << EOF
+cat > "$DESKTOP_DIR/todu.desktop" <<EOF
 [Desktop Entry]
 Name=todu
 Comment=Local-first task management
-Exec=$INSTALL_DIR/todu.AppImage
+Exec=${INSTALL_DIR}/todu.AppImage
 Icon=todu
 Terminal=false
 Type=Application
@@ -35,7 +52,17 @@ Categories=Office;ProjectManagement;
 StartupWMClass=todu
 EOF
 
+cat > "$ICON_DIR/todu.svg" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="todu icon">
+  <rect width="256" height="256" rx="48" fill="#1f6feb"/>
+  <path d="M64 78h128v20H64zm0 40h128v20H64zm0 40h84v20H64z" fill="#ffffff"/>
+  <circle cx="176" cy="168" r="24" fill="#ffffff"/>
+  <path d="m168 168 6 6 14-18" fill="none" stroke="#1f6feb" stroke-linecap="round" stroke-linejoin="round" stroke-width="8"/>
+</svg>
+EOF
+
 update-desktop-database "$DESKTOP_DIR" 2>/dev/null || true
 
-echo "Installed: $INSTALL_DIR/todu.AppImage"
-echo "Search 'todu' in your app menu to launch it."
+echo "Installed: ${INSTALL_DIR}/todu.AppImage"
+echo "Launch with: ${INSTALL_DIR}/todu.AppImage"
+echo "Or search 'todu' in your app menu."

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -22,15 +22,19 @@ case "$ARCH" in
 esac
 
 if [[ "$VERSION" == "latest" ]]; then
-  BASE_URL="https://github.com/${REPO}/releases/latest/download"
-  DMG_NAME="todu-mac-${DMG_ARCH}.dmg"
+  TAG=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" | sed 's#/$##' | awk -F/ '{print $NF}')
+  if [[ -z "$TAG" ]]; then
+    echo "error: failed to resolve latest todu release tag"
+    exit 1
+  fi
+  VERSION="${TAG#v}"
 else
   TAG="v${VERSION#v}"
   VERSION="${VERSION#v}"
-  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-  DMG_NAME="todu-${VERSION}-mac-${DMG_ARCH}.dmg"
 fi
 
+BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+DMG_NAME="todu-${VERSION}-mac-${DMG_ARCH}.dmg"
 DMG_URL="${BASE_URL}/${DMG_NAME}"
 TMP_DIR=$(mktemp -d)
 DMG_PATH="${TMP_DIR}/${DMG_NAME}"

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -1,24 +1,60 @@
 #!/usr/bin/env bash
-# Install todu on macOS by mounting the .dmg and copying to /Applications.
-# Run from the project root after `make dist`.
+# Install todu on macOS by downloading the GitHub release DMG and copying to /Applications.
 set -euo pipefail
 
-DMG=$(find dist/installers -name 'todu-*-mac*.dmg' 2>/dev/null | sort -V | tail -1 || true)
-if [[ -z "$DMG" ]]; then
-  echo "error: no .dmg found in dist/installers/ — run 'make dist' first"
-  exit 1
+REPO="evcraddock/todu"
+VERSION="${1:-latest}"
+ARCH=$(uname -m)
+APP_NAME="todu.app"
+TARGET_PATH="/Applications/${APP_NAME}"
+
+case "$ARCH" in
+  arm64)
+    DMG_ARCH="arm64"
+    ;;
+  x86_64)
+    DMG_ARCH="x64"
+    ;;
+  *)
+    echo "error: unsupported macOS architecture '$ARCH'"
+    exit 1
+    ;;
+esac
+
+if [[ "$VERSION" == "latest" ]]; then
+  BASE_URL="https://github.com/${REPO}/releases/latest/download"
+  DMG_NAME="todu-mac-${DMG_ARCH}.dmg"
+else
+  TAG="v${VERSION#v}"
+  VERSION="${VERSION#v}"
+  BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+  DMG_NAME="todu-${VERSION}-mac-${DMG_ARCH}.dmg"
 fi
 
-echo "Installing todu from $DMG..."
+DMG_URL="${BASE_URL}/${DMG_NAME}"
+TMP_DIR=$(mktemp -d)
+DMG_PATH="${TMP_DIR}/${DMG_NAME}"
+MOUNT=""
+trap 'if [[ -n "$MOUNT" ]]; then hdiutil detach "$MOUNT" -quiet 2>/dev/null || true; fi; rm -rf "$TMP_DIR"' EXIT
 
-MOUNT=$(hdiutil attach "$DMG" -nobrowse | awk '/\/Volumes\// {print substr($0, index($0, "/Volumes"))}')
+echo "Downloading ${DMG_URL}..."
+curl -fL --progress-bar "$DMG_URL" -o "$DMG_PATH"
+
+echo "Mounting ${DMG_NAME}..."
+MOUNT=$(hdiutil attach "$DMG_PATH" -nobrowse | awk '/\/Volumes\// {print substr($0, index($0, "/Volumes"))}' | tail -1)
 if [[ -z "$MOUNT" ]]; then
-  echo "error: failed to mount $DMG"
+  echo "error: failed to mount ${DMG_PATH}"
   exit 1
 fi
 
-trap 'hdiutil detach "$MOUNT" -quiet 2>/dev/null || true' EXIT
+if [[ ! -d "$MOUNT/${APP_NAME}" ]]; then
+  echo "error: ${APP_NAME} not found in mounted DMG"
+  exit 1
+fi
 
-cp -R "$MOUNT/todu.app" /Applications/
+echo "Installing to ${TARGET_PATH}..."
+rm -rf "$TARGET_PATH"
+ditto "$MOUNT/${APP_NAME}" "$TARGET_PATH"
 
-echo "Installed: /Applications/todu.app"
+echo "Installed: ${TARGET_PATH}"
+echo "Launch with: open -a todu"


### PR DESCRIPTION
## Summary
- add release-oriented Linux and macOS desktop installer helper scripts
- update README with copy-paste desktop install commands for Linux and macOS
- attach installer helper scripts to GitHub release assets

## Verification
- bash -n scripts/install-linux.sh scripts/install-mac.sh
- $(go env GOPATH)/bin/actionlint .github/workflows/release.yml
- npm run check:ci
- make pre-pr

Task: #task-45b6e4ac