### PR TITLE
Remove legacy sync provider v2 host support

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -227,7 +227,7 @@ Baseline worker lifecycle states are:
 - Generic worker plugins use `WorkerPluginRegistration` from `@todu/core` and export `workerPlugin`.
 - Sync provider plugins use `SyncProviderRegistration` from `@todu/core` and export `syncProvider`.
 - Plugin load paths validate registrations at load time before worker registration.
-- Compatibility baseline for sync providers is API-version based (latest provider API version: `3`; host-supported rollout window versions: `2` and `3`).
+- Compatibility baseline for sync providers is API-version based (latest provider API version: `3`; host-supported provider API versions: `3`).
 - Daemon plugin module paths resolve from `TODU_DAEMON_PLUGIN_PATHS` first, then legacy `TODUAI_DAEMON_PLUGIN_PATHS`, then `daemon.plugins.paths` in config; config file paths resolve relative to config location.
 - Plugin load activation occurs at daemon startup and applies on daemon restart.
 - Conflict resolution baseline for provider sync is last-write-wins by `updatedAt`.

--- a/docs/plans/multi-user-task-assignment-rollout.md
+++ b/docs/plans/multi-user-task-assignment-rollout.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Proposed rollout plan for the assignment and actor model defined in `docs/plans/multi-user-task-assignment.md`.
+Historical rollout plan for the assignment and actor model defined in `docs/plans/multi-user-task-assignment.md`.
+
+Compatibility-window note:
+
+- Both known sync providers are now on API v3.
+- Core host/runtime support for sync-provider API v2 has been removed.
+- This document remains as rollout history and sequencing context.
 
 ## Purpose
 
@@ -404,6 +410,10 @@ This gives time to:
 - no major compatibility regressions remain unresolved
 
 ## Phase 8: legacy removal
+
+### Status
+
+Completed. The compatibility window has ended and core host/runtime support for sync-provider API v2 has been removed.
 
 ### Scope
 

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -10,7 +10,7 @@ For generic daemon worker plugins, see `docs/worker-plugin-api.md`.
 
 This document defines the provider execution contract. Shared integration binding desired state is a separate architecture concern owned by core and documented in `docs/architecture/integrations.md`.
 
-Core-owned imported-content approval metadata also remains outside provider-managed state. Task description approval metadata lives with `TaskDetailDocument`, note/comment approval metadata lives with `Note`, and later runtime work is responsible for deriving approval from binding identity, actor identity, and content fingerprint.
+Core-owned imported-content approval metadata also remains outside provider-managed state. Task description approval metadata lives with `TaskDetailDocument`, note/comment approval metadata lives with `Note`, and the host/runtime is responsible for deriving approval from binding identity, actor identity, and content fingerprint.
 
 ## Relationship to generic integration architecture
 
@@ -25,20 +25,20 @@ Instead:
 
 Use local provider configuration for secrets and host-local runtime settings, not for synced integration binding desired state.
 
-## Compatibility Policy
+## Compatibility policy
 
 Compatibility is API-version based.
 
 - Latest provider API version: `SYNC_PROVIDER_API_VERSION` (currently `3`).
-- Host-supported provider API versions during the rollout window: `SYNC_PROVIDER_SUPPORTED_API_VERSIONS` (currently `2` and `3`).
+- Host-supported provider API versions: `SYNC_PROVIDER_SUPPORTED_API_VERSIONS` (currently `3`).
 - Every provider manifest must declare `apiVersion`.
 - Providers are loadable only when `manifest.apiVersion` is included in the host-supported version set.
 - Unsupported versions must fail closed at load time.
-- Provider API v2 remains a transition contract and will be removed after the compatibility window closes.
+- Provider API v2 compatibility has been removed.
 
 Use `validateSyncProviderRegistration(...)` during plugin load to enforce this gate.
 
-## Manifest Contract
+## Manifest contract
 
 ```ts
 interface SyncProviderManifest {
@@ -54,54 +54,9 @@ Rules:
 - `version` must be non-empty.
 - `apiVersion` must be a positive integer and API-compatible with host runtime.
 
-## API v2 contract
-
-API v2 is the legacy string-based provider contract.
-
-```ts
-interface ExternalTask {
-  externalId: string;
-  title: string;
-  description?: string;
-  status?: string;
-  priority?: string;
-  labels?: string[];
-  assignees?: string[];
-  sourceUrl?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  raw?: unknown;
-}
-
-interface ExternalComment {
-  externalId: string;
-  externalTaskId: string;
-  body: string;
-  author?: string;
-  createdAt: string;
-  updatedAt?: string;
-  raw?: unknown;
-}
-
-interface SyncProviderV2 {
-  readonly name: string;
-  readonly version: string;
-  initialize(config: SyncProviderConfig): Promise<void>;
-  shutdown(): Promise<void>;
-  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(binding: IntegrationBinding, tasks: TaskPushPayload[], project: Project): Promise<SyncProviderPushResult>;
-  mapToTask(external: ExternalTask, project: Project): Task;
-  mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
-}
-```
-
-`TaskPushPayload` extends `TaskWithDetail` with `comments: Note[]`, providing each task's description and attached comments during push.
-
-Use v2 only for compatibility with the existing runtime shim path.
-
 ## API v3 contract
 
-API v3 replaces direct `mapToTask(...)` and `mapFromTask(...)` coupling with normalized import/export payloads and structured external actor references.
+API v3 is the canonical and only supported sync-provider contract.
 
 ```ts
 interface ExternalActorRef {
@@ -153,6 +108,7 @@ interface ExportedTaskInput {
   labels: string[];
   assignees: ExternalActorRef[];
   sourceUrl?: string;
+  updatedAt: string;
   comments: ExportedCommentInput[];
 }
 
@@ -184,18 +140,7 @@ interface SyncProviderV3 {
 
 ## Task and comment sync semantics
 
-### v2 pull behavior
-
-`SyncProviderPullResult.tasks` accepts `ExternalTask[]`. The runtime reconciles pulled tasks within the binding's project by `externalId`.
-
-- Each pulled item is mapped through `mapToTask(external, project)`.
-- When no local task with the same `externalId` exists, the runtime creates a new task in the bound project.
-- When a matching local task exists, the runtime updates it only if the external item is newer by `updatedAt` (falling back to `createdAt` when `updatedAt` is absent).
-- Task deletions are not inferred from pull results in the current implementation.
-
-The runtime persists the pulled task's core fields, including mapped status, priority, labels, assignees, `externalId`, and `sourceUrl`. Task descriptions come from `ExternalTask.description`.
-
-### v3 pull behavior
+### Pull behavior
 
 `SyncProviderPullResultV3.tasks` accepts `ImportedTaskInput[]` and `comments` accepts `ImportedCommentInput[]`.
 
@@ -205,7 +150,7 @@ In v3:
 - providers do not translate directly into local tasks or notes
 - the host/runtime is responsible for actor creation/reuse, binding mapping updates, and approval-state computation
 
-Imported timestamp semantics stay the same across v2 and v3:
+Imported timestamp semantics:
 
 - newly created local tasks preserve external `createdAt` when provided
 - newly created local tasks preserve external `updatedAt` when provided
@@ -246,17 +191,15 @@ The runtime then applies each returned comment link idempotently by attaching th
 
 ### Comment pull path
 
-For v2, pulled comments are `ExternalComment[]` with string `author` values.
+Pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalActorRef`.
 
-For v3, pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalActorRef`.
-
-In both cases, the runtime reconciles pulled comments with local notes using a snapshot model:
+The runtime reconciles pulled comments with local notes using a snapshot model:
 
 - comments with an `externalId` not present locally are created as new notes with a `sync:externalId:<value>` tag
 - comments matching an existing local note are updated if the external `updatedAt` is newer than the local `createdAt`
 - local synced notes whose external IDs are absent from the pull result are deleted
 
-## Load-Time Enforcement
+## Load-time enforcement
 
 At plugin load time, call:
 
@@ -278,7 +221,7 @@ Validation errors use structured codes:
 - `API_VERSION_MISMATCH`
 - `IDENTITY_MISMATCH`
 
-## Daemon Host Configuration
+## Daemon host configuration
 
 Daemon plugin host loads sync plugin modules from configured local module paths.
 
@@ -312,6 +255,6 @@ Retry policy:
 - retry state resets after a successful cycle
 - daemon shutdown stops further scheduling and calls provider `shutdown()`
 
-## Conflict Resolution Baseline
+## Conflict resolution baseline
 
 Provider sync conflict resolution baseline is `last-write-wins` based on `updatedAt` timestamps. Providers should preserve external timestamps where available and provide deterministic mapping behavior under repeated pull/push runs.

--- a/packages/cli/src/commands/plugin.integration.test.ts
+++ b/packages/cli/src/commands/plugin.integration.test.ts
@@ -56,7 +56,7 @@ describe("plugin CLI commands", () => {
     const pluginPath = writePluginModule(tmpDir, "github-plugin.mjs", {
       name: "github",
       version: "1.0.0",
-      apiVersion: 1,
+      apiVersion: 3,
     });
 
     const installOutput = run(`plugin install ${pluginPath}`);
@@ -83,7 +83,7 @@ describe("plugin CLI commands", () => {
       manifest: {
         name: "github",
         version: "1.0.0",
-        apiVersion: 1,
+        apiVersion: 3,
       },
       status: "ok",
     });
@@ -102,7 +102,7 @@ describe("plugin CLI commands", () => {
     const pluginPath = writePluginModule(tmpDir, "forgejo-plugin.mjs", {
       name: "forgejo",
       version: "2.1.0",
-      apiVersion: 1,
+      apiVersion: 3,
     });
 
     run(`plugin install ${pluginPath}`);
@@ -190,7 +190,7 @@ describe("plugin CLI commands", () => {
     const pluginPath = writePluginModule(tmpDir, "config-plugin.mjs", {
       name: "github",
       version: "1.2.3",
-      apiVersion: 1,
+      apiVersion: 3,
     });
 
     run(`plugin install ${pluginPath}`);
@@ -224,27 +224,10 @@ function writePluginModule(
     async initialize() {},
     async shutdown() {},
     async pull() {
-      return { tasks: [] };
+      return { tasks: [], comments: [] };
     },
-    async push() {},
-    mapToTask() {
-      return {
-        id: "task-1",
-        title: "Example",
-        status: "active",
-        priority: "medium",
-        projectId: "project-1",
-        labels: [],
-        assignees: [],
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      };
-    },
-    mapFromTask() {
-      return {
-        externalId: "ext-1",
-        title: "Example",
-      };
+    async push() {
+      return { commentLinks: [], taskLinks: [] };
     },
   },
 };`;

--- a/packages/core/src/sync-provider.test.ts
+++ b/packages/core/src/sync-provider.test.ts
@@ -2,19 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   type AnySyncProviderRegistration,
   isSyncProviderApiVersionCompatible,
-  isSyncProviderRegistrationV2,
   isSyncProviderRegistrationV3,
   SYNC_PROVIDER_API_VERSION,
-  SYNC_PROVIDER_API_VERSION_V2,
   SYNC_PROVIDER_API_VERSION_V3,
   validateSyncProviderRegistration,
 } from "./sync-provider.js";
 
 describe("isSyncProviderApiVersionCompatible", () => {
-  it("accepts supported v2 API version", () => {
-    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V2)).toBe(true);
-  });
-
   it("accepts supported v3 API version", () => {
     expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION)).toBe(true);
   });
@@ -24,30 +18,12 @@ describe("isSyncProviderApiVersionCompatible", () => {
   });
 
   it("supports explicit supported version lists", () => {
-    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [2, 3])).toBe(true);
-    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [2])).toBe(false);
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [3])).toBe(true);
+    expect(isSyncProviderApiVersionCompatible(SYNC_PROVIDER_API_VERSION_V3, [4])).toBe(false);
   });
 });
 
 describe("validateSyncProviderRegistration", () => {
-  it("accepts a valid v2 provider registration", () => {
-    const registration = createValidV2Registration();
-
-    const result = validateSyncProviderRegistration(registration);
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) {
-      throw new Error("Expected valid sync provider registration");
-    }
-
-    expect(isSyncProviderRegistrationV2(result.value)).toBe(true);
-    expect(result.value.manifest).toEqual({
-      name: "github",
-      version: "1.2.3",
-      apiVersion: SYNC_PROVIDER_API_VERSION_V2,
-    });
-  });
-
   it("accepts a valid v3 provider registration", () => {
     const registration = createValidV3Registration();
 
@@ -81,7 +57,7 @@ describe("validateSyncProviderRegistration", () => {
       code: "API_VERSION_MISMATCH",
       details: {
         providerApiVersion: SYNC_PROVIDER_API_VERSION_V3 + 1,
-        supportedApiVersions: [SYNC_PROVIDER_API_VERSION_V2, SYNC_PROVIDER_API_VERSION_V3],
+        supportedApiVersions: [SYNC_PROVIDER_API_VERSION_V3],
       },
     });
   });
@@ -90,45 +66,25 @@ describe("validateSyncProviderRegistration", () => {
     const registration = createValidV3Registration();
 
     const result = validateSyncProviderRegistration(registration, {
-      supportedApiVersion: SYNC_PROVIDER_API_VERSION_V2,
+      supportedApiVersion: 4,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) {
-      throw new Error("Expected registration to fail when host only allows v2");
+      throw new Error("Expected registration to fail when host disallows v3");
     }
 
     expect(result.error).toMatchObject({
       code: "API_VERSION_MISMATCH",
       details: {
         providerApiVersion: SYNC_PROVIDER_API_VERSION_V3,
-        supportedApiVersion: SYNC_PROVIDER_API_VERSION_V2,
-        supportedApiVersions: [SYNC_PROVIDER_API_VERSION_V2],
+        supportedApiVersion: 4,
+        supportedApiVersions: [4],
       },
     });
   });
 
-  it("rejects v2 provider missing required lifecycle methods", () => {
-    const registration = createValidV2Registration();
-    registration.provider.shutdown = undefined as unknown as () => Promise<void>;
-
-    const result = validateSyncProviderRegistration(registration);
-
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("Expected registration to fail for missing provider method");
-    }
-
-    expect(result.error).toMatchObject({
-      code: "INVALID_PROVIDER",
-      details: {
-        method: "shutdown",
-        apiVersion: SYNC_PROVIDER_API_VERSION_V2,
-      },
-    });
-  });
-
-  it("rejects v3 provider missing required lifecycle methods", () => {
+  it("rejects provider missing required lifecycle methods", () => {
     const registration = createValidV3Registration();
     registration.provider.pull = undefined as unknown as typeof registration.provider.pull;
 
@@ -149,7 +105,7 @@ describe("validateSyncProviderRegistration", () => {
   });
 
   it("rejects provider/manifest identity mismatch", () => {
-    const registration = createValidV2Registration();
+    const registration = createValidV3Registration();
     registration.provider.version = "9.9.9";
 
     const result = validateSyncProviderRegistration(registration);
@@ -169,7 +125,7 @@ describe("validateSyncProviderRegistration", () => {
   });
 
   it("rejects invalid manifest apiVersion values", () => {
-    const registration = createValidV2Registration();
+    const registration = createValidV3Registration();
     registration.manifest.apiVersion = 0 as never;
 
     const result = validateSyncProviderRegistration(registration);
@@ -189,7 +145,7 @@ describe("validateSyncProviderRegistration", () => {
   });
 
   it("rejects non-string manifest name without throwing", () => {
-    const registration = createValidV2Registration();
+    const registration = createValidV3Registration();
     (registration.manifest as unknown as Record<string, unknown>).name = 42;
 
     const result = validateSyncProviderRegistration(registration);
@@ -207,53 +163,6 @@ describe("validateSyncProviderRegistration", () => {
     });
   });
 });
-
-function createValidV2Registration(): AnySyncProviderRegistration {
-  return {
-    manifest: {
-      name: "github",
-      version: "1.2.3",
-      apiVersion: SYNC_PROVIDER_API_VERSION_V2,
-    },
-    provider: {
-      name: "github",
-      version: "1.2.3",
-      async initialize() {},
-      async shutdown() {},
-      async pull() {
-        return {
-          tasks: [],
-        };
-      },
-      async push() {
-        return {
-          commentLinks: [],
-          taskLinks: [],
-        };
-      },
-      mapToTask() {
-        return {
-          id: "task-1" as never,
-          title: "Example",
-          status: "active",
-          priority: "medium",
-          projectId: "project-1" as never,
-          labels: [],
-          assigneeActorIds: [],
-          assignees: [],
-          createdAt: new Date(0).toISOString(),
-          updatedAt: new Date(0).toISOString(),
-        };
-      },
-      mapFromTask() {
-        return {
-          externalId: "ext-1",
-          title: "Example",
-        };
-      },
-    },
-  };
-}
 
 function createValidV3Registration(): AnySyncProviderRegistration {
   return {

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -5,20 +5,14 @@ import {
   ok,
   type Project,
   type Result,
-  type Task,
   type TaskId,
   type TaskPriority,
-  type TaskPushPayload,
   type TaskStatus,
 } from "./types.js";
 
-export const SYNC_PROVIDER_API_VERSION_V2 = 2 as const;
 export const SYNC_PROVIDER_API_VERSION_V3 = 3 as const;
 export const SYNC_PROVIDER_API_VERSION = SYNC_PROVIDER_API_VERSION_V3;
-export const SYNC_PROVIDER_SUPPORTED_API_VERSIONS = [
-  SYNC_PROVIDER_API_VERSION_V2,
-  SYNC_PROVIDER_API_VERSION_V3,
-] as const;
+export const SYNC_PROVIDER_SUPPORTED_API_VERSIONS = [SYNC_PROVIDER_API_VERSION_V3] as const;
 
 export const SYNC_CONFLICT_RESOLUTION_POLICIES = ["last-write-wins"] as const;
 export type SyncConflictResolutionPolicy = (typeof SYNC_CONFLICT_RESOLUTION_POLICIES)[number];
@@ -27,30 +21,6 @@ export interface SyncProviderManifest {
   name: string;
   version: string;
   apiVersion: number;
-}
-
-export interface ExternalTask {
-  externalId: string;
-  title: string;
-  description?: string;
-  status?: string;
-  priority?: string;
-  labels?: string[];
-  assignees?: string[];
-  sourceUrl?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  raw?: unknown;
-}
-
-export interface ExternalComment {
-  externalId: string;
-  externalTaskId: string;
-  body: string;
-  author?: string;
-  createdAt: string;
-  updatedAt?: string;
-  raw?: unknown;
 }
 
 export interface ExternalActorRef {
@@ -110,11 +80,6 @@ export interface SyncProviderConfig {
   settings: Record<string, unknown>;
 }
 
-export interface SyncProviderPullResult {
-  tasks: ExternalTask[];
-  comments?: ExternalComment[];
-}
-
 export interface SyncProviderPullResultV3 {
   tasks: ImportedTaskInput[];
   comments?: ImportedCommentInput[];
@@ -141,21 +106,6 @@ export interface SyncProviderPushResult {
   taskLinks: SyncProviderPushTaskLink[];
 }
 
-export interface SyncProviderV2 {
-  readonly name: string;
-  readonly version: string;
-  initialize(config: SyncProviderConfig): Promise<void>;
-  shutdown(): Promise<void>;
-  pull(binding: IntegrationBinding, project: Project): Promise<SyncProviderPullResult>;
-  push(
-    binding: IntegrationBinding,
-    tasks: TaskPushPayload[],
-    project: Project,
-  ): Promise<SyncProviderPushResult>;
-  mapToTask(external: ExternalTask, project: Project): Task;
-  mapFromTask(task: TaskPushPayload, project: Project): ExternalTask;
-}
-
 export interface SyncProviderV3 {
   readonly name: string;
   readonly version: string;
@@ -169,26 +119,17 @@ export interface SyncProviderV3 {
   ): Promise<SyncProviderPushResult>;
 }
 
-export type SyncProvider = SyncProviderV2;
-export type AnySyncProvider = SyncProviderV2 | SyncProviderV3;
+export type SyncProvider = SyncProviderV3;
+export type AnySyncProvider = SyncProviderV3;
 
-export interface SyncProviderRegistrationV2 {
-  manifest: SyncProviderManifest & {
-    apiVersion: typeof SYNC_PROVIDER_API_VERSION_V2;
-  };
-  provider: SyncProviderV2;
-}
-
-export interface SyncProviderRegistrationV3 {
+export interface SyncProviderRegistration {
   manifest: SyncProviderManifest & {
     apiVersion: typeof SYNC_PROVIDER_API_VERSION_V3;
   };
   provider: SyncProviderV3;
 }
 
-export type AnySyncProviderRegistration = SyncProviderRegistrationV2 | SyncProviderRegistrationV3;
-export type SyncProviderRegistration = AnySyncProviderRegistration;
-export type LegacySyncProviderRegistration = SyncProviderRegistrationV2;
+export type AnySyncProviderRegistration = SyncProviderRegistration;
 
 export const SYNC_PROVIDER_VALIDATION_ERROR_CODES = [
   "INVALID_MANIFEST",
@@ -210,15 +151,6 @@ export interface ValidateSyncProviderRegistrationOptions {
   supportedApiVersions?: readonly number[];
 }
 
-const REQUIRED_SYNC_PROVIDER_V2_METHODS = [
-  "initialize",
-  "shutdown",
-  "pull",
-  "push",
-  "mapToTask",
-  "mapFromTask",
-] as const;
-
 const REQUIRED_SYNC_PROVIDER_V3_METHODS = ["initialize", "shutdown", "pull", "push"] as const;
 
 export function isSyncProviderApiVersionCompatible(
@@ -236,15 +168,9 @@ export function isSyncProviderApiVersionCompatible(
   return normalizedSupportedApiVersions.includes(providerApiVersion);
 }
 
-export function isSyncProviderRegistrationV2(
-  registration: AnySyncProviderRegistration,
-): registration is SyncProviderRegistrationV2 {
-  return registration.manifest.apiVersion === SYNC_PROVIDER_API_VERSION_V2;
-}
-
 export function isSyncProviderRegistrationV3(
   registration: AnySyncProviderRegistration,
-): registration is SyncProviderRegistrationV3 {
+): registration is SyncProviderRegistration {
   return registration.manifest.apiVersion === SYNC_PROVIDER_API_VERSION_V3;
 }
 
@@ -315,8 +241,7 @@ export function validateSyncProviderRegistration(
     );
   }
 
-  const requiredMethods = getRequiredSyncProviderMethods(manifestApiVersion);
-  if (!requiredMethods) {
+  if (manifestApiVersion !== SYNC_PROVIDER_API_VERSION_V3) {
     return err(
       createSyncProviderValidationError(
         "API_VERSION_MISMATCH",
@@ -376,7 +301,7 @@ export function validateSyncProviderRegistration(
     );
   }
 
-  for (const method of requiredMethods) {
+  for (const method of REQUIRED_SYNC_PROVIDER_V3_METHODS) {
     if (typeof providerRecord[method] !== "function") {
       return err(
         createSyncProviderValidationError(
@@ -391,21 +316,12 @@ export function validateSyncProviderRegistration(
     }
   }
 
-  const normalizedManifest = {
-    name: manifestName,
-    version: manifestVersion,
-    apiVersion: manifestApiVersion,
-  };
-
-  if (manifestApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
-    return ok({
-      manifest: normalizedManifest as SyncProviderRegistrationV2["manifest"],
-      provider: registration.provider as SyncProviderV2,
-    });
-  }
-
   return ok({
-    manifest: normalizedManifest as SyncProviderRegistrationV3["manifest"],
+    manifest: {
+      name: manifestName,
+      version: manifestVersion,
+      apiVersion: manifestApiVersion as typeof SYNC_PROVIDER_API_VERSION_V3,
+    },
     provider: registration.provider as SyncProviderV3,
   });
 }
@@ -422,18 +338,6 @@ function resolveSupportedApiVersions(
   }
 
   return SYNC_PROVIDER_SUPPORTED_API_VERSIONS;
-}
-
-function getRequiredSyncProviderMethods(apiVersion: number): readonly string[] | null {
-  if (apiVersion === SYNC_PROVIDER_API_VERSION_V2) {
-    return REQUIRED_SYNC_PROVIDER_V2_METHODS;
-  }
-
-  if (apiVersion === SYNC_PROVIDER_API_VERSION_V3) {
-    return REQUIRED_SYNC_PROVIDER_V3_METHODS;
-  }
-
-  return null;
 }
 
 function createApiVersionMismatchDetails(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -256,11 +256,6 @@ export interface TaskWithDetail extends Task {
   descriptionApproval?: ImportedContentApproval;
 }
 
-/** Task with description and comments, used as sync-provider push input */
-export interface TaskPushPayload extends TaskWithDetail {
-  comments: Note[];
-}
-
 // ============================================================================
 // Label entity — stored in catalog document
 // ============================================================================

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -1581,65 +1581,6 @@ describe("createDaemonRuntime", () => {
     await runtime.stop();
   });
 
-  it("loads configured sync plugins and surfaces runtime state via worker.status", async () => {
-    const pluginPath = writeValidSyncPluginModule(tmpDir, "github-plugin.mjs", {
-      providerName: "github",
-      providerVersion: "1.0.0",
-    });
-
-    const runtime = createDaemonRuntime({
-      storagePath: tmpDir,
-      syncPluginModulePaths: [pluginPath],
-      enabledWorkerDomains: ["project", "task", "sync"],
-    });
-
-    await runtime.start();
-
-    expect(runtime.getWorker("github-sync")).toMatchObject({
-      state: "running",
-      manifest: {
-        type: "github-sync",
-        requiredDomains: ["sync", "task"],
-      },
-    });
-
-    const workerStatusResponse = await sendRequest(runtime.config().socketPath, {
-      id: "worker-status-plugin-1",
-      method: "worker.status",
-      params: {
-        workerType: "github-sync",
-      },
-    });
-
-    expect(workerStatusResponse).toEqual({
-      id: "worker-status-plugin-1",
-      result: {
-        workers: [
-          {
-            type: "github-sync",
-            state: "running",
-            blockedReason: null,
-            errorMessage: null,
-            updatedAt: expect.any(String),
-            requiredDomains: ["sync", "task"],
-            optionalDomains: [],
-            roleHints: ["node"],
-            isAssigned: true,
-            missingRequiredDomains: [],
-          },
-        ],
-        assignment: {
-          assignedWorkerTypes: null,
-        },
-        enabledWorkerDomains: ["project", "task", "sync"],
-      },
-    });
-
-    await runtime.stop();
-
-    expect(runtime.getWorker("github-sync")?.state).toBe("stopped");
-  });
-
   it("loads configured v3 sync plugins and surfaces runtime state via worker.status", async () => {
     const pluginPath = writeValidSyncPluginModule(tmpDir, "github-plugin-v3.mjs", {
       providerName: "github",
@@ -1954,117 +1895,6 @@ describe("createDaemonRuntime", () => {
         lastSuccessfulSyncAt: expect.any(String),
         lastErrorSummary: null,
       }),
-    );
-
-    await runtime.stop();
-  });
-
-  it("executes mixed v2 and v3 sync providers in the same daemon runtime", async () => {
-    const githubOutputPath = path.join(tmpDir, "github-provider-events.ndjson");
-    const forgejoOutputPath = path.join(tmpDir, "forgejo-provider-events.ndjson");
-    const githubPluginPath = writeRecordingSyncPluginModule(tmpDir, "github-mixed-plugin.mjs", {
-      providerName: "github",
-      providerVersion: "1.0.0",
-      outputPath: githubOutputPath,
-      apiVersion: 2,
-    });
-    const forgejoPluginPath = writeRecordingSyncPluginModule(tmpDir, "forgejo-mixed-plugin.mjs", {
-      providerName: "forgejo",
-      providerVersion: "2.0.0",
-      outputPath: forgejoOutputPath,
-      apiVersion: 3,
-    });
-
-    const runtime = createDaemonRuntime({
-      storagePath: tmpDir,
-      socketPath: path.join(tmpDir, "mixed.sock"),
-      syncPluginModulePaths: [githubPluginPath, forgejoPluginPath],
-      syncPluginConfigs: {
-        github: { intervalSeconds: 0.05 },
-        forgejo: { intervalSeconds: 0.05 },
-      },
-      enabledWorkerDomains: ["project", "task", "sync"],
-    });
-
-    await runtime.start();
-
-    const githubProjectResponse = await sendRequest(runtime.config().socketPath, {
-      id: "project-mixed-github-create",
-      method: "project.create",
-      params: { input: { name: "GitHub Mixed Project" } },
-    });
-    const githubProjectId = (githubProjectResponse.result as { id: string }).id;
-
-    const forgejoProjectResponse = await sendRequest(runtime.config().socketPath, {
-      id: "project-mixed-forgejo-create",
-      method: "project.create",
-      params: { input: { name: "Forgejo Mixed Project" } },
-    });
-    const forgejoProjectId = (forgejoProjectResponse.result as { id: string }).id;
-
-    await sendRequest(runtime.config().socketPath, {
-      id: "task-mixed-github-create",
-      method: "task.create",
-      params: { input: { title: "GitHub Task", projectId: githubProjectId } },
-    });
-    await sendRequest(runtime.config().socketPath, {
-      id: "task-mixed-forgejo-create",
-      method: "task.create",
-      params: { input: { title: "Forgejo Task", projectId: forgejoProjectId } },
-    });
-
-    const githubIntegrationResponse = await sendRequest(runtime.config().socketPath, {
-      id: "integration-mixed-github-create",
-      method: "integration.create",
-      params: {
-        input: {
-          provider: "github",
-          projectId: githubProjectId,
-          targetKind: "repository",
-          targetRef: "owner/repo",
-          strategy: "bidirectional",
-          enabled: true,
-        },
-      },
-    });
-    const githubBindingId = (githubIntegrationResponse.result as { id: string }).id;
-
-    const forgejoIntegrationResponse = await sendRequest(runtime.config().socketPath, {
-      id: "integration-mixed-forgejo-create",
-      method: "integration.create",
-      params: {
-        input: {
-          provider: "forgejo",
-          projectId: forgejoProjectId,
-          targetKind: "repository",
-          targetRef: "team/repo",
-          strategy: "bidirectional",
-          enabled: true,
-        },
-      },
-    });
-    const forgejoBindingId = (forgejoIntegrationResponse.result as { id: string }).id;
-
-    await waitForProviderEvent(
-      githubOutputPath,
-      (event) => event.type === "push" && event.bindingId === githubBindingId,
-    );
-    await waitForProviderEvent(
-      forgejoOutputPath,
-      (event) => event.type === "push" && event.bindingId === forgejoBindingId,
-    );
-
-    expect(readProviderEvents(githubOutputPath)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: "pull", bindingId: githubBindingId }),
-        expect.objectContaining({ type: "push", bindingId: githubBindingId, taskCount: 1 }),
-      ]),
-    );
-    expect(readProviderEvents(forgejoOutputPath)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: "pull", bindingId: forgejoBindingId }),
-        expect.objectContaining({ type: "push", bindingId: forgejoBindingId, taskCount: 1 }),
-      ]),
     );
 
     await runtime.stop();
@@ -2777,18 +2607,16 @@ function writeValidSyncPluginModule(
   options: {
     providerName: string;
     providerVersion: string;
-    apiVersion?: 2 | 3;
+    apiVersion?: 3;
   },
 ): string {
   const modulePath = path.join(directory, filename);
 
-  const moduleSource =
-    options.apiVersion === 3
-      ? `export const syncProvider = {
+  const moduleSource = `export const syncProvider = {
   manifest: {
     name: ${JSON.stringify(options.providerName)},
     version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 3,
+    apiVersion: ${options.apiVersion ?? 3},
   },
   provider: {
     name: ${JSON.stringify(options.providerName)},
@@ -2800,45 +2628,6 @@ function writeValidSyncPluginModule(
     },
     async push() {
       return { commentLinks: [], taskLinks: [] };
-    },
-  },
-};`
-      : `export const syncProvider = {
-  manifest: {
-    name: ${JSON.stringify(options.providerName)},
-    version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 2,
-  },
-  provider: {
-    name: ${JSON.stringify(options.providerName)},
-    version: ${JSON.stringify(options.providerVersion)},
-    async initialize() {},
-    async shutdown() {},
-    async pull() {
-      return { tasks: [] };
-    },
-    async push() {
-      return { commentLinks: [], taskLinks: [] };
-    },
-    mapToTask() {
-      return {
-        id: "task-1",
-        title: "Example",
-        status: "active",
-        priority: "medium",
-        projectId: "project-1",
-        labels: [],
-        assigneeActorIds: [],
-        assignees: [],
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      };
-    },
-    mapFromTask() {
-      return {
-        externalId: "ext-1",
-        title: "Example",
-      };
     },
   },
 };`;
@@ -2855,14 +2644,12 @@ function writeRecordingSyncPluginModule(
     providerName: string;
     providerVersion: string;
     outputPath: string;
-    apiVersion?: 2 | 3;
+    apiVersion?: 3;
   },
 ): string {
   const modulePath = path.join(directory, filename);
 
-  const moduleSource =
-    options.apiVersion === 3
-      ? `import fs from "node:fs";
+  const moduleSource = `import fs from "node:fs";
 
 const outputPath = ${JSON.stringify(options.outputPath)};
 
@@ -2874,7 +2661,7 @@ export const syncProvider = {
   manifest: {
     name: ${JSON.stringify(options.providerName)},
     version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 3,
+    apiVersion: ${options.apiVersion ?? 3},
   },
   provider: {
     name: ${JSON.stringify(options.providerName)},
@@ -2907,74 +2694,6 @@ export const syncProvider = {
         taskCount: tasks.length,
       });
       return { commentLinks: [], taskLinks: [] };
-    },
-  },
-};`
-      : `import fs from "node:fs";
-
-const outputPath = ${JSON.stringify(options.outputPath)};
-
-function record(event) {
-  fs.appendFileSync(outputPath, JSON.stringify(event) + "\\n", "utf8");
-}
-
-export const syncProvider = {
-  manifest: {
-    name: ${JSON.stringify(options.providerName)},
-    version: ${JSON.stringify(options.providerVersion)},
-    apiVersion: 2,
-  },
-  provider: {
-    name: ${JSON.stringify(options.providerName)},
-    version: ${JSON.stringify(options.providerVersion)},
-    async initialize(config) {
-      record({ type: "initialize", settings: config.settings });
-    },
-    async shutdown() {
-      record({ type: "shutdown" });
-    },
-    async pull(binding, project) {
-      record({
-        type: "pull",
-        bindingId: binding.id,
-        provider: binding.provider,
-        targetRef: binding.targetRef,
-        projectId: project.id,
-        strategy: binding.strategy,
-      });
-      return { tasks: [] };
-    },
-    async push(binding, tasks, project) {
-      record({
-        type: "push",
-        bindingId: binding.id,
-        provider: binding.provider,
-        targetRef: binding.targetRef,
-        projectId: project.id,
-        strategy: binding.strategy,
-        taskCount: tasks.length,
-      });
-      return { commentLinks: [], taskLinks: [] };
-    },
-    mapToTask() {
-      return {
-        id: "task-1",
-        title: "Example",
-        status: "active",
-        priority: "medium",
-        projectId: "project-1",
-        labels: [],
-        assigneeActorIds: [],
-        assignees: [],
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      };
-    },
-    mapFromTask() {
-      return {
-        externalId: "ext-1",
-        title: "Example",
-      };
     },
   },
 };`;
@@ -3128,27 +2847,10 @@ function writeInvalidSyncPluginModule(directory: string, filename: string): stri
     async initialize() {},
     async shutdown() {},
     async pull() {
-      return { tasks: [] };
+      return { tasks: [], comments: [] };
     },
-    async push() {},
-    mapToTask() {
-      return {
-        id: "task-1",
-        title: "Example",
-        status: "active",
-        priority: "medium",
-        projectId: "project-1",
-        labels: [],
-        assignees: [],
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
-      };
-    },
-    mapFromTask() {
-      return {
-        externalId: "ext-1",
-        title: "Example",
-      };
+    async push() {
+      return { commentLinks: [], taskLinks: [] };
     },
   },
 };`;

--- a/packages/daemon/src/sync-plugin-loader.ts
+++ b/packages/daemon/src/sync-plugin-loader.ts
@@ -2,9 +2,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   type AnySyncProviderRegistration,
-  isSyncProviderRegistrationV2,
-  type SyncProviderRegistrationV2,
-  type SyncProviderRegistrationV3,
+  type SyncProviderRegistration,
   type SyncProviderValidationError,
   validateSyncProviderRegistration,
   validateWorkerPluginRegistration,
@@ -33,23 +31,13 @@ export interface SyncPluginLoadError {
   details?: Record<string, unknown>;
 }
 
-export interface LoadedSyncPluginV2 {
+export interface LoadedSyncPlugin {
   kind: "sync-provider";
   workerRegistration: WorkerRegistration;
-  manifest: SyncProviderRegistrationV2["manifest"];
-  provider: SyncProviderRegistrationV2["provider"];
+  manifest: SyncProviderRegistration["manifest"];
+  provider: SyncProviderRegistration["provider"];
   modulePath: string;
 }
-
-export interface LoadedSyncPluginV3 {
-  kind: "sync-provider";
-  workerRegistration: WorkerRegistration;
-  manifest: SyncProviderRegistrationV3["manifest"];
-  provider: SyncProviderRegistrationV3["provider"];
-  modulePath: string;
-}
-
-export type LoadedSyncPlugin = LoadedSyncPluginV2 | LoadedSyncPluginV3;
 
 export interface LoadedWorkerPlugin {
   kind: "worker-plugin";
@@ -60,14 +48,6 @@ export interface LoadedWorkerPlugin {
 }
 
 export type LoadedConfiguredPlugin = LoadedSyncPlugin | LoadedWorkerPlugin;
-
-export function isLoadedSyncPluginV2(plugin: LoadedSyncPlugin): plugin is LoadedSyncPluginV2 {
-  return plugin.manifest.apiVersion === 2;
-}
-
-export function isLoadedSyncPluginV3(plugin: LoadedSyncPlugin): plugin is LoadedSyncPluginV3 {
-  return plugin.manifest.apiVersion === 3;
-}
 
 export interface LoadConfiguredPluginsResult {
   loadedPlugins: LoadedConfiguredPlugin[];
@@ -184,29 +164,16 @@ export async function loadConfiguredPlugins(
 
     seenWorkerTypes.add(workerType);
 
-    loadedPlugins.push(
-      isSyncProviderRegistrationV2(syncValidation.value)
-        ? {
-            kind: "sync-provider",
-            modulePath,
-            manifest: syncValidation.value.manifest,
-            provider: syncValidation.value.provider,
-            workerRegistration: {
-              manifest: createSyncPluginWorkerManifest(workerType),
-              runtime: createNoopWorkerRuntime(),
-            },
-          }
-        : {
-            kind: "sync-provider",
-            modulePath,
-            manifest: syncValidation.value.manifest,
-            provider: syncValidation.value.provider,
-            workerRegistration: {
-              manifest: createSyncPluginWorkerManifest(workerType),
-              runtime: createNoopWorkerRuntime(),
-            },
-          },
-    );
+    loadedPlugins.push({
+      kind: "sync-provider",
+      modulePath,
+      manifest: syncValidation.value.manifest,
+      provider: syncValidation.value.provider,
+      workerRegistration: {
+        manifest: createSyncPluginWorkerManifest(workerType),
+        runtime: createNoopWorkerRuntime(),
+      },
+    });
   }
 
   return {

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -5,8 +5,6 @@ import {
   createNoteId,
   createProjectId,
   createTaskId,
-  type ExternalComment,
-  type ExternalTask,
   type ImportedCommentInput,
   type ImportedTaskInput,
   type IntegrationBinding,
@@ -95,7 +93,21 @@ describe("sync-worker-runtime", () => {
     expect(provider.push).toHaveBeenCalledTimes(1);
     expect(provider.push).toHaveBeenCalledWith(
       binding,
-      [{ ...task, description: undefined, comments: [] }],
+      [
+        {
+          localTaskId: task.id,
+          externalId: task.externalId,
+          title: task.title,
+          description: undefined,
+          status: task.status,
+          priority: task.priority,
+          labels: task.labels,
+          assignees: [],
+          sourceUrl: task.sourceUrl,
+          updatedAt: task.updatedAt,
+          comments: [],
+        },
+      ],
       project,
     );
     expect(todu.integration.updateStatus).toHaveBeenCalledTimes(2);
@@ -306,7 +318,7 @@ describe("sync-worker-runtime", () => {
     expect(computeRetryDelayMs(3, resolved.config)).toBe(12_000);
   });
 
-  it("push includes task comments from note.list in each TaskPushPayload", async () => {
+  it("push includes task comments from note.list in each exported task payload", async () => {
     const provider = createProvider();
     const project = createProject();
     const task = createTask(project.id);
@@ -343,7 +355,13 @@ describe("sync-worker-runtime", () => {
     const pushArgs = provider.push.mock.calls[0];
     const pushedTasks = pushArgs[1];
     expect(pushedTasks).toHaveLength(1);
-    expect(pushedTasks[0].comments).toEqual([taskNote]);
+    expect(pushedTasks[0].comments).toEqual([
+      {
+        localNoteId: taskNote.id,
+        body: taskNote.content,
+        createdAt: taskNote.createdAt,
+      },
+    ]);
 
     handle.stop();
   });
@@ -471,21 +489,6 @@ describe("sync-worker-runtime", () => {
           ],
         })
         .mockResolvedValue({ commentLinks: [], taskLinks: [] }),
-      mapToTask: vi
-        .fn<SyncProvider["mapToTask"]>()
-        .mockImplementation((external, activeProject) => ({
-          id: task.id,
-          title: external.title,
-          status: "active",
-          priority: "medium",
-          projectId: activeProject.id,
-          labels: [],
-          assignees: [],
-          externalId: external.externalId,
-          sourceUrl: external.sourceUrl,
-          createdAt: new Date(0).toISOString(),
-          updatedAt: new Date(0).toISOString(),
-        })),
     });
     const todu = createTodu(project, [task], [binding]);
 
@@ -821,11 +824,15 @@ describe("sync-worker-runtime", () => {
   it("pull creates new tasks from pulled external tasks", async () => {
     const project = createProject();
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledTasks: ExternalTask[] = [
+    const pulledTasks: ImportedTaskInput[] = [
       {
         externalId: "gh-101",
         title: "Pulled bug",
         description: "Imported from GitHub",
+        status: "waiting",
+        priority: "high",
+        labels: ["bug"],
+        assignees: [{ externalLogin: "octocat", displayName: "octocat" }],
         sourceUrl: "https://example.com/issues/101",
         createdAt: "2021-04-17T14:30:00Z",
         updatedAt: "2026-03-10T15:00:00Z",
@@ -835,20 +842,6 @@ describe("sync-worker-runtime", () => {
       pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
         tasks: pulledTasks,
       }),
-      mapToTask: vi
-        .fn<SyncProvider["mapToTask"]>()
-        .mockImplementation((external, activeProject) => ({
-          id: createTaskId(`task-${external.externalId}`),
-          title: external.title,
-          status: "waiting",
-          priority: "high",
-          projectId: activeProject.id,
-          labels: ["bug"],
-          assignees: ["octocat"],
-          sourceUrl: external.sourceUrl,
-          createdAt: new Date(0).toISOString(),
-          updatedAt: new Date(0).toISOString(),
-        })),
     });
     const todu = createTodu(project, [], [binding]);
 
@@ -872,11 +865,6 @@ describe("sync-worker-runtime", () => {
     const handle = runtime.start();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(provider.mapToTask).toHaveBeenCalledTimes(1);
-    expect(provider.mapToTask).toHaveBeenCalledWith(
-      pulledTasks[0],
-      expect.objectContaining({ id: project.id }),
-    );
     expect(todu.project.update).toHaveBeenCalledWith(project.id, {
       authorizedAssigneeActorIds: expect.arrayContaining([createActorId("actor-user")]),
     });
@@ -914,11 +902,15 @@ describe("sync-worker-runtime", () => {
       updatedAt: "2026-03-09T10:00:00Z",
     };
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledTasks: ExternalTask[] = [
+    const pulledTasks: ImportedTaskInput[] = [
       {
         externalId: "gh-101",
         title: "Updated pulled bug",
         description: "Updated from GitHub",
+        status: "inprogress",
+        priority: "high",
+        labels: ["bug", "synced"],
+        assignees: [{ externalLogin: "octocat", displayName: "octocat" }],
         sourceUrl: "https://example.com/issues/101",
         updatedAt: "2026-03-10T15:00:00Z",
       },
@@ -927,20 +919,6 @@ describe("sync-worker-runtime", () => {
       pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
         tasks: pulledTasks,
       }),
-      mapToTask: vi
-        .fn<SyncProvider["mapToTask"]>()
-        .mockImplementation((external, activeProject) => ({
-          id: existingTask.id,
-          title: external.title,
-          status: "inprogress",
-          priority: "high",
-          projectId: activeProject.id,
-          labels: ["bug", "synced"],
-          assignees: ["octocat"],
-          sourceUrl: external.sourceUrl,
-          createdAt: existingTask.createdAt,
-          updatedAt: external.updatedAt ?? existingTask.updatedAt,
-        })),
     });
     const todu = createTodu(project, [existingTask], [binding]);
 
@@ -991,11 +969,15 @@ describe("sync-worker-runtime", () => {
   it("pull falls back imported updatedAt to createdAt when missing", async () => {
     const project = createProject();
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledTasks: ExternalTask[] = [
+    const pulledTasks: ImportedTaskInput[] = [
       {
         externalId: "gh-101",
         title: "Pulled bug",
         description: "Imported from GitHub",
+        status: "waiting",
+        priority: "high",
+        labels: ["bug"],
+        assignees: [{ externalLogin: "octocat", displayName: "octocat" }],
         createdAt: "2021-04-17T14:30:00Z",
       },
     ];
@@ -1003,20 +985,6 @@ describe("sync-worker-runtime", () => {
       pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
         tasks: pulledTasks,
       }),
-      mapToTask: vi
-        .fn<SyncProvider["mapToTask"]>()
-        .mockImplementation((external, activeProject) => ({
-          id: createTaskId(`task-${external.externalId}`),
-          title: external.title,
-          status: "waiting",
-          priority: "high",
-          projectId: activeProject.id,
-          labels: ["bug"],
-          assignees: ["octocat"],
-          sourceUrl: external.sourceUrl,
-          createdAt: new Date(0).toISOString(),
-          updatedAt: new Date(0).toISOString(),
-        })),
     });
     const todu = createTodu(project, [], [binding]);
 
@@ -1071,7 +1039,7 @@ describe("sync-worker-runtime", () => {
       updatedAt: "2026-03-10T20:00:00Z",
     };
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledTasks: ExternalTask[] = [
+    const pulledTasks: ImportedTaskInput[] = [
       {
         externalId: "gh-101",
         title: "Older pulled bug",
@@ -1106,7 +1074,6 @@ describe("sync-worker-runtime", () => {
     const handle = runtime.start();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(provider.mapToTask).toHaveBeenCalledTimes(1);
     expect(todu.task.update).not.toHaveBeenCalled();
     expect(todu.task.create).not.toHaveBeenCalled();
 
@@ -1116,7 +1083,7 @@ describe("sync-worker-runtime", () => {
   it("pull fails safely when a pulled task timestamp is invalid", async () => {
     const project = createProject();
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledTasks: ExternalTask[] = [
+    const pulledTasks: ImportedTaskInput[] = [
       {
         externalId: "gh-101",
         title: "Pulled bug",
@@ -1160,12 +1127,12 @@ describe("sync-worker-runtime", () => {
     const project = createProject();
     const task = createTask(project.id, { externalId: "gh-task-1" });
     const binding = createBinding(project.id, { strategy: "pull" });
-    const pulledComments: ExternalComment[] = [
+    const pulledComments: ImportedCommentInput[] = [
       {
         externalId: "gh-comment-1",
         externalTaskId: task.externalId!,
         body: "New comment from GitHub",
-        author: "octocat",
+        author: { externalLogin: "octocat", displayName: "octocat" },
         createdAt: "2026-03-10T10:00:00Z",
       },
     ];
@@ -1229,12 +1196,12 @@ describe("sync-worker-runtime", () => {
       tags: ["sync:externalId:gh-comment-1"],
       createdAt: "2026-03-09T10:00:00Z",
     });
-    const pulledComments: ExternalComment[] = [
+    const pulledComments: ImportedCommentInput[] = [
       {
         externalId: "gh-comment-1",
         externalTaskId: task.externalId!,
         body: "Updated content from GitHub",
-        author: "octocat",
+        author: { externalLogin: "octocat", displayName: "octocat" },
         createdAt: "2026-03-09T10:00:00Z",
         updatedAt: "2026-03-10T15:00:00Z",
       },
@@ -1349,12 +1316,12 @@ describe("sync-worker-runtime", () => {
       tags: ["sync:externalId:gh-comment-1"],
       createdAt: "2026-03-10T20:00:00Z",
     });
-    const pulledComments: ExternalComment[] = [
+    const pulledComments: ImportedCommentInput[] = [
       {
         externalId: "gh-comment-1",
         externalTaskId: task.externalId!,
         body: "Older external content",
-        author: "octocat",
+        author: { externalLogin: "octocat", displayName: "octocat" },
         createdAt: "2026-03-09T10:00:00Z",
         updatedAt: "2026-03-10T12:00:00Z",
       },
@@ -1406,7 +1373,7 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-comment-1",
             externalTaskId: "gh-task-missing",
             body: "Skipped because task is not imported",
-            author: "octocat",
+            author: { externalLogin: "octocat", displayName: "octocat" },
             createdAt: "2026-03-10T10:00:00Z",
           },
         ],
@@ -1546,7 +1513,7 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-comment-1",
             externalTaskId: task.externalId!,
             body: overLimitBody,
-            author: "octocat",
+            author: { externalLogin: "octocat", displayName: "octocat" },
             createdAt: "2026-01-01T00:00:00Z",
           },
         ],
@@ -1602,7 +1569,7 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-comment-1",
             externalTaskId: task.externalId!,
             body: overLimitBody,
-            author: "octocat",
+            author: { externalLogin: "octocat", displayName: "octocat" },
             createdAt: "2026-01-01T00:00:00Z",
             updatedAt: "2026-01-02T00:00:00Z",
           },
@@ -1652,7 +1619,7 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-comment-1",
             externalTaskId: task.externalId!,
             body: atLimitBody,
-            author: "octocat",
+            author: { externalLogin: "octocat", displayName: "octocat" },
             createdAt: "2026-01-01T00:00:00Z",
           },
         ],
@@ -1687,7 +1654,7 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
-  it("reuses trusted actor mappings during v2 pull and skips approval for mapped note authors", async () => {
+  it("reuses trusted actor mappings during pull and skips approval for mapped note authors", async () => {
     const project = createProject();
     const task = createTask(project.id, { externalId: "gh-task-1" });
     const binding = createBinding(project.id, {
@@ -1710,6 +1677,7 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-101",
             title: "Pulled bug",
             description: "Imported from GitHub",
+            assignees: [{ externalLogin: "octocat", displayName: "octocat" }],
             createdAt: "2026-01-01T00:00:00Z",
           },
         ],
@@ -1718,23 +1686,10 @@ describe("sync-worker-runtime", () => {
             externalId: "gh-comment-1",
             externalTaskId: task.externalId!,
             body: "Trusted comment",
-            author: "octocat",
+            author: { externalLogin: "octocat", displayName: "octocat" },
             createdAt: "2026-01-01T00:00:00Z",
           },
         ],
-      }),
-      mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockReturnValue({
-        id: createTaskId("task-gh-101"),
-        title: "Pulled bug",
-        status: "active",
-        priority: "medium",
-        projectId: project.id,
-        labels: [],
-        assigneeActorIds: [],
-        assignees: ["octocat"],
-        externalId: "gh-101",
-        createdAt: new Date(0).toISOString(),
-        updatedAt: new Date(0).toISOString(),
       }),
     });
     const todu = createTodu(project, [task], [binding], {
@@ -2064,25 +2019,9 @@ describe("sync-worker-runtime", () => {
 function createProvider(overrides: Partial<SyncProvider> = {}): SyncProvider {
   return {
     initialize: vi.fn<SyncProvider["initialize"]>().mockResolvedValue(undefined),
-    pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({ tasks: [] }),
+    pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({ tasks: [], comments: [] }),
     push: vi.fn<SyncProvider["push"]>().mockResolvedValue({ commentLinks: [], taskLinks: [] }),
     shutdown: vi.fn<SyncProvider["shutdown"]>().mockResolvedValue(undefined),
-    mapToTask: vi.fn<SyncProvider["mapToTask"]>().mockImplementation((item) => ({
-      id: createTaskId(String(item.externalId)),
-      title: item.title,
-      status: "active",
-      priority: "medium",
-      projectId: createProject().id,
-      labels: [],
-      assigneeActorIds: [],
-      assignees: [],
-      createdAt: new Date(0).toISOString(),
-      updatedAt: new Date(0).toISOString(),
-    })),
-    mapFromTask: vi.fn<SyncProvider["mapFromTask"]>().mockImplementation((task) => ({
-      externalId: task.id,
-      title: task.title,
-    })),
     name: "github",
     version: "1.0.0",
     ...overrides,

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -2,14 +2,11 @@ import crypto from "node:crypto";
 import {
   type Actor,
   type ActorId,
-  type AnySyncProvider,
   createActorId,
   createProjectId,
   type ExportedCommentInput,
   type ExportedTaskInput,
   type ExternalActorRef,
-  type ExternalComment,
-  type ExternalTask,
   type ImportedCommentInput,
   type ImportedContentApproval,
   type ImportedTaskInput,
@@ -19,14 +16,11 @@ import {
   MAX_NOTE_CONTENT_LENGTH,
   type Note,
   type Project,
-  SYNC_PROVIDER_API_VERSION_V2,
-  SYNC_PROVIDER_API_VERSION_V3,
+  SYNC_PROVIDER_API_VERSION,
   type SyncProviderPushCommentLink,
   type SyncProviderPushTaskLink,
-  type SyncProviderV2,
   type SyncProviderV3,
   type Task,
-  type TaskPushPayload,
   type ToduError,
 } from "@todu/core";
 import type { Todu, ToduWithInternalTools } from "@todu/engine";
@@ -62,7 +56,7 @@ export interface CreateSyncPluginWorkerRuntimeOptions {
   pluginVersion: string;
   modulePath: string;
   authorityId: string;
-  provider: AnySyncProvider;
+  provider: SyncProviderV3;
   providerApiVersion?: number;
   config: SyncPluginExecutionConfig;
   logger: DaemonLogger;
@@ -180,7 +174,7 @@ export function createSyncPluginWorkerRuntime(
   const clearTimeoutFn = options.scheduler?.clearTimeoutFn ?? clearTimeout;
   const now = options.scheduler?.now ?? (() => Date.now());
   const runtimeLogger = options.logger.child(`sync-plugin.${options.pluginName}`);
-  const providerApiVersion = options.providerApiVersion ?? SYNC_PROVIDER_API_VERSION_V2;
+  const providerApiVersion = options.providerApiVersion ?? SYNC_PROVIDER_API_VERSION;
 
   return {
     start() {
@@ -290,93 +284,48 @@ export function createSyncPluginWorkerRuntime(
 
         await ensureInitialized();
 
+        if (providerApiVersion !== SYNC_PROVIDER_API_VERSION) {
+          throw new Error(
+            `unsupported sync provider API version at runtime: ${providerApiVersion}`,
+          );
+        }
+
         if (binding.strategy === "pull" || binding.strategy === "bidirectional") {
-          if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
-            const provider = options.provider as SyncProviderV2;
-            const pullResult = await provider.pull(binding, project);
+          const pullResult = await options.provider.pull(binding, project);
 
-            if (pullResult.tasks.length > 0) {
-              const pullStats = await applyPulledTasksV2(
-                activeTodu,
-                actorState,
-                provider,
-                project,
-                pullResult.tasks,
-              );
-              project = pullStats.project;
-            }
-
-            if (pullResult.comments && pullResult.comments.length > 0) {
-              await applyPulledCommentsV2(activeTodu, actorState, project.id, pullResult.comments);
-            }
-          } else if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V3) {
-            const provider = options.provider as SyncProviderV3;
-            const pullResult = await provider.pull(binding, project);
-
-            if (pullResult.tasks.length > 0) {
-              const pullStats = await applyPulledTasksV3(
-                activeTodu,
-                actorState,
-                project,
-                pullResult.tasks,
-              );
-              project = pullStats.project;
-            }
-
-            if (pullResult.comments && pullResult.comments.length > 0) {
-              await applyPulledCommentsV3(activeTodu, actorState, project.id, pullResult.comments);
-            }
-          } else {
-            throw new Error(
-              `unsupported sync provider API version at runtime: ${providerApiVersion}`,
+          if (pullResult.tasks.length > 0) {
+            const pullStats = await applyPulledTasksV3(
+              activeTodu,
+              actorState,
+              project,
+              pullResult.tasks,
             );
+            project = pullStats.project;
+          }
+
+          if (pullResult.comments && pullResult.comments.length > 0) {
+            await applyPulledCommentsV3(activeTodu, actorState, project.id, pullResult.comments);
           }
         }
 
         if (binding.strategy === "push" || binding.strategy === "bidirectional") {
-          if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V2) {
-            const provider = options.provider as SyncProviderV2;
-            const pushPayloads = await buildPushPayloadsV2(
-              activeTodu,
-              actorState,
-              project,
-              runtimeLogger,
-            );
-            const pushResult = await provider.push(binding, pushPayloads, project);
-            if (
-              !pushResult ||
-              !Array.isArray(pushResult.commentLinks) ||
-              !Array.isArray(pushResult.taskLinks)
-            ) {
-              throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
-            }
-
-            await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
-            await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
-          } else if (providerApiVersion === SYNC_PROVIDER_API_VERSION_V3) {
-            const provider = options.provider as SyncProviderV3;
-            const pushPayloads = await buildPushPayloadsV3(
-              activeTodu,
-              actorState,
-              project,
-              runtimeLogger,
-            );
-            const pushResult = await provider.push(binding, pushPayloads, project);
-            if (
-              !pushResult ||
-              !Array.isArray(pushResult.commentLinks) ||
-              !Array.isArray(pushResult.taskLinks)
-            ) {
-              throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
-            }
-
-            await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
-            await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
-          } else {
-            throw new Error(
-              `unsupported sync provider API version at runtime: ${providerApiVersion}`,
-            );
+          const pushPayloads = await buildPushPayloadsV3(
+            activeTodu,
+            actorState,
+            project,
+            runtimeLogger,
+          );
+          const pushResult = await options.provider.push(binding, pushPayloads, project);
+          if (
+            !pushResult ||
+            !Array.isArray(pushResult.commentLinks) ||
+            !Array.isArray(pushResult.taskLinks)
+          ) {
+            throw new Error("sync provider push must return { commentLinks: [], taskLinks: [] }");
           }
+
+          await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
+          await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
         }
 
         if (actorState.mappingsChanged) {
@@ -624,32 +573,6 @@ function getImportedTaskTimestamps(task: RuntimeImportedTask): {
   };
 }
 
-async function applyPulledTasksV2(
-  todu: Todu,
-  actorState: SyncBindingActorState,
-  provider: SyncProviderV2,
-  project: Project,
-  tasks: ExternalTask[],
-): Promise<{ created: number; updated: number; skipped: number; project: Project }> {
-  const importedTasks = tasks.map((externalTask) => {
-    const mappedTask = provider.mapToTask(externalTask, project);
-    return {
-      externalId: mappedTask.externalId ?? externalTask.externalId,
-      title: mappedTask.title,
-      description: externalTask.description,
-      status: mappedTask.status,
-      priority: mappedTask.priority,
-      labels: mappedTask.labels,
-      assignees: mappedTask.assignees.map(createV2ExternalActorRef),
-      sourceUrl: mappedTask.sourceUrl ?? externalTask.sourceUrl,
-      createdAt: externalTask.createdAt,
-      updatedAt: externalTask.updatedAt,
-    } satisfies RuntimeImportedTask;
-  });
-
-  return applyImportedTasks(todu, actorState, project, importedTasks);
-}
-
 async function applyPulledTasksV3(
   todu: Todu,
   actorState: SyncBindingActorState,
@@ -822,24 +745,6 @@ async function applyImportedTasks(
   };
 }
 
-async function applyPulledCommentsV2(
-  todu: Todu,
-  actorState: SyncBindingActorState,
-  projectId: Project["id"],
-  comments: ExternalComment[],
-): Promise<{ created: number; updated: number; deleted: number }> {
-  const importedComments = comments.map((comment) => ({
-    externalId: comment.externalId,
-    externalTaskId: comment.externalTaskId,
-    body: comment.body,
-    author: comment.author ? createV2ExternalActorRef(comment.author) : undefined,
-    createdAt: comment.createdAt,
-    updatedAt: comment.updatedAt,
-  })) satisfies RuntimeImportedComment[];
-
-  return applyImportedComments(todu, actorState, projectId, importedComments);
-}
-
 async function applyPulledCommentsV3(
   todu: Todu,
   actorState: SyncBindingActorState,
@@ -976,39 +881,6 @@ async function applyImportedComments(
   }
 
   return stats;
-}
-
-async function buildPushPayloadsV2(
-  todu: Todu,
-  actorState: SyncBindingActorState,
-  project: Project,
-  logger: DaemonLogger,
-): Promise<TaskPushPayload[]> {
-  const tasksResult = await todu.task.list({ projectId: project.id });
-  if (!tasksResult.ok) {
-    throw new Error(`task list failed: ${formatToduError(tasksResult.error)}`);
-  }
-
-  const pushPayloads: TaskPushPayload[] = [];
-  for (const task of tasksResult.value) {
-    const detailResult = await todu.task.get(task.id);
-    const taskDetail = detailResult.ok ? detailResult.value : { ...task, description: undefined };
-
-    const commentsResult = await todu.note.list({
-      entityType: "task",
-      entityId: task.id,
-    });
-    const comments: Note[] = commentsResult.ok ? commentsResult.value : [];
-
-    const mappedAssignees = buildOutboundV2Assignees(taskDetail, actorState, logger);
-    pushPayloads.push({
-      ...taskDetail,
-      assignees: taskDetail.assigneeActorIds.length > 0 ? mappedAssignees : taskDetail.assignees,
-      comments,
-    });
-  }
-
-  return pushPayloads;
 }
 
 async function buildPushPayloadsV3(
@@ -1213,34 +1085,6 @@ async function ensureProjectAuthorizedAssigneeActors(
   return updateResult.value;
 }
 
-function buildOutboundV2Assignees(
-  task: Task,
-  actorState: SyncBindingActorState,
-  logger: DaemonLogger,
-): string[] {
-  const assignees: string[] = [];
-
-  for (const actorId of task.assigneeActorIds) {
-    const mapping = actorState.actorMappings.find((candidate) => candidate.actorId === actorId);
-    const outboundAssignee = mapping ? getOutboundV2Assignee(mapping) : null;
-
-    if (!mapping || !outboundAssignee) {
-      logger.warn("sync plugin skipped unmapped outbound assignee", {
-        bindingId: actorState.binding.id,
-        provider: actorState.binding.provider,
-        taskId: task.id,
-        taskTitle: task.title,
-        actorId,
-      });
-      continue;
-    }
-
-    assignees.push(outboundAssignee);
-  }
-
-  return assignees;
-}
-
 function buildOutboundV3Assignees(
   task: Task,
   actorState: SyncBindingActorState,
@@ -1267,10 +1111,6 @@ function buildOutboundV3Assignees(
   }
 
   return assignees;
-}
-
-function getOutboundV2Assignee(mapping: IntegrationBindingActorMapping): string | null {
-  return mapping.externalLogin ?? mapping.displayName ?? mapping.externalAccountId ?? null;
 }
 
 function getOutboundV3Assignee(mapping: IntegrationBindingActorMapping): ExternalActorRef | null {
@@ -1301,15 +1141,6 @@ function normalizeExternalActorRef(actorRef: ExternalActorRef): ExternalActorRef
       ? { displayName: parseOptionalString(actorRef.displayName)! }
       : {}),
     ...(actorRef.raw !== undefined ? { raw: actorRef.raw } : {}),
-  };
-}
-
-function createV2ExternalActorRef(value: string): ExternalActorRef {
-  const normalizedValue = value.trim();
-  return {
-    externalLogin: normalizedValue,
-    displayName: normalizedValue,
-    raw: value,
   };
 }
 


### PR DESCRIPTION
## Summary
- remove sync-provider API v2 definitions and validation from core
- remove v2 sync plugin loader/runtime branches from daemon
- update docs and tests for a v3-only sync provider host

## Verification
- make pre-pr
- npx vitest run --config vitest.all.config.ts packages/daemon/src/runtime.integration.test.ts packages/cli/src/commands/plugin.integration.test.ts
- npm run test -- packages/core/src/sync-provider.test.ts packages/daemon/src/sync-worker-runtime.test.ts

Closes task-9da71a25.
