### PR TITLE
Interactive `todu config init` for identity

### DIFF
--- a/packages/cli/src/commands/config.integration.test.ts
+++ b/packages/cli/src/commands/config.integration.test.ts
@@ -22,7 +22,7 @@ describe("config CLI commands", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function run(args: string): string {
+  function run(args: string, input = "", extraEnv: Record<string, string> = {}): string {
     return execSync(`node ${cliPath} ${args}`, {
       cwd: tmpDir,
       env: {
@@ -30,14 +30,16 @@ describe("config CLI commands", () => {
         TODU_DATA_DIR: "",
         TODU_CONFIG: "",
         TODUAI_NO_SYNC: "1",
+        ...extraEnv,
       },
+      input,
       encoding: "utf-8",
       timeout: 15000,
     }).trim();
   }
 
   it("config init creates config and gitignore in .todu", { timeout: 30000 }, () => {
-    const output = run("config init");
+    const output = run("config init", "actor-erik\nErik\nn\n");
 
     const configPath = path.join(tmpDir, ".todu", "config.yaml");
     const gitignorePath = path.join(tmpDir, ".todu", ".gitignore");
@@ -47,11 +49,18 @@ describe("config CLI commands", () => {
 
     const configContent = fs.readFileSync(configPath, "utf-8");
     expect(configContent).toContain("data_dir");
+    expect(configContent).toContain("identity:");
+    expect(configContent).toContain("id: actor-erik");
+    expect(configContent).toContain("displayName: Erik");
+    expect(configContent).not.toContain("sync:");
 
     const gitignoreContent = fs.readFileSync(gitignorePath, "utf-8");
     expect(gitignoreContent).toContain("# Ignore todu data");
     expect(gitignoreContent).toContain("data/");
 
+    expect(output).toContain("Owner actor ID:");
+    expect(output).toContain("Display name:");
+    expect(output).toContain("Configure a sync server? [y/N]");
     expect(output).toContain(`todu --config ${configPath} task list`);
   });
 
@@ -76,7 +85,7 @@ describe("config CLI commands", () => {
   );
 
   it("config show displays resolved config", { timeout: 30000 }, () => {
-    run("config init");
+    run("config init", "actor-erik\nErik\nn\n");
     const configPath = path.join(tmpDir, ".todu", "config.yaml");
 
     const output = run(`--config ${configPath} config show`);
@@ -85,15 +94,31 @@ describe("config CLI commands", () => {
     expect(output).toContain("--config flag");
   });
 
+  it("config init enables sync when a sync server is provided", { timeout: 30000 }, () => {
+    run("config init", "actor-erik\nErik\ny\nws://localhost:3030\n");
+
+    const configPath = path.join(tmpDir, ".todu", "config.yaml");
+    const configContent = fs.readFileSync(configPath, "utf-8");
+
+    expect(configContent).toContain("sync:");
+    expect(configContent).toContain("remote:");
+    expect(configContent).toContain("server: ws://localhost:3030");
+    expect(configContent).toContain("enabled: true");
+  });
+
   it("--config flag routes data to config data_dir", { timeout: 30000 }, async () => {
-    run("config init");
+    run("config init", "actor-erik\nErik\nn\n");
     const configPath = path.join(tmpDir, ".todu", "config.yaml");
     const dataDir = path.join(tmpDir, ".todu", "data");
 
     const daemon = await startDaemonForTests(rootDir, dataDir);
+    const daemonEnv = {
+      TODU_DAEMON_SOCKET: path.join(dataDir, "daemon.sock"),
+      TODUAI_DAEMON_SOCKET: path.join(dataDir, "daemon.sock"),
+    };
     try {
-      run(`--config ${configPath} project create --name "Dev Project"`);
-      const output = run(`--config ${configPath} --format json project list`);
+      run(`--config ${configPath} project create --name "Dev Project"`, "", daemonEnv);
+      const output = run(`--config ${configPath} --format json project list`, "", daemonEnv);
       const projects = JSON.parse(output);
       expect(projects).toHaveLength(1);
       expect(projects[0].name).toBe("Dev Project");

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,5 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import { stdin, stdout } from "node:process";
+import { createInterface } from "node:readline/promises";
+import { type ToduFileConfig, validateActorDisplayName, validateActorId } from "@todu/core";
 import type { Command } from "commander";
 import { getConfigPath, loadConfig, resolveConfigSources, saveConfig } from "../config.js";
 import { formatJSON } from "../format.js";
@@ -45,7 +48,7 @@ export function registerConfigCommands(program: Command): void {
     .command("init")
     .description("Create a config file for local development")
     .option("--dir <path>", "directory to create config in", DEFAULT_LOCAL_CONFIG_DIR)
-    .action((opts) => {
+    .action(async (opts) => {
       const dir = path.resolve(opts.dir);
       const configPath = path.join(dir, "config.yaml");
 
@@ -64,8 +67,10 @@ export function registerConfigCommands(program: Command): void {
         return;
       }
 
+      const config = await promptForInitConfig();
+
       // Create config with data_dir relative to config location
-      saveConfig({ data_dir: "./data" }, configPath);
+      saveConfig(config, configPath);
 
       // Add .gitignore to keep data out of version control
       const gitignorePath = path.join(dir, ".gitignore");
@@ -80,6 +85,129 @@ export function registerConfigCommands(program: Command): void {
       console.log("Usage:");
       console.log(`  todu --config ${configPath} task list`);
     });
+}
+
+async function promptForInitConfig(): Promise<ToduFileConfig> {
+  const prompts = await createPromptSession();
+
+  try {
+    const ownerActorId = await promptUntilValid(
+      prompts,
+      "Owner actor ID: ",
+      (value) => validateActorId("identity.ownerActor.id", value.trim())?.message ?? null,
+    );
+    const displayName = await promptUntilValid(
+      prompts,
+      "Display name: ",
+      (value) =>
+        validateActorDisplayName("identity.ownerActor.displayName", value.trim())?.message ?? null,
+    );
+    const configureSync = await promptYesNo(prompts, "Configure a sync server? [y/N] ");
+
+    const config: ToduFileConfig = {
+      data_dir: "./data",
+      identity: {
+        ownerActor: {
+          id: ownerActorId.trim(),
+          displayName: displayName.trim(),
+        },
+      },
+    };
+
+    if (configureSync) {
+      const server = await promptUntilValid(prompts, "Sync server: ", (value) =>
+        value.trim().length > 0 ? null : "Sync server must be a non-empty string",
+      );
+      config.sync = {
+        remote: {
+          server: server.trim(),
+          enabled: true,
+        },
+      };
+    }
+
+    return config;
+  } finally {
+    prompts.close();
+  }
+}
+
+interface PromptSession {
+  question(prompt: string): Promise<string>;
+  close(): void;
+}
+
+async function createPromptSession(): Promise<PromptSession> {
+  if (stdin.isTTY && stdout.isTTY) {
+    const rl = createInterface({ input: stdin, output: stdout });
+    return {
+      question: (prompt) => rl.question(prompt),
+      close: () => rl.close(),
+    };
+  }
+
+  const bufferedAnswers = splitPromptAnswers(await readStdin());
+  let answerIndex = 0;
+
+  return {
+    question: async (prompt) => {
+      stdout.write(prompt);
+      const answer = bufferedAnswers[answerIndex] ?? "";
+      answerIndex += 1;
+      return answer;
+    },
+    close: () => {},
+  };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+function splitPromptAnswers(input: string): string[] {
+  if (input.length === 0) {
+    return [];
+  }
+
+  const answers = input.split(/\r?\n/);
+  if (answers.at(-1) === "") {
+    answers.pop();
+  }
+  return answers;
+}
+
+async function promptUntilValid(
+  prompts: PromptSession,
+  prompt: string,
+  validate: (value: string) => string | null,
+): Promise<string> {
+  while (true) {
+    const answer = await prompts.question(prompt);
+    const error = validate(answer);
+    if (error === null) {
+      return answer;
+    }
+
+    console.log(`Error: ${error}`);
+  }
+}
+
+async function promptYesNo(prompts: PromptSession, prompt: string): Promise<boolean> {
+  while (true) {
+    const answer = (await prompts.question(prompt)).trim().toLowerCase();
+    if (answer === "" || answer === "n" || answer === "no") {
+      return false;
+    }
+    if (answer === "y" || answer === "yes") {
+      return true;
+    }
+
+    console.log("Error: enter y or n");
+  }
 }
 
 function maybeMigrateLegacyProjectConfigDir(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,4 +55,7 @@ registerSyncCommands(program, invokeDaemon);
 registerPluginCommands(program, invokeDaemon);
 registerConfigCommands(program);
 
-program.parse();
+program.parseAsync().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- prompt for owner actor ID and display name during `todu config init`
- optionally prompt for a sync server and persist enabled remote sync config
- add integration coverage for interactive init and config-routed daemon usage

## Verification
- make pre-pr
- npx vitest run --config vitest.all.config.ts packages/cli/src/commands/config.integration.test.ts

Task: #task-dfcb8d28