### PR TITLE
fix: recover wedged remote sync adapter

### DIFF
--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -466,12 +466,18 @@ If the daemon is healthy, status reports `running: true` and includes daemon hea
 Use daemon-owned join flows from CLI:
 
 ```bash
+todu sync status
+todu sync start
+todu sync stop
+todu sync restart
 todu sync join <catalogId> --check
 todu sync join <catalogId>
 todu sync join <catalogId> --yes
 ```
 
 Behavior:
+- `status` reports local daemon sync mode and remote sync state
+- `start`, `stop`, and `restart` control the daemon-owned remote sync adapter
 - `--check` validates format + reachability only (no catalog switch)
 - default join prompts for confirmation before transactional switch
 - `--yes` skips confirmation for non-interactive automation

--- a/packages/cli/src/commands/sync.integration.test.ts
+++ b/packages/cli/src/commands/sync.integration.test.ts
@@ -65,6 +65,26 @@ describe("sync CLI commands", () => {
     expect(status.remote.state).toBe("disconnected");
   });
 
+  it("sync start requests daemon sync.start and reports status", () => {
+    const output = run("sync start");
+    expect(output).toContain("Sync start: requested");
+    expect(output).toContain("Remote Sync:  disconnected");
+  });
+
+  it("sync stop requests daemon sync.stop and reports status", () => {
+    const output = run("sync stop");
+    expect(output).toContain("Sync stop: requested");
+    expect(output).toContain("Remote Sync:  disconnected");
+  });
+
+  it("sync restart requests daemon sync.stop and sync.start in JSON format", () => {
+    const output = run("sync restart --format json");
+    const result = JSON.parse(output);
+    expect(result.action).toBe("restart");
+    expect(result.status.local.mode).toBe("standalone");
+    expect(result.status.remote.state).toBe("disconnected");
+  });
+
   it("sync join --check validates target via daemon without switching catalog", async () => {
     const initialCatalogId = await readCatalogId(tmpDir);
     const targetCatalogId = alternateCatalogId;

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -23,6 +23,8 @@ interface SyncJoinResult {
   rolledBack: boolean;
 }
 
+type SyncControlAction = "start" | "stop" | "restart";
+
 interface DaemonError {
   code: string;
   message: string;
@@ -63,6 +65,27 @@ export function registerSyncCommands(program: Command, invokeDaemon: CliDaemonIn
           console.log(`Last Sync:    ${status.remote.lastSync}`);
         }
       }
+    });
+
+  sync
+    .command("start")
+    .description("Start remote sync through the local daemon")
+    .action(async () => {
+      await runSyncControl(program, invokeDaemon, "start");
+    });
+
+  sync
+    .command("stop")
+    .description("Stop remote sync through the local daemon")
+    .action(async () => {
+      await runSyncControl(program, invokeDaemon, "stop");
+    });
+
+  sync
+    .command("restart")
+    .description("Restart remote sync through the local daemon")
+    .action(async () => {
+      await runSyncControl(program, invokeDaemon, "restart");
     });
 
   sync
@@ -120,6 +143,51 @@ export function registerSyncCommands(program: Command, invokeDaemon: CliDaemonIn
 
       renderJoinResult(program, joined.value);
     });
+}
+
+async function runSyncControl(
+  program: Command,
+  invokeDaemon: CliDaemonInvoker,
+  action: SyncControlAction,
+): Promise<void> {
+  const methods = action === "restart" ? ["sync.stop", "sync.start"] : [`sync.${action}`];
+
+  for (const method of methods) {
+    const result = await invokeDaemon<void>(method, {});
+    if (!result.ok) {
+      console.error(formatDaemonCommandError(result.error));
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  const statusResult = await invokeDaemon<SyncStatus>("sync.status", {});
+  if (!statusResult.ok) {
+    console.error(formatDaemonCommandError(statusResult.error));
+    process.exitCode = 1;
+    return;
+  }
+
+  renderControlResult(program, action, statusResult.value);
+}
+
+function renderControlResult(
+  program: Command,
+  action: SyncControlAction,
+  status: SyncStatus,
+): void {
+  const opts = program.opts();
+
+  if (opts.format === "json") {
+    console.log(formatJSON({ action, status }));
+    return;
+  }
+
+  console.log(`Sync ${action}: requested`);
+  console.log(`Remote Sync:  ${status.remote.state}`);
+  if (status.remote.server) {
+    console.log(`Server:       ${status.remote.server}`);
+  }
 }
 
 function renderJoinResult(program: Command, result: SyncJoinResult): void {

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -775,6 +775,7 @@ export function createDaemonRuntime(config: DaemonRuntimeConfig = {}): DaemonRun
       storagePath: resolvedConfig.storagePath,
       remoteSync: resolvedConfig.remoteSync,
       bootstrapOwnerActor: resolvedConfig.bootstrapOwnerActor,
+      syncLogger: runtimeLogger.child("remote-sync"),
       startupTemplateProcessing: {
         enabled: true,
       },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -18,7 +18,7 @@ import { createRecurringNamespace } from "./recurring.js";
 import { createSyncRuntimeActorTools } from "./runtime-internals.js";
 import { processTemplates } from "./scheduling.js";
 import { initBootstrapStorage, initEphemeralStorage, type Storage } from "./storage.js";
-import { addRemoteSyncAdapter, connectSyncClient } from "./sync-client.js";
+import { addRemoteSyncAdapter, connectSyncClient, isSyncServerAvailable } from "./sync-client.js";
 import { type SyncServer, startSyncServer } from "./sync-server.js";
 import { createTaskNamespace } from "./tasks.js";
 import {
@@ -91,6 +91,9 @@ export async function createTodu(
   const resolvedConfig: ToduConfig = {
     storagePath: config.storagePath,
     bootstrapOwnerActor: config.bootstrapOwnerActor,
+    syncLogger: config.syncLogger,
+    remoteSyncWatchdogIntervalMs: config.remoteSyncWatchdogIntervalMs,
+    remoteSyncAvailabilityTimeoutMs: config.remoteSyncAvailabilityTimeoutMs,
   };
 
   await ensureAutomergeWasmInitialized();
@@ -122,7 +125,12 @@ export async function createTodu(
       storage: new NodeFSStorageAdapter(resolvedConfig.storagePath),
     });
     if (config?.remoteSync) {
-      initialRemoteAdapter = addRemoteSyncAdapter(repo, config.remoteSync.server);
+      initialRemoteAdapter = addRemoteSyncAdapter(
+        repo,
+        config.remoteSync.server,
+        undefined,
+        resolvedConfig.syncLogger,
+      );
     }
     storage = await initBootstrapStorage(
       resolvedConfig.storagePath,
@@ -167,12 +175,77 @@ export async function createTodu(
 
   // Remote sync adapter — set up if configured, null when stopped
   let remoteAdapter: WebSocketClientAdapter | null = null;
+  let remoteWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+  let remoteWatchdogRestarting = false;
   // Tracked handler references so we can remove them cleanly on stop
   let remoteHandlers: {
     onPeerCandidate: (_payload: PeerCandidatePayload) => void;
     onPeerDisconnected: (_payload: PeerDisconnectedPayload) => void;
     onClose: () => void;
   } | null = null;
+
+  function setRemoteState(
+    state: SyncStatus["remote"]["state"],
+    options: { forceNotify?: boolean } = {},
+  ): void {
+    if (syncStatus.remote.state === state && !options.forceNotify) return;
+
+    syncStatus.remote.state = state;
+    notifySyncStatusListeners();
+  }
+
+  function isRemoteAdapterConnected(adapter: WebSocketClientAdapter): boolean {
+    const socket = adapter.socket;
+    return Boolean(adapter.remotePeerId && socket && socket.readyState === socket.OPEN);
+  }
+
+  function reconcileRemoteAdapterState(): void {
+    if (!remoteAdapter) return;
+
+    if (isRemoteAdapterConnected(remoteAdapter)) {
+      setRemoteState("connected");
+    }
+  }
+
+  function startRemoteWatchdog(): void {
+    if (!config?.remoteSync || remoteWatchdogTimer) return;
+
+    remoteWatchdogTimer = setInterval(() => {
+      void checkRemoteAdapterHealth();
+    }, config.remoteSyncWatchdogIntervalMs ?? 30_000);
+  }
+
+  function stopRemoteWatchdog(): void {
+    if (!remoteWatchdogTimer) return;
+
+    clearInterval(remoteWatchdogTimer);
+    remoteWatchdogTimer = null;
+  }
+
+  async function checkRemoteAdapterHealth(): Promise<void> {
+    if (!config?.remoteSync || !remoteAdapter || remoteWatchdogRestarting) return;
+
+    reconcileRemoteAdapterState();
+    if (syncStatus.remote.state !== "disconnected") return;
+
+    const available = await isSyncServerAvailable(
+      config.remoteSync.server,
+      config.remoteSyncAvailabilityTimeoutMs ?? 200,
+    );
+    if (!available || !remoteAdapter || syncStatus.remote.state !== "disconnected") return;
+
+    remoteWatchdogRestarting = true;
+    resolvedConfig.syncLogger?.warn("remote sync watchdog restarting stale adapter", {
+      server: config.remoteSync.server,
+    });
+
+    try {
+      stopRemoteAdapter({ manual: false });
+      startRemoteAdapter();
+    } finally {
+      remoteWatchdogRestarting = false;
+    }
+  }
 
   /**
    * Attach a remote sync adapter to the repo and track connection state.
@@ -181,32 +254,46 @@ export async function createTodu(
   function startRemoteAdapter(): void {
     if (!config?.remoteSync || remoteAdapter) return;
 
-    const onPeerCandidate = (_payload: PeerCandidatePayload): void => {
-      syncStatus.remote.state = "connected";
-      notifySyncStatusListeners();
+    const onPeerCandidate = (payload: PeerCandidatePayload): void => {
+      resolvedConfig.syncLogger?.info("remote sync peer connected", {
+        server: config.remoteSync?.server,
+        peerId: payload.peerId,
+      });
+      setRemoteState("connected");
     };
-    const onPeerDisconnected = (_payload: PeerDisconnectedPayload): void => {
-      syncStatus.remote.state = "disconnected";
-      notifySyncStatusListeners();
+    const onPeerDisconnected = (payload: PeerDisconnectedPayload): void => {
+      resolvedConfig.syncLogger?.warn("remote sync peer disconnected", {
+        server: config.remoteSync?.server,
+        peerId: payload.peerId,
+      });
+      setRemoteState("disconnected");
     };
     const onClose = (): void => {
-      syncStatus.remote.state = "disconnected";
-      notifySyncStatusListeners();
+      resolvedConfig.syncLogger?.warn("remote sync adapter closed", {
+        server: config.remoteSync?.server,
+      });
+      setRemoteState("disconnected");
     };
-
     // Reuse the adapter created during init (before catalog load) to avoid
     // a duplicate WebSocket connection. Only create a new one on restart.
     if (initialRemoteAdapter) {
       remoteAdapter = initialRemoteAdapter;
       initialRemoteAdapter = null;
     } else {
-      remoteAdapter = addRemoteSyncAdapter(storage.repo, config.remoteSync.server);
+      remoteAdapter = addRemoteSyncAdapter(
+        storage.repo,
+        config.remoteSync.server,
+        undefined,
+        resolvedConfig.syncLogger,
+      );
     }
     remoteAdapter.on("peer-candidate", onPeerCandidate);
     remoteAdapter.on("peer-disconnected", onPeerDisconnected);
     remoteAdapter.on("close", onClose);
 
     remoteHandlers = { onPeerCandidate, onPeerDisconnected, onClose };
+    reconcileRemoteAdapterState();
+    startRemoteWatchdog();
   }
 
   /**
@@ -218,8 +305,12 @@ export async function createTodu(
    * inside removeNetworkAdapter will throw — that's safe to ignore since
    * the adapter has already been filtered out of the subsystem's adapter list.
    */
-  function stopRemoteAdapter(): void {
+  function stopRemoteAdapter(options: { manual?: boolean } = {}): void {
     if (!remoteAdapter) return;
+
+    if (options.manual !== false) {
+      stopRemoteWatchdog();
+    }
 
     // Remove our listeners before touching the adapter
     if (remoteHandlers) {
@@ -231,8 +322,7 @@ export async function createTodu(
 
     const adapter = remoteAdapter;
     remoteAdapter = null;
-    syncStatus.remote.state = "disconnected";
-    notifySyncStatusListeners();
+    setRemoteState("disconnected", { forceNotify: options.manual !== false });
 
     try {
       // Swallow async WebSocket errors during teardown — the connection may
@@ -273,7 +363,10 @@ export async function createTodu(
     recurring: createRecurringNamespace(storage.catalog, storage.repo),
     habit: createHabitNamespace(storage.catalog, storage.repo),
     sync: {
-      status: () => syncStatus,
+      status: () => {
+        reconcileRemoteAdapterState();
+        return syncStatus;
+      },
       start: async () => {
         startRemoteAdapter();
       },
@@ -292,6 +385,7 @@ export async function createTodu(
     async close() {
       // Stop remote adapter first to avoid reconnect attempts during shutdown
       stopRemoteAdapter();
+      stopRemoteWatchdog();
       // repo.shutdown() handles disconnecting remaining network adapters.
       await storage.close();
       if (syncServer) {

--- a/packages/engine/src/remote-sync.integration.test.ts
+++ b/packages/engine/src/remote-sync.integration.test.ts
@@ -17,6 +17,8 @@ const RELAY_PORTS = {
   stop: 24402,
   start: 24403,
   noOp: 24404,
+  reconcile: 24405,
+  watchdog: 24406,
 };
 
 /**
@@ -203,6 +205,102 @@ describe("remote sync", () => {
         await todu.sync.start();
         expect(todu.sync.status().remote.state).toBe("connected");
       } finally {
+        if (todu) {
+          await todu.close();
+          todu = null;
+        }
+        await stopRelay(relay, relayDir);
+      }
+    },
+  );
+
+  (RUN_SYNC_SERVER_TESTS ? it : it.skip)(
+    "sync.status() reconciles an already-connected adapter after a stale disconnect event",
+    { timeout: 10000 },
+    async () => {
+      const { relay, relayDir } = await startRelay(RELAY_PORTS.reconcile);
+      let connectedAdapter: WebSocketClientAdapter | null = null;
+      const originalPeerCandidate = WebSocketClientAdapter.prototype.peerCandidate;
+      const peerCandidateSpy = vi
+        .spyOn(WebSocketClientAdapter.prototype, "peerCandidate")
+        .mockImplementation(function mockPeerCandidate(
+          this: WebSocketClientAdapter,
+          ...args: Parameters<WebSocketClientAdapter["peerCandidate"]>
+        ) {
+          connectedAdapter = this;
+          return originalPeerCandidate.apply(this, args);
+        });
+
+      try {
+        todu = await createTodu({
+          storagePath: tmpDir,
+          remoteSync: { server: `ws://localhost:${RELAY_PORTS.reconcile}` },
+        });
+
+        await waitForRemoteState(todu, "connected");
+        expect(connectedAdapter).not.toBeNull();
+
+        connectedAdapter?.emit("peer-disconnected", {
+          peerId: connectedAdapter.remotePeerId,
+        });
+        expect(todu.sync.status().remote.state).toBe("connected");
+      } finally {
+        peerCandidateSpy.mockRestore();
+        if (todu) {
+          await todu.close();
+          todu = null;
+        }
+        await stopRelay(relay, relayDir);
+      }
+    },
+  );
+
+  (RUN_SYNC_SERVER_TESTS ? it : it.skip)(
+    "watchdog restarts a stale disconnected adapter while the server is reachable",
+    { timeout: 10000 },
+    async () => {
+      const { relay, relayDir } = await startRelay(RELAY_PORTS.watchdog);
+      let connectedAdapter: WebSocketClientAdapter | null = null;
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
+      const originalPeerCandidate = WebSocketClientAdapter.prototype.peerCandidate;
+      const peerCandidateSpy = vi
+        .spyOn(WebSocketClientAdapter.prototype, "peerCandidate")
+        .mockImplementation(function mockPeerCandidate(
+          this: WebSocketClientAdapter,
+          ...args: Parameters<WebSocketClientAdapter["peerCandidate"]>
+        ) {
+          connectedAdapter = this;
+          return originalPeerCandidate.apply(this, args);
+        });
+
+      try {
+        todu = await createTodu({
+          storagePath: tmpDir,
+          remoteSync: { server: `ws://localhost:${RELAY_PORTS.watchdog}` },
+          remoteSyncWatchdogIntervalMs: 20,
+          remoteSyncAvailabilityTimeoutMs: 200,
+          syncLogger: logger,
+        });
+
+        await waitForRemoteState(todu, "connected");
+        expect(connectedAdapter).not.toBeNull();
+
+        const staleAdapter = connectedAdapter;
+        staleAdapter.remotePeerId = undefined;
+        staleAdapter.emit("peer-disconnected", { peerId: "stale-remote" });
+        expect(todu.sync.status().remote.state).toBe("disconnected");
+
+        await waitForRemoteState(todu, "connected");
+        expect(logger.warn).toHaveBeenCalledWith(
+          "remote sync watchdog restarting stale adapter",
+          expect.objectContaining({ server: `ws://localhost:${RELAY_PORTS.watchdog}` }),
+        );
+      } finally {
+        peerCandidateSpy.mockRestore();
         if (todu) {
           await todu.close();
           todu = null;

--- a/packages/engine/src/sync-client.ts
+++ b/packages/engine/src/sync-client.ts
@@ -3,6 +3,10 @@ import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websoc
 
 export const DEFAULT_SYNC_URL = "ws://127.0.0.1:24377";
 
+export interface SyncAdapterEventLogger {
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
 const TRANSIENT_SOCKET_ERROR_CODES = new Set([
   "ECONNREFUSED",
   "ECONNRESET",
@@ -65,17 +69,25 @@ export function addRemoteSyncAdapter(
   repo: Repo,
   url: string,
   retryInterval = 30000,
+  logger?: SyncAdapterEventLogger,
 ): WebSocketClientAdapter {
   const adapter = new WebSocketClientAdapter(url, retryInterval);
-  hardenWebSocketClientAdapterErrors(adapter);
+  hardenWebSocketClientAdapterErrors(adapter, logger);
   repo.networkSubsystem.addNetworkAdapter(adapter);
   return adapter;
 }
 
-export function hardenWebSocketClientAdapterErrors(adapter: WebSocketClientAdapter): void {
+export function hardenWebSocketClientAdapterErrors(
+  adapter: WebSocketClientAdapter,
+  logger?: SyncAdapterEventLogger,
+): void {
   const originalOnError = adapter.onError;
 
   adapter.onError = (event) => {
+    logger?.warn("remote sync adapter error", {
+      error: getErrorMessage(getEventError(event) ?? event),
+    });
+
     try {
       originalOnError(event);
     } catch (error) {
@@ -87,6 +99,14 @@ export function hardenWebSocketClientAdapterErrors(adapter: WebSocketClientAdapt
       throw error;
     }
   };
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }
 
 function getEventError(event: unknown): unknown {

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -94,6 +94,29 @@ export interface ToduConfig {
    * Use ws://localhost:3030 via `make dev`.
    */
   remoteSync?: RemoteSyncConfig;
+
+  /**
+   * Remote sync watchdog polling interval in milliseconds.
+   *
+   * Defaults to 30 seconds when remote sync is configured.
+   */
+  remoteSyncWatchdogIntervalMs?: number;
+
+  /**
+   * Remote sync watchdog reachability timeout in milliseconds.
+   *
+   * Defaults to 200 milliseconds.
+   */
+  remoteSyncAvailabilityTimeoutMs?: number;
+
+  /**
+   * Optional host logger for remote sync lifecycle events.
+   */
+  syncLogger?: {
+    debug(message: string, context?: Record<string, unknown>): void;
+    info(message: string, context?: Record<string, unknown>): void;
+    warn(message: string, context?: Record<string, unknown>): void;
+  };
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add daemon-backed `todu sync start`, `todu sync stop`, and `todu sync restart` commands.
- Reconcile remote sync status from the live adapter so missed peer events do not leave status stale.
- Add a remote sync watchdog that restarts a stale disconnected adapter when the configured server is reachable.
- Log remote peer, disconnect, close, error, and watchdog restart events through the daemon logger.
- Document the new sync controls in daemon CLI usage.

## Verification

- `TODU_RUN_SYNC_SERVER_TESTS=1 npx vitest run --config vitest.all.config.ts packages/engine/src/remote-sync.integration.test.ts`
- `npx vitest run --config vitest.all.config.ts packages/cli/src/commands/sync.integration.test.ts`
- `make pre-pr`

Task: #task-643e274c