### PR TITLE
fix: support npm symlink launchers for daemon reexec

### DIFF
--- a/packages/cli/src/commands/daemon.integration.test.ts
+++ b/packages/cli/src/commands/daemon.integration.test.ts
@@ -42,13 +42,13 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
 
   function runCli(
     args: string[],
-    options: { env?: Record<string, string>; timeoutMs?: number } = {},
+    options: { env?: Record<string, string>; timeoutMs?: number; launcherPath?: string } = {},
   ): {
     status: number;
     stdout: string;
     stderr: string;
   } {
-    const completed = spawnSync(process.execPath, [cliPath, ...args], {
+    const completed = spawnSync(process.execPath, [options.launcherPath ?? cliPath, ...args], {
       cwd: rootDir,
       env: {
         ...process.env,
@@ -144,11 +144,8 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     expect(afterStop.running).toBe(false);
   });
 
-  it("daemon start/stop/restart commands manage daemon in direct mode", async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-lifecycle-test-"));
-    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
-
-    const start = runCli(["daemon", "start"]);
+  async function expectManagedDirectLifecycle(launcherPath?: string): Promise<void> {
+    const start = runCli(["daemon", "start"], { launcherPath });
     expect(start.status).toBe(0);
     expect(start.stdout).toContain("Daemon start: started managed daemon process");
 
@@ -157,25 +154,41 @@ describe("daemon CLI commands", { timeout: 30000 }, () => {
     await waitForFileContains(stdoutLogPath, '"message":"daemon process started"', 5000);
     expect(fs.existsSync(stderrLogPath)).toBe(true);
 
-    const statusAfterStart = runCli(["--format", "json", "daemon", "status"]);
+    const statusAfterStart = runCli(["--format", "json", "daemon", "status"], { launcherPath });
     expect(statusAfterStart.status).toBe(0);
     expect(JSON.parse(statusAfterStart.stdout).running).toBe(true);
 
-    const restart = runCli(["daemon", "restart"]);
+    const restart = runCli(["daemon", "restart"], { launcherPath });
     expect(restart.status).toBe(0);
     expect(restart.stdout).toContain("Daemon restart: started managed daemon process");
 
-    const statusAfterRestart = runCli(["--format", "json", "daemon", "status"]);
+    const statusAfterRestart = runCli(["--format", "json", "daemon", "status"], { launcherPath });
     expect(statusAfterRestart.status).toBe(0);
     expect(JSON.parse(statusAfterRestart.stdout).running).toBe(true);
 
-    const stop = runCli(["daemon", "stop"]);
+    const stop = runCli(["daemon", "stop"], { launcherPath });
     expect(stop.status).toBe(0);
     expect(stop.stdout).toContain("Daemon stop: stopped managed daemon process");
 
-    const statusAfterStop = runCli(["--format", "json", "daemon", "status"]);
+    const statusAfterStop = runCli(["--format", "json", "daemon", "status"], { launcherPath });
     expect(statusAfterStop.status).toBe(0);
     expect(JSON.parse(statusAfterStop.stdout).running).toBe(false);
+  }
+
+  it("daemon start/stop/restart commands manage daemon in direct mode", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-lifecycle-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+
+    await expectManagedDirectLifecycle();
+  });
+
+  it("daemon start works when invoked through a symlinked launcher without a js suffix", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-symlink-lifecycle-test-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-cli-daemon-home-"));
+    const launcherPath = path.join(tmpDir, "todu");
+    fs.symlinkSync(cliPath, launcherPath);
+
+    await expectManagedDirectLifecycle(launcherPath);
   });
 
   it("daemon start rotates oversized direct log files on startup", async () => {

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -896,15 +896,11 @@ function createDaemonChildEnv(context: DaemonCommandContext): NodeJS.ProcessEnv 
 function resolveSelfInvocationArgs(commandArgs: string[]): string[] {
   const scriptPath = process.argv[1];
 
-  if (scriptPath && isNodeScriptEntrypointPath(scriptPath) && isExistingFile(scriptPath)) {
+  if (scriptPath && isExistingFile(scriptPath)) {
     return [scriptPath, ...commandArgs];
   }
 
   return commandArgs;
-}
-
-function isNodeScriptEntrypointPath(filePath: string): boolean {
-  return filePath.endsWith(".js") || filePath.endsWith(".mjs") || filePath.endsWith(".cjs");
 }
 
 function isExistingFile(filePath: string): boolean {


### PR DESCRIPTION
## Summary
- allow daemon direct-mode self-reexec to reuse any existing argv[1] path instead of requiring a .js suffix
- support npm-installed symlink launchers like /opt/homebrew/bin/todu
- add an integration regression test covering symlinked launcher invocation without a .js suffix

## Verification
- npx vitest run --config vitest.all.config.ts packages/cli/src/commands/daemon.integration.test.ts
- npm run check:ci
- make pre-pr