### PR TITLE
fix: add note.get daemon RPC

### DIFF
--- a/packages/daemon/src/core-rpc-adapters.ts
+++ b/packages/daemon/src/core-rpc-adapters.ts
@@ -228,6 +228,10 @@ export function createCoreNamespaceHandlers(
         const filter = getOptionalObjectParam<NoteFilter>(request, "filter");
         return todu.note.list(filter);
       }),
+      get: method(async (request, todu) => {
+        const id = createNoteId(getRequiredStringParam(request, "id"));
+        return todu.note.get(id);
+      }),
       update: method(async (request, todu) => {
         const id = createNoteId(getRequiredStringParam(request, "id"));
         const input = getRequiredObjectParam<UpdateNoteInput>(request, "input");

--- a/packages/daemon/src/runtime.integration.test.ts
+++ b/packages/daemon/src/runtime.integration.test.ts
@@ -770,6 +770,18 @@ describe("createDaemonRuntime", () => {
       expect.arrayContaining([expect.objectContaining({ id: noteId, content: "Capture context" })]),
     );
 
+    const getNoteResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-get-1",
+      method: "note.get",
+      params: {
+        id: noteId,
+      },
+    });
+
+    expect(getNoteResponse.result).toEqual(
+      expect.objectContaining({ id: noteId, content: "Capture context" }),
+    );
+
     const updateNoteResponse = await sendRequest(runtime.config().socketPath, {
       id: "note-update-1",
       method: "note.update",
@@ -2205,6 +2217,23 @@ describe("createDaemonRuntime", () => {
       details: {
         entity: "project",
         id: "proj-missing",
+      },
+    });
+
+    const missingNoteGetResponse = await sendRequest(runtime.config().socketPath, {
+      id: "note-get-not-found",
+      method: "note.get",
+      params: {
+        id: "note-missing",
+      },
+    });
+
+    expect(missingNoteGetResponse.error).toEqual({
+      code: "NOT_FOUND",
+      message: "note not found: note-missing",
+      details: {
+        entity: "note",
+        id: "note-missing",
       },
     });
 

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -2138,6 +2138,7 @@ function createTodu(
   };
   note: {
     list: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
@@ -2347,6 +2348,12 @@ function createTodu(
     },
   );
 
+  const noteGet = vi.fn().mockImplementation(async (id: string) => {
+    const note = notes.find((candidate) => candidate.id === id);
+    if (!note) return ok(undefined);
+    return ok({ ...note, tags: [...note.tags] });
+  });
+
   const noteCreate = vi
     .fn()
     .mockImplementation(
@@ -2443,6 +2450,7 @@ function createTodu(
       },
       note: {
         list: noteList,
+        get: noteGet,
         create: noteCreate,
         update: noteUpdate,
         delete: noteDelete,
@@ -2465,6 +2473,7 @@ function createTodu(
     },
     note: {
       list: noteList,
+      get: noteGet,
       create: noteCreate,
       update: noteUpdate,
       delete: noteDelete,

--- a/packages/electron/src/main/daemon-todu-client.test.ts
+++ b/packages/electron/src/main/daemon-todu-client.test.ts
@@ -102,6 +102,23 @@ describe("createDaemonToduClient", () => {
     });
   });
 
+  it("routes note.get to daemon RPC and preserves Result shape", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { id: "note-1", content: "Captured", tags: [], createdAt: "2026-04-23T00:00:00Z" },
+    });
+
+    const client = createDaemonToduClient({ request });
+
+    const result = await client.note.get("note-1");
+
+    expect(request).toHaveBeenCalledWith("note.get", { id: "note-1" });
+    expect(result).toEqual({
+      ok: true,
+      value: { id: "note-1", content: "Captured", tags: [], createdAt: "2026-04-23T00:00:00Z" },
+    });
+  });
+
   it("maps daemon NOT_FOUND errors to not-found ToduError", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/electron/src/main/daemon-todu-client.ts
+++ b/packages/electron/src/main/daemon-todu-client.ts
@@ -36,6 +36,7 @@ interface DaemonBackedToduMethods {
   };
   note: {
     list(filter?: unknown): Promise<Result<unknown, ToduError>>;
+    get(id: string): Promise<Result<unknown, ToduError>>;
     create(input: unknown): Promise<Result<unknown, ToduError>>;
   };
   recurring: {
@@ -89,6 +90,7 @@ export function createDaemonToduClient(daemon: Pick<DaemonConnectionManager, "re
     },
     note: {
       list: (filter) => invoke("note.list", { filter }),
+      get: (id) => invoke("note.get", { id }),
       create: (input) => invoke("note.create", { input }),
     },
     recurring: {

--- a/packages/electron/src/main/ipc.integration.test.ts
+++ b/packages/electron/src/main/ipc.integration.test.ts
@@ -66,6 +66,28 @@ describe("createDaemonIpcHandlers", () => {
     });
   });
 
+  it("routes note IPC handlers to daemon RPC and preserves Result contract", async () => {
+    const daemon = {
+      request: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { id: "note-1", content: "Captured" },
+      }),
+    };
+
+    const handlers = createDaemonIpcHandlers({
+      daemon,
+      storagePath: "/tmp/todu-ipc-test",
+    });
+
+    const result = await handlers["todu:note:get"](undefined, "note-1");
+
+    expect(daemon.request).toHaveBeenCalledWith("note.get", { id: "note-1" });
+    expect(result).toEqual({
+      ok: true,
+      value: { id: "note-1", content: "Captured" },
+    });
+  });
+
   it("routes approval IPC handlers to daemon RPC and preserves Result contract", async () => {
     const daemon = {
       request: vi

--- a/packages/electron/src/main/ipc.ts
+++ b/packages/electron/src/main/ipc.ts
@@ -74,6 +74,7 @@ export function createDaemonIpcHandlers(
 
     // ── Note ──────────────────────────────────────────────────────────────
     "todu:note:list": (_event, filter) => invokeResult("note.list", { filter }),
+    "todu:note:get": (_event, id) => invokeResult("note.get", { id }),
     "todu:note:create": (_event, input) => invokeResult("note.create", { input }),
     "todu:note:update": (_event, id, input) => invokeResult("note.update", { id, input }),
     "todu:note:delete": (_event, id) => invokeResult("note.delete", { id }),

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -57,6 +57,7 @@ const api = {
   // ── Note ───────────────────────────────────────────────────────────
   note: {
     list: (filter?: unknown) => ipcRenderer.invoke("todu:note:list", filter),
+    get: (id: string) => ipcRenderer.invoke("todu:note:get", id),
     create: (input: unknown) => ipcRenderer.invoke("todu:note:create", input),
     update: (id: string, input: unknown) => ipcRenderer.invoke("todu:note:update", id, input),
     delete: (id: string) => ipcRenderer.invoke("todu:note:delete", id),

--- a/packages/electron/src/renderer/types/window.d.ts
+++ b/packages/electron/src/renderer/types/window.d.ts
@@ -81,6 +81,7 @@ export interface ToduLabelApi {
 
 export interface ToduNoteApi {
   list(filter?: NoteFilter): Promise<Result<Note[]>>;
+  get(id: NoteId): Promise<Result<Note>>;
   create(input: CreateNoteInput): Promise<Result<Note>>;
   update(id: NoteId, input: UpdateNoteInput): Promise<Result<Note>>;
   delete(id: NoteId): Promise<Result<void>>;

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -613,6 +613,30 @@ describe("note namespace", () => {
     });
   });
 
+  describe("get", () => {
+    it("returns a note by id", async () => {
+      const created = await todu.note.create({
+        content: "Capture context",
+        author: "agent",
+        tags: ["phase-2"],
+      });
+      if (!created.ok) throw new Error("create failed");
+
+      const result = await todu.note.get(created.value.id);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual(created.value);
+    });
+
+    it("returns NotFound for nonexistent note", async () => {
+      const result = await todu.note.get(createNoteId("note-nope"));
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.type).toBe("not-found");
+      expect(result.error.entity).toBe("note");
+    });
+  });
+
   describe("update", () => {
     it("updates note content", async () => {
       const created = await todu.note.create({ content: "Original" });

--- a/packages/engine/src/notes.ts
+++ b/packages/engine/src/notes.ts
@@ -485,6 +485,18 @@ export function createNoteNamespace(
       return ok(notes);
     },
 
+    async get(id: NoteId): Promise<Result<Note>> {
+      await ensurePartitionModelReady();
+
+      const location = await findNoteLocation(id);
+      if (!location) return err(notFound("note", id));
+
+      const note = location.handle.doc()?.notes[location.index];
+      if (!note) return err(notFound("note", id));
+
+      return ok(cloneNote(note));
+    },
+
     async update(id: NoteId, input: UpdateNoteInput): Promise<Result<Note>> {
       const validationErr = validateUpdateNoteInput(input);
       if (validationErr) return err(validationErr);

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -158,6 +158,7 @@ export interface IntegrationNamespace {
 export interface NoteNamespace {
   create(input: CreateNoteInput): Promise<Result<Note>>;
   list(filter?: NoteFilter): Promise<Result<Note[]>>;
+  get(id: NoteId): Promise<Result<Note>>;
   update(id: NoteId, input: UpdateNoteInput): Promise<Result<Note>>;
   delete(id: NoteId): Promise<Result<void>>;
 }
@@ -343,6 +344,7 @@ export function createStubNamespaces(config: ToduConfig): Omit<Todu, "close" | "
     note: {
       create: stub,
       list: stub,
+      get: stub,
       update: stub,
       delete: stub,
     },


### PR DESCRIPTION
Expose first-class note lookup through the engine, daemon RPC, and local daemon-backed client wrappers so single-note consumers stop failing with METHOD_NOT_FOUND.

Task: #task-4d8bec7b
