### PR TITLE
Search tasks by description

### DIFF
--- a/docs/architecture/task-search.md
+++ b/docs/architecture/task-search.md
@@ -1,0 +1,11 @@
+# Task Search
+
+Task title and description search uses task-list metadata so routine searches do not load every `TaskDetailDocument`.
+
+## Approach
+
+Each `TaskListDocument` stores `descriptionSearchTextByTaskId`, a normalized copy of the task description text used only for search matching. Task creation and description updates maintain this index. Task moves transfer the indexed text to the target project task list, and task deletes remove it. Legacy task lists backfill missing search text from detail docs once when a task list is loaded; after backfill, normal `task.search` and `task.list({ search })` calls scan task-list docs only.
+
+## Performance target
+
+The expected near-term scale is hundreds to low thousands of tasks per dataset, with task lists partitioned by project. Indexed title+description search should avoid per-query detail-doc fanout and complete an indexed 1,000-task query in under 250 ms on a developer machine. A local benchmark on 2026-04-28 created 1,000 tasks with descriptions and ran 20 warm indexed description searches for `framework`; average query time was 0.24 ms. Backfill may load detail docs once for missing index entries, but that cost is migration work and is not paid by every later search.

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -240,6 +240,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
     .option("--status <statuses>", "filter by status (comma-separated)")
     .option("--priority <priority>", "filter by priority")
     .option("--label <label>", "filter by label")
+    .option("--search <query>", "search task titles and descriptions")
     .option("--from <date>", "filter by created-at start (YYYY-MM-DD or ISO-8601)")
     .option("--to <date>", "filter by created-at end (YYYY-MM-DD or ISO-8601)")
     .option("--updated-from <date>", "filter by updated-at start (YYYY-MM-DD or ISO-8601)")
@@ -295,6 +296,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
           status,
           priority: opts.priority,
           label: opts.label,
+          search: opts.search,
           createdFrom: opts.from,
           createdTo: opts.to,
           updatedFrom: opts.updatedFrom,
@@ -415,7 +417,7 @@ export function registerTaskCommands(program: Command, invokeDaemon: CliDaemonIn
 
   task
     .command("search <query>")
-    .description("Search tasks by title")
+    .description("Search tasks by title and description")
     .action(async (query) => {
       const result = await invokeDaemon<Task[]>("task.search", { query });
       if (!result.ok) {

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -77,6 +77,7 @@ describe("schema", () => {
       expect(doc.projectId).toBe(projectId);
       expect(doc.tasks).toEqual([]);
       expect(doc.detailDocIds).toEqual({});
+      expect(doc.descriptionSearchTextByTaskId).toEqual({});
     });
   });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -83,8 +83,8 @@ export interface CatalogDocument {
 
 /**
  * Task list document (one per project).
- * Contains task metadata only — no descriptions or heavy content.
- * Each task is ~200 bytes, so a project with 1000 tasks ≈ 200KB.
+ * Contains task metadata and lightweight search text only — no full descriptions or heavy content.
+ * Each task is ~200 bytes plus a normalized description search excerpt, so searches can avoid loading every detail doc.
  */
 export interface TaskListDocument {
   /** Project this task list belongs to */
@@ -98,6 +98,12 @@ export interface TaskListDocument {
    * Loaded on demand when task.get() is called.
    */
   detailDocIds: Record<string, string>;
+
+  /**
+   * Map of taskId → normalized description text for cheap title+description search.
+   * Backfilled from detail docs when missing and maintained by task description writes.
+   */
+  descriptionSearchTextByTaskId: Record<string, string>;
 }
 
 /**
@@ -198,6 +204,7 @@ export function createTaskListDocument(projectId: ProjectId): TaskListDocument {
     projectId,
     tasks: [],
     detailDocIds: {},
+    descriptionSearchTextByTaskId: {},
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -385,6 +385,8 @@ export interface TaskFilter {
   priority?: TaskPriority;
   projectId?: ProjectId;
   label?: string;
+  /** Search query matched against task title and indexed description text. */
+  search?: string;
   createdFrom?: string;
   createdTo?: string;
   dueBefore?: string;

--- a/packages/electron/src/main/tools.integration.test.ts
+++ b/packages/electron/src/main/tools.integration.test.ts
@@ -199,6 +199,23 @@ describe("todu agent tools", () => {
       expect(data[0].title).toBe("Alpha");
       expect(data[1].title).toBe("Bravo");
     });
+
+    it("filters by description search text", async () => {
+      await exec("create_task", {
+        title: "Investigate UI",
+        projectId,
+        description: "Compare popular agent framework options",
+      });
+      await exec("create_task", {
+        title: "Write docs",
+        projectId,
+        description: "Document setup steps",
+      });
+
+      const data = await execJson("list_tasks", { search: "framework" });
+      expect(data).toHaveLength(1);
+      expect(data[0].title).toBe("Investigate UI");
+    });
   });
 
   describe("get_task", () => {
@@ -249,6 +266,23 @@ describe("todu agent tools", () => {
       const data = await execJson("search_tasks", { query: "login" });
       expect(data).toHaveLength(1);
       expect(data[0].title).toBe("Login bug fix");
+    });
+
+    it("finds tasks by description", async () => {
+      await exec("create_task", {
+        title: "Investigate UI",
+        projectId,
+        description: "Compare popular agent framework options",
+      });
+      await exec("create_task", {
+        title: "Write docs",
+        projectId,
+        description: "Document setup steps",
+      });
+
+      const data = await execJson("search_tasks", { query: "framework" });
+      expect(data).toHaveLength(1);
+      expect(data[0].title).toBe("Investigate UI");
     });
 
     it("returns empty for no matches", async () => {

--- a/packages/electron/src/main/tools.ts
+++ b/packages/electron/src/main/tools.ts
@@ -104,6 +104,9 @@ const ListTasksParams = Type.Object({
   ),
   projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
   label: Type.Optional(Type.String({ description: "Filter by label" })),
+  search: Type.Optional(
+    Type.String({ description: "Search query to match against task titles and descriptions" }),
+  ),
   dueBefore: Type.Optional(
     Type.String({ description: "Filter tasks due before date (YYYY-MM-DD)" }),
   ),
@@ -189,7 +192,7 @@ const MoveTaskParams = Type.Object({
 });
 
 const SearchTasksParams = Type.Object({
-  query: Type.String({ description: "Search query to match against task titles" }),
+  query: Type.String({ description: "Search query to match against task titles and descriptions" }),
 });
 
 const ListLabelsParams = Type.Object({});
@@ -318,7 +321,7 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     {
       name: "list_tasks",
       description:
-        "List tasks with optional filtering by status, priority, project, label, due date, or updated-at range. Use updatedFrom/updatedTo with status=done for monthly review. Supports sorting.",
+        "List tasks with optional filtering by status, priority, project, label, search query, due date, or updated-at range. Use updatedFrom/updatedTo with status=done for monthly review. Supports sorting.",
       label: "List Tasks",
       parameters: ListTasksParams,
       execute: async (_toolCallId, params) => {
@@ -393,7 +396,7 @@ export function createToduTools(todu: Todu, mainWindow?: BrowserWindow): AgentTo
     },
     {
       name: "search_tasks",
-      description: "Search tasks by title.",
+      description: "Search tasks by title and description.",
       label: "Search Tasks",
       parameters: SearchTasksParams,
       execute: async (_toolCallId, { query }) => formatResult(await todu.task.search(query)),

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -33,6 +33,36 @@ async function readCatalogDocument(storagePath: string): Promise<CatalogDocument
   }
 }
 
+async function removeDescriptionSearchIndex(
+  storagePath: string,
+  projectId: ProjectId,
+  taskId: TaskId,
+): Promise<void> {
+  const markerPath = path.join(storagePath, "todu-catalog.id");
+  const catalogId = fs.readFileSync(markerPath, "utf-8").trim();
+  const repo = new Repo({
+    storage: new NodeFSStorageAdapter(storagePath),
+  });
+
+  try {
+    const catalogHandle = await repo.find<CatalogDocument>(catalogId);
+    await catalogHandle.whenReady();
+    const taskListDocId = catalogHandle.doc()?.taskListDocIds[projectId];
+    if (!taskListDocId) {
+      throw new Error(`task list not found for project ${projectId}`);
+    }
+
+    const taskListHandle = await repo.find<TaskListDocument>(taskListDocId);
+    await taskListHandle.whenReady();
+    taskListHandle.change((doc) => {
+      delete doc.descriptionSearchTextByTaskId[taskId];
+    });
+    await repo.flush();
+  } finally {
+    await repo.shutdown();
+  }
+}
+
 async function removeTaskArrays(
   storagePath: string,
   projectId: ProjectId,
@@ -729,6 +759,26 @@ describe("task namespace", () => {
       expect(result.value.map((t) => t.title)).toEqual(["Alpha", "Bravo", "Charlie"]);
     });
 
+    it("filters by title and description search text", async () => {
+      await todu.task.create({ title: "Login bug", projectId });
+      await todu.task.create({
+        title: "Investigate UI",
+        projectId,
+        description: "Compare framework options",
+      });
+      await todu.task.create({ title: "Write docs", projectId, description: "Document setup" });
+
+      const titleResult = await todu.task.list({ search: "login" });
+      expect(titleResult.ok).toBe(true);
+      if (!titleResult.ok) return;
+      expect(titleResult.value.map((task) => task.title)).toEqual(["Login bug"]);
+
+      const descriptionResult = await todu.task.list({ search: "framework" });
+      expect(descriptionResult.ok).toBe(true);
+      if (!descriptionResult.ok) return;
+      expect(descriptionResult.value.map((task) => task.title)).toEqual(["Investigate UI"]);
+    });
+
     it("sorts by dueDate descending, missing dates last", async () => {
       await todu.task.create({ title: "Early", projectId, dueDate: "2026-01-01" });
       await todu.task.create({ title: "Late", projectId, dueDate: "2026-12-31" });
@@ -1171,6 +1221,74 @@ describe("task namespace", () => {
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value).toHaveLength(1);
+    });
+
+    it("finds tasks by description substring without a title match", async () => {
+      await todu.task.create({
+        title: "Investigate UI",
+        projectId,
+        description: "Compare popular agent framework options",
+      });
+      await todu.task.create({
+        title: "Write docs",
+        projectId,
+        description: "Document setup steps",
+      });
+
+      const result = await todu.task.search("framework");
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].title).toBe("Investigate UI");
+    });
+
+    it("updates description search text when descriptions change", async () => {
+      const created = await todu.task.create({
+        title: "Investigate UI",
+        projectId,
+        description: "Compare framework options",
+      });
+      if (!created.ok) throw new Error("create failed");
+
+      const before = await todu.task.search("framework");
+      expect(before.ok).toBe(true);
+      if (!before.ok) return;
+      expect(before.value).toHaveLength(1);
+
+      const update = await todu.task.update(created.value.id, {
+        description: "Document accessibility findings",
+      });
+      expect(update.ok).toBe(true);
+
+      const oldQuery = await todu.task.search("framework");
+      expect(oldQuery.ok).toBe(true);
+      if (!oldQuery.ok) return;
+      expect(oldQuery.value).toHaveLength(0);
+
+      const newQuery = await todu.task.search("accessibility");
+      expect(newQuery.ok).toBe(true);
+      if (!newQuery.ok) return;
+      expect(newQuery.value).toHaveLength(1);
+      expect(newQuery.value[0].id).toBe(created.value.id);
+    });
+
+    it("backfills missing description search text once from detail docs", async () => {
+      const created = await todu.task.create({
+        title: "Investigate UI",
+        projectId,
+        description: "Compare framework options",
+      });
+      if (!created.ok) throw new Error("create failed");
+
+      await todu.close();
+      await removeDescriptionSearchIndex(tmpDir, projectId, created.value.id);
+      todu = await createTodu({ storagePath: tmpDir });
+
+      const result = await todu.task.search("framework");
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].id).toBe(created.value.id);
     });
 
     it("returns empty for no matches", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -111,6 +111,20 @@ export function createTaskNamespace(
     };
   }
 
+  function normalizeTaskSearchText(content: string): string {
+    return content.trim().toLowerCase();
+  }
+
+  function taskMatchesSearch(task: Task, descriptionSearchText: string, query: string): boolean {
+    const normalizedQuery = normalizeTaskSearchText(query);
+    if (normalizedQuery.length === 0) return true;
+
+    return (
+      task.title.toLowerCase().includes(normalizedQuery) ||
+      descriptionSearchText.includes(normalizedQuery)
+    );
+  }
+
   function findMissingActorId(actorIds: readonly string[]): string | null {
     const catalogDoc = catalog.doc();
     if (!catalogDoc) return actorIds[0] ?? null;
@@ -141,6 +155,8 @@ export function createTaskNamespace(
     const needsMigration =
       doc.detailDocIds === undefined ||
       doc.detailDocIds === null ||
+      doc.descriptionSearchTextByTaskId === undefined ||
+      doc.descriptionSearchTextByTaskId === null ||
       tasks.some((task) => task.labels === undefined || task.labels === null) ||
       tasks.some((task) => task.assigneeActorIds === undefined || task.assigneeActorIds === null) ||
       tasks.some((task) => task.assignees === undefined || task.assignees === null);
@@ -150,6 +166,12 @@ export function createTaskNamespace(
     handle.change((d) => {
       if (d.detailDocIds === undefined || d.detailDocIds === null) {
         d.detailDocIds = {};
+      }
+      if (
+        d.descriptionSearchTextByTaskId === undefined ||
+        d.descriptionSearchTextByTaskId === null
+      ) {
+        d.descriptionSearchTextByTaskId = {};
       }
       for (const task of d.tasks) {
         if (task.labels === undefined || task.labels === null) {
@@ -165,9 +187,54 @@ export function createTaskNamespace(
     });
   }
 
+  async function backfillDescriptionSearchIndex(
+    handle: DocHandle<TaskListDocument>,
+  ): Promise<void> {
+    const doc = handle.doc();
+    if (!doc) return;
+
+    const existingTaskIds = new Set(doc.tasks.map((task) => task.id));
+    const updates: Record<string, string | null> = {};
+
+    for (const indexedTaskId of Object.keys(doc.descriptionSearchTextByTaskId)) {
+      if (!existingTaskIds.has(indexedTaskId as TaskId) || !doc.detailDocIds[indexedTaskId]) {
+        updates[indexedTaskId] = null;
+      }
+    }
+
+    for (const [taskId, detailDocId] of Object.entries(doc.detailDocIds)) {
+      if (!existingTaskIds.has(taskId as TaskId)) {
+        updates[taskId] = null;
+        continue;
+      }
+
+      if (doc.descriptionSearchTextByTaskId[taskId] !== undefined) {
+        continue;
+      }
+
+      const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
+      const detailDoc = detailHandle.doc();
+      const searchText = detailDoc ? normalizeTaskSearchText(detailDoc.description) : "";
+      updates[taskId] = searchText.length > 0 ? searchText : null;
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    handle.change((d) => {
+      for (const [taskId, searchText] of Object.entries(updates)) {
+        if (searchText === null) {
+          delete d.descriptionSearchTextByTaskId[taskId];
+        } else {
+          d.descriptionSearchTextByTaskId[taskId] = searchText;
+        }
+      }
+    });
+  }
+
   async function loadTaskListDoc(docId: string): Promise<DocHandle<TaskListDocument>> {
     const handle = await repo.find<TaskListDocument>(docId as DocumentId);
     migrateTaskListDoc(handle);
+    await backfillDescriptionSearchIndex(handle);
     return handle;
   }
 
@@ -192,6 +259,7 @@ export function createTaskNamespace(
       doc.projectId = template.projectId;
       doc.tasks = template.tasks;
       doc.detailDocIds = template.detailDocIds;
+      doc.descriptionSearchTextByTaskId = template.descriptionSearchTextByTaskId;
     });
 
     // Register in catalog
@@ -310,6 +378,7 @@ export function createTaskNamespace(
 
         listHandle.change((doc) => {
           doc.detailDocIds[id] = detailHandle.documentId;
+          doc.descriptionSearchTextByTaskId[id] = normalizeTaskSearchText(description);
         });
       }
 
@@ -325,6 +394,7 @@ export function createTaskNamespace(
 
       const normalizedFilter = normalizeTaskFilter(filter);
       const allTasks: Task[] = [];
+      const searchQuery = normalizedFilter?.search;
 
       // If filtering by project, only load that project's task list
       const docIds = normalizedFilter?.projectId
@@ -337,6 +407,13 @@ export function createTaskNamespace(
         if (!doc) continue;
 
         for (const task of doc.tasks) {
+          if (
+            searchQuery !== undefined &&
+            !taskMatchesSearch(task, doc.descriptionSearchTextByTaskId[task.id] ?? "", searchQuery)
+          ) {
+            continue;
+          }
+
           allTasks.push(cloneTask(task));
         }
       }
@@ -524,6 +601,14 @@ export function createTaskNamespace(
         const detailDoc = detailHandle.doc();
         description = detailDoc?.description;
         if (detailDoc?.description !== undefined) {
+          const searchText = normalizeTaskSearchText(detailDoc.description);
+          result.listHandle.change((doc) => {
+            if (searchText.length > 0) {
+              doc.descriptionSearchTextByTaskId[id] = searchText;
+            } else {
+              delete doc.descriptionSearchTextByTaskId[id];
+            }
+          });
           descriptionApproval = normalizeContentApproval(
             detailDoc.description,
             detailDoc.descriptionApproval,
@@ -543,6 +628,7 @@ export function createTaskNamespace(
         });
         result.listHandle.change((doc) => {
           doc.detailDocIds[id] = detailHandle.documentId;
+          doc.descriptionSearchTextByTaskId[id] = normalizeTaskSearchText(descriptionText);
         });
         description = descriptionText;
       } else if (input.descriptionApproval !== undefined) {
@@ -576,6 +662,7 @@ export function createTaskNamespace(
       result.listHandle.change((doc) => {
         doc.tasks.splice(result.index, 1);
         delete doc.detailDocIds[id];
+        delete doc.descriptionSearchTextByTaskId[id];
       });
 
       // Detail and comments docs are orphaned — they'll be cleaned up
@@ -608,9 +695,11 @@ export function createTaskNamespace(
       const detailDocId = sourceListDoc?.detailDocIds[id];
 
       // Remove from source task list
+      const sourceDescriptionSearchText = sourceListDoc?.descriptionSearchTextByTaskId[id];
       result.listHandle.change((doc) => {
         doc.tasks.splice(result.index, 1);
         delete doc.detailDocIds[id];
+        delete doc.descriptionSearchTextByTaskId[id];
       });
 
       // Add to target task list
@@ -625,6 +714,9 @@ export function createTaskNamespace(
         doc.tasks.push(cleanTask as Task);
         if (detailDocId) {
           doc.detailDocIds[id] = detailDocId;
+        }
+        if (sourceDescriptionSearchText) {
+          doc.descriptionSearchTextByTaskId[id] = sourceDescriptionSearchText;
         }
       });
 
@@ -650,7 +742,9 @@ export function createTaskNamespace(
       const catalogDoc = catalog.doc();
       if (!catalogDoc) return ok([]);
 
-      const lowerQuery = query.toLowerCase();
+      const lowerQuery = normalizeTaskSearchText(query);
+      if (lowerQuery.length === 0) return ok([]);
+
       const matches: Task[] = [];
 
       for (const docId of Object.values(catalogDoc.taskListDocIds)) {
@@ -659,7 +753,8 @@ export function createTaskNamespace(
         if (!doc) continue;
 
         for (const task of doc.tasks) {
-          if (task.title.toLowerCase().includes(lowerQuery)) {
+          const descriptionSearchText = doc.descriptionSearchTextByTaskId[task.id] ?? "";
+          if (taskMatchesSearch(task, descriptionSearchText, lowerQuery)) {
             matches.push(cloneTask(task));
           }
         }


### PR DESCRIPTION
## Summary
- add a lightweight per-task-list description search index that is backfilled from detail docs and maintained on task description writes/move/delete
- make task search and task list search filters match title or description text without loading all detail docs for every query
- update CLI/agent tool descriptions and add integration coverage for description search and list filtering

## Verification
- `npx vitest run --config vitest.all.config.ts packages/engine/src/tasks.integration.test.ts packages/electron/src/main/tools.integration.test.ts packages/core/src/schema.test.ts`
- `make check`
- `make pre-pr`

Task: #task-ae949ce1