### PR TITLE
Remove toduai CLI alias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # Environment variables for local development
 # Copy to .env and fill in values
 
-# Data storage location (default: ~/.config/toduai/data)
-# TODUAI_DATA_DIR=~/.config/toduai/data
+# Data storage location (default: ~/.config/todu/data)
+# TODU_DATA_DIR=~/.config/todu/data
 
 # Automerge sync server (Phase 3+)
-# TODUAI_SYNC_SERVER=ws://localhost:3030
+# TODU_SYNC_SERVER=ws://localhost:3030
 
 # Debug mode
-# DEBUG=toduai:*
+# DEBUG=todu:*

--- a/docs/archive/ARCHITECTURE.legacy.md
+++ b/docs/archive/ARCHITECTURE.legacy.md
@@ -514,7 +514,7 @@ Config file at `~/.config/toduai/config.yaml` (default). Covers: data directory,
 
 ### Dev Workflow
 
-For project-specific data isolation, run `toduai config init` in a project directory. This creates `.toduai/config.yaml` + `.toduai/.gitignore`. Tell agents to use `--config .toduai/config.yaml` and they get an isolated data directory.
+For project-specific data isolation, run `todu config init` in a project directory. This creates `.toduai/config.yaml` + `.toduai/.gitignore`. Tell agents to use `--config .toduai/config.yaml` and they get an isolated data directory.
 
 ### Config Behavior
 
@@ -571,7 +571,7 @@ Import strategy: relative `.js` imports (no path aliases). `Node16` module resol
 | `@todu/engine` | Recurring templates (CRUD, task generation, skip list, upcoming, early materialization) | ✅ Done |
 | `@todu/engine` | Habits (CRUD, check/uncheck, computed streaks, history) | ✅ Done |
 | `@todu/engine` | Configuration system (`--config` flag, `config init`, resolution order) | ✅ Done |
-| `@todu/cli` | Thin CLI (`toduai`) consuming engine, table/JSON output, color, status shortcuts | ✅ Done |
+| `@todu/cli` | Thin CLI (`todu`) consuming engine, table/JSON output, color, status shortcuts | ✅ Done |
 | Tests | 384 tests across 21 test files (unit + integration + CLI) | ✅ Done |
 
 ### Phase 2: Electron
@@ -609,7 +609,7 @@ Import strategy: relative `.js` imports (no path aliases). `Node16` module resol
 For users of the current todu-api + todu.sh:
 
 1. Export data from todu-api (JSON format)
-2. Run `toduai migrate import ./export.json`
+2. Run `todu migrate import ./export.json`
 3. Configure sync extensions for existing projects
 4. Verify data, then sunset todu-api
 

--- a/docs/archive/plans-legacy/phase-2-electron.md
+++ b/docs/archive/plans-legacy/phase-2-electron.md
@@ -436,7 +436,7 @@ Decisions to make before or during implementation:
 
 2. **Electron build tool** — electron-forge vs electron-vite. electron-vite is newer and integrates Vite natively, which simplifies React HMR. electron-forge is more mature. Evaluate during Slice 1.
 
-3. **Binary name coexistence** — Currently `toduai` is the CLI. Should launching the Electron app be `toduai --gui`, a separate `toduai-app` binary, or just double-click the packaged app? The CLI and Electron share the engine but are separate packages.
+3. **Binary name coexistence** — The CLI command is `todu`. Should launching the Electron app be `todu --gui`, a separate app binary, or just double-click the packaged app? The CLI and Electron share the engine but are separate packages.
 
 4. **Agent conversation persistence** — Should chat history persist across app restarts? If so, store in a new Automerge document or local file? Start without persistence, add later if needed.
 

--- a/docs/archive/plans-legacy/phase-5-sync-worker.md
+++ b/docs/archive/plans-legacy/phase-5-sync-worker.md
@@ -100,7 +100,7 @@ function generateRecurringTaskId(templateId: string, scheduledDate: Date): strin
 ### Worker Coordination
 
 - On multi-device, only worker should process recurring tasks
-- If no worker, devices should not auto-process (use manual `toduai recurring process`)
+- If no worker, devices should not auto-process (use manual `todu recurring process`)
 - Worker claims ownership via Automerge document flag
 
 ## Open Questions

--- a/docs/archive/plans-legacy/phase-6-plugin-system.md
+++ b/docs/archive/plans-legacy/phase-6-plugin-system.md
@@ -24,10 +24,10 @@ Implement the plugin system that enables external integrations. Create GitHub an
    - Plugin lifecycle management
 
 2. **Plugin CLI Commands**
-   - `toduai plugin install <name>`
-   - `toduai plugin list`
-   - `toduai plugin remove <name>`
-   - `toduai plugin config <name>`
+   - `todu plugin install <name>`
+   - `todu plugin list`
+   - `todu plugin remove <name>`
+   - `todu plugin config <name>`
 
 3. **todu-github plugin** (separate repo)
    - Bidirectional sync with GitHub Issues

--- a/docs/archive/plans-legacy/phase-7-polish.md
+++ b/docs/archive/plans-legacy/phase-7-polish.md
@@ -19,7 +19,7 @@ Final polish phase covering migration from old system, advanced background job t
 
 1. **Migration Tooling**
    - Export from todu-api (JSON format)
-   - `toduai migrate import ./export.json`
+   - `todu migrate import ./export.json`
    - Map old IDs to new IDs
    - Preserve history and comments
    - Validate imported data
@@ -55,11 +55,11 @@ Final polish phase covering migration from old system, advanced background job t
 curl https://api.todu.example.com/export > export.json
 
 # Import to new system
-toduai migrate import ./export.json --dry-run
-toduai migrate import ./export.json
+todu migrate import ./export.json --dry-run
+todu migrate import ./export.json
 
 # Verify
-toduai migrate verify
+todu migrate verify
 ```
 
 ### Migration Mapping

--- a/docs/plans/phase-5-join-safety.md
+++ b/docs/plans/phase-5-join-safety.md
@@ -67,10 +67,10 @@ Implementation note:
 
 ### CLI UX
 
-- `toduai sync status` — show daemon/catalog state
-- `toduai sync join <catalogId> --check` — validation only
-- `toduai sync join <catalogId>` — interactive confirmation + join
-- `toduai sync join <catalogId> --yes` — non-interactive mode
+- `todu sync status` — show daemon/catalog state
+- `todu sync join <catalogId> --check` — validation only
+- `todu sync join <catalogId>` — interactive confirmation + join
+- `todu sync join <catalogId> --yes` — non-interactive mode
 
 CLI output should clearly indicate:
 - previous catalog ID
@@ -78,8 +78,8 @@ CLI output should clearly indicate:
 - success or rollback outcome
 
 Implementation note:
-- `toduai sync join <catalogId> --check` calls daemon `sync.join` with `check=true`
-- `toduai sync join <catalogId>` performs validation first, prompts for confirmation, then calls daemon `sync.join`
+- `todu sync join <catalogId> --check` calls daemon `sync.join` with `check=true`
+- `todu sync join <catalogId>` performs validation first, prompts for confirmation, then calls daemon `sync.join`
 - `--yes` skips confirmation for non-interactive flows
 
 ### Daemon join API behavior (Phase 5 implementation)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12577,8 +12577,7 @@
         "yaml": "^2.8.2"
       },
       "bin": {
-        "todu": "dist/index.js",
-        "toduai": "dist/index.js"
+        "todu": "dist/index.js"
       },
       "engines": {
         "node": ">=20"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,8 +4,7 @@
   "description": "CLI for todu task management — create, track, and sync tasks from the terminal",
   "type": "module",
   "bin": {
-    "todu": "dist/index.js",
-    "toduai": "dist/index.js"
+    "todu": "dist/index.js"
   },
   "main": "./dist/index.js",
   "files": [
@@ -34,7 +33,6 @@
   "license": "MIT",
   "keywords": [
     "todu",
-    "toduai",
     "task-management",
     "cli",
     "todo",

--- a/packages/cli/src/commands/plugin.integration.test.ts
+++ b/packages/cli/src/commands/plugin.integration.test.ts
@@ -133,6 +133,45 @@ describe("plugin CLI commands", () => {
     });
   });
 
+  it("redacts sensitive plugin config values in command output", () => {
+    const pluginPath = writePluginModule(tmpDir, "forgejo-plugin.mjs", {
+      name: "forgejo",
+      version: "2.1.0",
+      apiVersion: 3,
+    });
+
+    run(`plugin install ${pluginPath}`);
+
+    const updateOutput = run(
+      'plugin config forgejo --set \'{"repo":"acme/demo","token":"secret-token","nested":{"apiKey":"api-key-secret","label":"safe"},"auth":[{"password":"passw0rd"}]}\'',
+    );
+    expect(updateOutput).toContain("[redacted]");
+    expect(updateOutput).not.toContain("secret-token");
+    expect(updateOutput).not.toContain("api-key-secret");
+    expect(updateOutput).not.toContain("passw0rd");
+
+    const shownConfigJson = run("--format json plugin config forgejo");
+    expect(shownConfigJson).not.toContain("secret-token");
+    expect(shownConfigJson).not.toContain("api-key-secret");
+    expect(shownConfigJson).not.toContain("passw0rd");
+    expect(JSON.parse(shownConfigJson)).toEqual({
+      plugin: "forgejo",
+      settings: {
+        repo: "acme/demo",
+        token: "[redacted]",
+        nested: {
+          apiKey: "[redacted]",
+          label: "safe",
+        },
+        auth: [
+          {
+            password: "[redacted]",
+          },
+        ],
+      },
+    });
+  });
+
   it("fails with actionable error for missing plugin removal", () => {
     const output = run("plugin remove missing-plugin", true);
 

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -87,6 +87,18 @@ interface PluginModuleShape {
   workerPlugin?: unknown;
 }
 
+const REDACTED_PLUGIN_SETTING = "[redacted]";
+const SENSITIVE_PLUGIN_CONFIG_KEY_TERMS = [
+  "token",
+  "secret",
+  "password",
+  "passwd",
+  "credential",
+  "apikey",
+  "accesskey",
+  "privatekey",
+] as const;
+
 export function registerPluginCommands(program: Command, invokeDaemon: CliDaemonInvoker): void {
   const plugin = program.command("plugin").description("Manage daemon worker plugins");
 
@@ -330,16 +342,17 @@ export function registerPluginCommands(program: Command, invokeDaemon: CliDaemon
       const existingConfig = readPluginSettings(config, resolvedPlugin.pluginName);
 
       if (!options.set && !options.clear) {
+        const redactedConfig = redactPluginSettings(existingConfig);
         const result: PluginConfigCommandResult = {
           plugin: resolvedPlugin.pluginName,
-          settings: existingConfig,
+          settings: redactedConfig,
         };
 
         if (program.opts().format === "json") {
           console.log(formatJSON(result));
         } else {
           console.log(`Plugin: ${resolvedPlugin.pluginName}`);
-          console.log(`Config: ${formatJSON(existingConfig)}`);
+          console.log(`Config: ${formatJSON(redactedConfig)}`);
         }
         return;
       }
@@ -371,16 +384,17 @@ export function registerPluginCommands(program: Command, invokeDaemon: CliDaemon
       writePluginSettings(config, resolvedPlugin.pluginName, parsedConfig.value);
       saveConfig(config, configPath);
 
+      const redactedConfig = redactPluginSettings(parsedConfig.value);
       const result: PluginConfigCommandResult = {
         plugin: resolvedPlugin.pluginName,
-        settings: parsedConfig.value,
+        settings: redactedConfig,
       };
 
       if (program.opts().format === "json") {
         console.log(formatJSON(result));
       } else {
         console.log(`Plugin config updated: ${resolvedPlugin.pluginName}`);
-        console.log(`Config: ${formatJSON(parsedConfig.value)}`);
+        console.log(`Config: ${formatJSON(redactedConfig)}`);
       }
     });
 }
@@ -412,6 +426,38 @@ function readPluginSettings(config: ToduFileConfig, pluginName: string): Record<
   }
 
   return { ...rawConfig };
+}
+
+function redactPluginSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const redactedSettings: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(settings)) {
+    redactedSettings[key] = redactPluginConfigValue(key, value);
+  }
+
+  return redactedSettings;
+}
+
+function redactPluginConfigValue(key: string, value: unknown): unknown {
+  if (isSensitivePluginConfigKey(key)) {
+    return REDACTED_PLUGIN_SETTING;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactPluginConfigValue("", item));
+  }
+
+  if (isRecord(value)) {
+    return redactPluginSettings(value);
+  }
+
+  return value;
+}
+
+function isSensitivePluginConfigKey(key: string): boolean {
+  const normalizedKey = key.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+
+  return SENSITIVE_PLUGIN_CONFIG_KEY_TERMS.some((term) => normalizedKey.includes(term));
 }
 
 function writePluginSettings(

--- a/packages/cli/src/version-command.test.ts
+++ b/packages/cli/src/version-command.test.ts
@@ -33,14 +33,14 @@ describe("CLI version output", { timeout: 30000 }, () => {
     expect(output).toContain("Usage: todu");
   });
 
-  it("publishes both todu and toduai CLI bin entries during the transition", async () => {
+  it("publishes only the todu CLI bin entry", async () => {
     const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8")) as {
       bin: Record<string, string>;
     };
 
     expect(packageJson.bin).toEqual({
       todu: "dist/index.js",
-      toduai: "dist/index.js",
     });
+    expect(packageJson.bin).not.toHaveProperty("toduai");
   });
 });

--- a/packages/electron/build/linux/after-install.sh
+++ b/packages/electron/build/linux/after-install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# Post-install: create primary todu CLI symlink and preserve toduai compatibility.
+# Post-install: create the primary todu CLI symlink.
 CLI_PATH="/opt/todu/resources/cli/todu"
 if [ -f "$CLI_PATH" ]; then
   chmod +x "$CLI_PATH"
   ln -sf "$CLI_PATH" /usr/local/bin/todu
-  ln -sf "$CLI_PATH" /usr/local/bin/toduai
 fi


### PR DESCRIPTION
## Summary
- remove the obsolete `toduai` CLI bin alias from @todu/cli packaging and Linux installer symlink creation
- redact sensitive plugin config values in show/update command output
- update stale docs command examples from `toduai` to `todu`

## Verification
- `npx vitest run packages/cli/src/version-command.test.ts`
- `npx vitest run --config vitest.all.config.ts packages/cli/src/commands/plugin.integration.test.ts`
- `make check`
- `make pre-pr`

Task: #task-fd5e4884