### PR TITLE
Add structured comment sync provenance

### DIFF
--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -92,8 +92,8 @@ The following remain outside synced core entities:
 - credential references
 - cursors and checkpoints
 - retry and backoff state
-- linkage tables between local and external comments/items
-- loop-prevention bookkeeping
+- provider-local linkage tables for non-comment runtime state
+- loop-prevention bookkeeping except core-owned comment provenance records
 - provider diagnostics and caches
 
 ## Credential provisioning in v1
@@ -123,8 +123,9 @@ Initial storage shape should be:
 
 - one shared integration registry document referenced by the catalog for integration bindings
 - one separate integration binding status document per integration binding for synced operational status
+- one shared comment sync provenance document referenced by the catalog for local note/comment to external comment links
 
-This keeps shared desired state simple while isolating higher-churn status updates per integration binding.
+This keeps shared desired state simple while isolating higher-churn status updates per integration binding. Comment provenance is the narrow exception to provider-local linkage storage: it is core-owned because providers need a stable host API for imported/mirrored comments and because user-visible note tags are not an appropriate internal sync channel.
 
 ## Ownership Boundary
 
@@ -133,7 +134,8 @@ This keeps shared desired state simple while isolating higher-churn status updat
 | Integration binding identity, linked project, target reference, strategy, enabled state | Core synced model | Users must be able to view and manage these from any machine |
 | Credentials, tokens, API secrets | Provider-local runtime storage | Secrets should not sync through Automerge core state |
 | Cursors, checkpoints, retry state | Provider-local runtime storage | Operational internals belong to the executing daemon |
-| Item and comment linkage tables | Provider-local runtime storage | They are provider bookkeeping, not baseline user data |
+| Comment sync provenance | Core synced model | Comment loop prevention must work across providers without user-visible tags or provider CLI lookups |
+| Other item linkage tables and provider cursors | Provider-local runtime storage | They are provider bookkeeping, not baseline user data |
 | Tasks and notes created as sync results | Core entities | They are user-visible product outputs |
 | Plugin logs and diagnostics | Local daemon/plugin runtime | Operational data should remain local and observable |
 

--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -90,12 +90,27 @@ interface ImportedCommentInput {
   raw?: unknown;
 }
 
+interface CommentSyncProvenance {
+  bindingId: IntegrationBindingId;
+  provider: string;
+  targetKind: string;
+  targetRef: string;
+  localNoteId: NoteId;
+  externalTaskId: string;
+  externalCommentId: string;
+  sourceUrl?: string;
+  lastMirroredAt: string;
+}
+
 interface ExportedCommentInput {
   localNoteId: NoteId;
   body: string;
   createdAt: string;
   updatedAt?: string;
   sourceUrl?: string;
+  provenance?: CommentSyncProvenance;
+  /** @deprecated Use provenance.externalCommentId. */
+  externalId?: string;
 }
 
 interface ExportedTaskInput {
@@ -187,7 +202,7 @@ interface SyncProviderPushResult {
 
 The runtime applies returned `taskLinks` first, writing back task linkage for pushed local tasks so later pull cycles deduplicate by `externalId`. Returning the same task link again is a no-op. Returning a conflicting task link for a task that is already linked to a different external item is treated as a runtime error.
 
-The runtime then applies each returned comment link idempotently by attaching the canonical `sync:externalId:<externalCommentId>` tag to the referenced local note. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error.
+The runtime then applies each returned comment link idempotently by writing structured comment provenance for the referenced local note and integration binding. Returning the same link again is a no-op. Returning a conflicting link for a note that is already linked to a different external comment is treated as a runtime error. During rollout, the runtime may preserve legacy `sync:externalId:<externalCommentId>` tags for local-origin comment links so older providers keep working, but providers should migrate to `ExportedCommentInput.provenance` and stop reading note tags.
 
 ### Comment pull path
 
@@ -195,9 +210,14 @@ Pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalA
 
 The runtime reconciles pulled comments with local notes using a snapshot model:
 
-- comments with an `externalId` not present locally are created as new notes with a `sync:externalId:<value>` tag
+- comments with an `externalId` not present locally are created as new notes and linked through structured comment provenance, not user-visible tags
 - comments matching an existing local note are updated if the external `updatedAt` is newer than the local `createdAt`
 - local synced notes whose external IDs are absent from the pull result are deleted
+- existing notes with legacy `sync:externalId:*` tags are resolved lazily into provenance records when encountered; notes without sync tags are not rewritten by this migration
+
+### Comment provenance migration path
+
+Comment provenance is core-owned sync bookkeeping keyed by local note ID and integration binding. It stores the binding/provider target context, local note ID, external task/thread ID, external comment ID, optional source URL, and last mirrored timestamp. New providers should use `comment.provenance?.externalCommentId` to decide whether to skip, create, update, or delete remote comments. Existing GitHub/Forgejo-style providers that previously called `note list` and inspected `sync:externalId:*` tags can migrate by reading `ExportedTaskInput.comments[].provenance` from the push payload instead; `comment.externalId` is a temporary compatibility alias for `comment.provenance.externalCommentId`.
 
 ## Load-time enforcement
 

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -13,7 +13,7 @@ import { createActorId, createIntegrationBindingId, createProjectId } from "./ty
 
 describe("schema", () => {
   it("exports schema version", () => {
-    expect(SCHEMA_VERSION).toBe(2);
+    expect(SCHEMA_VERSION).toBe(3);
   });
 
   describe("createEmptyCatalog", () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -2,6 +2,7 @@ import type { BootstrapOwnerActor } from "./config.js";
 import {
   type Actor,
   type ActorId,
+  type CommentSyncProvenance,
   createActorId,
   type Habit,
   type HabitEntry,
@@ -67,6 +68,9 @@ export interface CatalogDocument {
 
   /** Map of integrationBindingId → Automerge document ID for that binding's status doc */
   integrationStatusDocIds: Record<string, string>;
+
+  /** Automerge document ID for structured comment sync provenance records. */
+  commentSyncProvenanceDocId?: string;
 
   /** Habit definitions */
   habits: Habit[];
@@ -150,6 +154,14 @@ export interface IntegrationBindingStatusDocument extends IntegrationBindingStat
 }
 
 /**
+ * Comment sync provenance document (one per dataset).
+ * Stores provider-owned linkage for synced comments independently from user-visible note tags.
+ */
+export interface CommentSyncProvenanceDocument {
+  records: CommentSyncProvenance[];
+}
+
+/**
  * Habit log document (one per habit).
  * Contains check-in entries keyed by date for deterministic multi-device merging.
  */
@@ -165,7 +177,7 @@ export interface HabitLogDocument {
 // Schema version
 // ============================================================================
 
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 export const DEFAULT_OWNER_ACTOR_ID = createActorId("actor-user");
 export const DEFAULT_OWNER_ACTOR_DISPLAY_NAME = "user";
 export const DEFAULT_OWNER_ACTOR: BootstrapOwnerActor = {
@@ -229,6 +241,12 @@ export function createNotesDocument(): NotesDocument {
 export function createIntegrationRegistryDocument(): IntegrationRegistryDocument {
   return {
     bindings: [],
+  };
+}
+
+export function createCommentSyncProvenanceDocument(): CommentSyncProvenanceDocument {
+  return {
+    records: [],
   };
 }
 

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -1,4 +1,5 @@
 import {
+  type CommentSyncProvenance,
   err,
   type IntegrationBinding,
   type NoteId,
@@ -60,6 +61,13 @@ export interface ExportedCommentInput {
   createdAt: string;
   updatedAt?: string;
   sourceUrl?: string;
+  /**
+   * Structured linkage for comments already known to this integration binding.
+   * Providers should use this instead of inspecting user-visible note tags.
+   */
+  provenance?: CommentSyncProvenance;
+  /** @deprecated Use provenance.externalCommentId. Kept during provider rollout. */
+  externalId?: string;
 }
 
 export interface ExportedTaskInput {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,7 @@ export type NoteId = string & { readonly __brand: "NoteId" };
 export type HabitId = string & { readonly __brand: "HabitId" };
 export type RecurringId = string & { readonly __brand: "RecurringId" };
 export type IntegrationBindingId = string & { readonly __brand: "IntegrationBindingId" };
+export type CommentSyncProvenanceId = string & { readonly __brand: "CommentSyncProvenanceId" };
 
 export function createTaskId(id: string): TaskId {
   return id as TaskId;
@@ -41,6 +42,10 @@ export function createRecurringId(id: string): RecurringId {
 
 export function createIntegrationBindingId(id: string): IntegrationBindingId {
   return id as IntegrationBindingId;
+}
+
+export function createCommentSyncProvenanceId(id: string): CommentSyncProvenanceId {
+  return id as CommentSyncProvenanceId;
 }
 
 // ============================================================================
@@ -198,6 +203,40 @@ export interface IntegrationBindingActorMapping {
 export interface IntegrationBindingOptions {
   actorMappings?: IntegrationBindingActorMapping[];
   [key: string]: unknown;
+}
+
+export interface CommentSyncProvenance {
+  id: CommentSyncProvenanceId;
+  bindingId: IntegrationBindingId;
+  provider: string;
+  targetKind: string;
+  targetRef: string;
+  localNoteId: NoteId;
+  externalTaskId: string;
+  externalCommentId: string;
+  sourceUrl?: string;
+  lastMirroredAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertCommentSyncProvenanceInput {
+  bindingId: IntegrationBindingId;
+  provider: string;
+  targetKind: string;
+  targetRef: string;
+  localNoteId: NoteId;
+  externalTaskId: string;
+  externalCommentId: string;
+  sourceUrl?: string;
+  lastMirroredAt: string;
+}
+
+export interface CommentSyncProvenanceFilter {
+  bindingId?: IntegrationBindingId;
+  localNoteId?: NoteId;
+  externalTaskId?: string;
+  externalCommentId?: string;
 }
 
 // ============================================================================

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -1,6 +1,8 @@
 import {
   type Actor,
+  type CommentSyncProvenance,
   createActorId,
+  createCommentSyncProvenanceId,
   createIntegrationBindingId,
   createNoteId,
   createProjectId,
@@ -321,7 +323,7 @@ describe("sync-worker-runtime", () => {
   it("push includes task comments from note.list in each exported task payload", async () => {
     const provider = createProvider();
     const project = createProject();
-    const task = createTask(project.id);
+    const task = createTask(project.id, { externalId: "gh-task-1" });
     const binding = createBinding(project.id, { strategy: "push" });
     const taskNote = createNote({
       entityType: "task",
@@ -356,11 +358,18 @@ describe("sync-worker-runtime", () => {
     const pushedTasks = pushArgs[1];
     expect(pushedTasks).toHaveLength(1);
     expect(pushedTasks[0].comments).toEqual([
-      {
+      expect.objectContaining({
         localNoteId: taskNote.id,
         body: taskNote.content,
         createdAt: taskNote.createdAt,
-      },
+        externalId: "ext-c1",
+        provenance: expect.objectContaining({
+          bindingId: binding.id,
+          localNoteId: taskNote.id,
+          externalTaskId: task.externalId,
+          externalCommentId: "ext-c1",
+        }),
+      }),
     ]);
 
     handle.stop();
@@ -1177,9 +1186,76 @@ describe("sync-worker-runtime", () => {
         }),
         entityType: "task",
         entityId: task.id,
-        tags: ["sync:externalId:gh-comment-1"],
+        tags: [],
         createdAt: "2026-03-10T10:00:00.000Z",
       }),
+    );
+
+    handle.stop();
+  });
+
+  it("bidirectional sync exposes provenance for newly imported comments before push", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "bidirectional" });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-1",
+            externalTaskId: task.externalId!,
+            body: "Imported comment",
+            createdAt: "2026-03-10T10:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding]);
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: [],
+      }),
+    );
+    expect(provider.push).toHaveBeenCalledWith(
+      binding,
+      [
+        expect.objectContaining({
+          comments: [
+            expect.objectContaining({
+              body: "Imported comment",
+              externalId: "gh-comment-1",
+              provenance: expect.objectContaining({
+                bindingId: binding.id,
+                externalTaskId: task.externalId,
+                externalCommentId: "gh-comment-1",
+              }),
+            }),
+          ],
+        }),
+      ],
+      project,
     );
 
     handle.stop();
@@ -1356,6 +1432,50 @@ describe("sync-worker-runtime", () => {
 
     expect(todu.note.update).not.toHaveBeenCalled();
     expect(todu.note.create).not.toHaveBeenCalled();
+    expect(todu.note.delete).not.toHaveBeenCalled();
+
+    handle.stop();
+  });
+
+  it("pull does not modify local notes without sync tags or provenance", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const localNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "ordinary user note",
+      tags: [],
+    });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [localNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.update).not.toHaveBeenCalled();
     expect(todu.note.delete).not.toHaveBeenCalled();
 
     handle.stop();
@@ -2112,6 +2232,7 @@ function createNote(overrides: Partial<Note> & { content: string }): Note {
 interface CreateToduOptions {
   notes?: Note[];
   actors?: Actor[];
+  commentProvenance?: CommentSyncProvenance[];
 }
 
 function createTodu(
@@ -2147,6 +2268,7 @@ function createTodu(
 } {
   const tasks: Task[] = [...initialTasks];
   const notes: Note[] = [...(options.notes ?? [])];
+  const commentProvenance: CommentSyncProvenance[] = [...(options.commentProvenance ?? [])];
   const actors: Actor[] = [{ id: createActorId("actor-user"), displayName: "user" }];
   for (const actor of options.actors ?? []) {
     if (!actors.some((candidate) => candidate.id === actor.id)) {
@@ -2409,6 +2531,87 @@ function createTodu(
     return ok(undefined);
   });
 
+  const commentProvenanceList = vi.fn(
+    async (filter?: {
+      bindingId?: string;
+      localNoteId?: string;
+      externalTaskId?: string;
+      externalCommentId?: string;
+    }) => {
+      let filtered = commentProvenance;
+      if (filter?.bindingId !== undefined) {
+        filtered = filtered.filter((record) => record.bindingId === filter.bindingId);
+      }
+      if (filter?.localNoteId !== undefined) {
+        filtered = filtered.filter((record) => record.localNoteId === filter.localNoteId);
+      }
+      if (filter?.externalTaskId !== undefined) {
+        filtered = filtered.filter((record) => record.externalTaskId === filter.externalTaskId);
+      }
+      if (filter?.externalCommentId !== undefined) {
+        filtered = filtered.filter(
+          (record) => record.externalCommentId === filter.externalCommentId,
+        );
+      }
+      return ok(filtered.map((record) => ({ ...record })));
+    },
+  );
+
+  const commentProvenanceUpsert = vi.fn(
+    async (input: {
+      bindingId: IntegrationBinding["id"];
+      provider: string;
+      targetKind: string;
+      targetRef: string;
+      localNoteId: Note["id"];
+      externalTaskId: string;
+      externalCommentId: string;
+      sourceUrl?: string;
+      lastMirroredAt: string;
+    }) => {
+      const existing = commentProvenance.find(
+        (record) =>
+          record.bindingId === input.bindingId && record.localNoteId === input.localNoteId,
+      );
+      if (existing) {
+        existing.provider = input.provider;
+        existing.targetKind = input.targetKind;
+        existing.targetRef = input.targetRef;
+        existing.externalTaskId = input.externalTaskId;
+        existing.externalCommentId = input.externalCommentId;
+        if (input.sourceUrl !== undefined) existing.sourceUrl = input.sourceUrl;
+        existing.lastMirroredAt = input.lastMirroredAt;
+        existing.updatedAt = new Date(0).toISOString();
+        return ok({ ...existing });
+      }
+      const created: CommentSyncProvenance = {
+        id: createCommentSyncProvenanceId(`cprov-${commentProvenance.length + 1}`),
+        bindingId: input.bindingId,
+        provider: input.provider,
+        targetKind: input.targetKind,
+        targetRef: input.targetRef,
+        localNoteId: input.localNoteId,
+        externalTaskId: input.externalTaskId,
+        externalCommentId: input.externalCommentId,
+        ...(input.sourceUrl !== undefined ? { sourceUrl: input.sourceUrl } : {}),
+        lastMirroredAt: input.lastMirroredAt,
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      };
+      commentProvenance.push(created);
+      return ok({ ...created });
+    },
+  );
+
+  const commentProvenanceDeleteForNote = vi.fn(async (noteId: Note["id"]) => {
+    for (let index = commentProvenance.length - 1; index >= 0; index -= 1) {
+      if (commentProvenance[index].localNoteId === noteId) {
+        commentProvenance.splice(index, 1);
+      }
+    }
+    return ok(undefined);
+  });
+
   const actorList = vi.fn().mockImplementation(async () => ok([...actors]));
   const actorEnsure = vi
     .fn()
@@ -2430,6 +2633,11 @@ function createTodu(
               .fn()
               .mockImplementation(async () => ok(createActorId("actor-user"))),
             ensure: actorEnsure,
+          },
+          commentProvenance: {
+            list: commentProvenanceList,
+            upsert: commentProvenanceUpsert,
+            deleteForNote: commentProvenanceDeleteForNote,
           },
         },
       },

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import {
   type Actor,
   type ActorId,
+  type CommentSyncProvenance,
   createActorId,
   createProjectId,
   type ExportedCommentInput,
@@ -325,7 +326,7 @@ export function createSyncPluginWorkerRuntime(
           }
 
           await applyPushTaskLinks(activeTodu, pushResult.taskLinks);
-          await applyPushCommentLinks(activeTodu, pushResult.commentLinks);
+          await applyPushCommentLinks(activeTodu, actorState, pushResult.commentLinks);
         }
 
         if (actorState.mappingsChanged) {
@@ -460,6 +461,85 @@ function getSyncExternalIdFromNote(note: Note): string | null {
   return externalIdTag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length);
 }
 
+async function listCommentProvenance(
+  todu: Todu,
+  filter: {
+    bindingId: IntegrationBinding["id"];
+    localNoteId?: Note["id"];
+    externalTaskId?: string;
+  },
+): Promise<CommentSyncProvenance[]> {
+  const result =
+    await getToduWithInternals(todu).__internal.syncRuntime.commentProvenance.list(filter);
+  if (!result.ok) {
+    throw new Error(`comment provenance list failed: ${formatToduError(result.error)}`);
+  }
+  return result.value;
+}
+
+async function upsertCommentProvenance(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  input: {
+    localNoteId: Note["id"];
+    externalTaskId: string;
+    externalCommentId: string;
+    sourceUrl?: string;
+    lastMirroredAt: string;
+  },
+): Promise<CommentSyncProvenance> {
+  const result = await getToduWithInternals(todu).__internal.syncRuntime.commentProvenance.upsert({
+    bindingId: actorState.binding.id,
+    provider: actorState.binding.provider,
+    targetKind: actorState.binding.targetKind,
+    targetRef: actorState.binding.targetRef,
+    localNoteId: input.localNoteId,
+    externalTaskId: input.externalTaskId,
+    externalCommentId: input.externalCommentId,
+    ...(input.sourceUrl !== undefined ? { sourceUrl: input.sourceUrl } : {}),
+    lastMirroredAt: input.lastMirroredAt,
+  });
+  if (!result.ok) {
+    throw new Error(`comment provenance upsert failed: ${formatToduError(result.error)}`);
+  }
+  return result.value;
+}
+
+async function deleteCommentProvenanceForNote(todu: Todu, noteId: Note["id"]): Promise<void> {
+  const result =
+    await getToduWithInternals(todu).__internal.syncRuntime.commentProvenance.deleteForNote(noteId);
+  if (!result.ok) {
+    throw new Error(`comment provenance delete failed: ${formatToduError(result.error)}`);
+  }
+}
+
+async function resolveExportedCommentProvenance(
+  todu: Todu,
+  actorState: SyncBindingActorState,
+  note: Note,
+  externalTaskId: string | undefined,
+): Promise<CommentSyncProvenance | undefined> {
+  const existing = await listCommentProvenance(todu, {
+    bindingId: actorState.binding.id,
+    localNoteId: note.id,
+  });
+  if (existing[0]) {
+    return existing[0];
+  }
+
+  const legacyExternalId = getSyncExternalIdFromNote(note);
+  if (!legacyExternalId || !externalTaskId) {
+    return undefined;
+  }
+
+  return upsertCommentProvenance(todu, actorState, {
+    localNoteId: note.id,
+    externalTaskId,
+    externalCommentId: legacyExternalId,
+    lastMirroredAt: note.createdAt,
+  });
+}
+
 async function applyPushTaskLinks(todu: Todu, links: SyncProviderPushTaskLink[]): Promise<void> {
   for (const link of links) {
     const taskResult = await todu.task.get(link.localTaskId);
@@ -504,37 +584,76 @@ async function applyPushTaskLinks(todu: Todu, links: SyncProviderPushTaskLink[])
 
 async function applyPushCommentLinks(
   todu: Todu,
+  actorState: SyncBindingActorState,
   links: SyncProviderPushCommentLink[],
 ): Promise<void> {
   for (const link of links) {
-    const notesResult = await todu.note.list({
-      entityType: "task",
-      entityId: link.externalTaskId,
-    });
-    const notes = notesResult.ok ? notesResult.value : [];
-    const note = notes.find((candidate) => candidate.id === link.localNoteId);
+    const noteResult = await todu.note.get(link.localNoteId);
+    const note = noteResult.ok ? noteResult.value : null;
 
-    if (!note) {
+    if (!note || note.entityType !== "task" || !note.entityId) {
       throw new Error(
         `push comment link references missing task note: note=${link.localNoteId} task=${link.externalTaskId}`,
       );
     }
 
-    const existingExternalId = getSyncExternalIdFromNote(note);
-    if (existingExternalId === link.externalCommentId) {
+    const existingProvenance = await listCommentProvenance(todu, {
+      bindingId: actorState.binding.id,
+      localNoteId: note.id,
+    });
+    if (existingProvenance[0]?.externalCommentId === link.externalCommentId) {
       continue;
     }
+    if (
+      existingProvenance[0] &&
+      existingProvenance[0].externalCommentId !== link.externalCommentId
+    ) {
+      throw new Error(
+        `push comment link conflicts with existing note linkage: note=${link.localNoteId} existing=${existingProvenance[0].externalCommentId} next=${link.externalCommentId}`,
+      );
+    }
 
+    const existingExternalId = getSyncExternalIdFromNote(note);
     if (existingExternalId && existingExternalId !== link.externalCommentId) {
       throw new Error(
         `push comment link conflicts with existing note linkage: note=${link.localNoteId} existing=${existingExternalId} next=${link.externalCommentId}`,
       );
     }
 
-    await todu.note.update(note.id, {
-      tags: [...note.tags, createSyncExternalIdTag(link.externalCommentId)],
+    const taskResult = await todu.task.get(note.entityId as Task["id"]);
+    const task = taskResult.ok ? taskResult.value : null;
+    const externalTaskId = task?.externalId ?? link.externalTaskId;
+    const lastMirroredAt =
+      normalizeOptionalTimestamp(link.updatedAt ?? link.createdAt) ?? new Date().toISOString();
+
+    await upsertCommentProvenance(todu, actorState, {
+      localNoteId: note.id,
+      externalTaskId,
+      externalCommentId: link.externalCommentId,
+      ...(link.sourceUrl !== undefined ? { sourceUrl: link.sourceUrl } : {}),
+      lastMirroredAt,
     });
+
+    // Preserve legacy tag compatibility for local-origin comments linked by existing providers.
+    if (!existingExternalId) {
+      await todu.note.update(note.id, {
+        tags: [...note.tags, createSyncExternalIdTag(link.externalCommentId)],
+      });
+    }
   }
+}
+
+function normalizeOptionalTimestamp(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    return null;
+  }
+
+  return timestamp.toISOString();
 }
 
 function normalizeImportedTaskTimestamp(
@@ -777,9 +896,11 @@ async function applyImportedComments(
   }
 
   const localTaskIdByExternalId = new Map<string, Task["id"]>();
+  const externalTaskIdByLocalId = new Map<string, string>();
   for (const task of tasksResult.value) {
     if (task.externalId) {
       localTaskIdByExternalId.set(task.externalId, task.id);
+      externalTaskIdByLocalId.set(task.id, task.externalId);
     }
   }
 
@@ -805,12 +926,38 @@ async function applyImportedComments(
       entityId: taskId,
     });
     const localNotes: Note[] = localNotesResult.ok ? localNotesResult.value : [];
+    const externalTaskId = externalTaskIdByLocalId.get(taskId);
+    if (!externalTaskId) {
+      continue;
+    }
 
+    const localNotesById = new Map(localNotes.map((note) => [note.id, note]));
     const localByExternalId = new Map<string, Note>();
+    const provenanceRecords = await listCommentProvenance(todu, {
+      bindingId: actorState.binding.id,
+      externalTaskId,
+    });
+    for (const provenance of provenanceRecords) {
+      const note = localNotesById.get(provenance.localNoteId);
+      if (note) {
+        localByExternalId.set(provenance.externalCommentId, note);
+      }
+    }
+
     for (const note of localNotes) {
-      const externalId = getSyncExternalIdFromNote(note);
-      if (externalId) {
-        localByExternalId.set(externalId, note);
+      const legacyExternalId = getSyncExternalIdFromNote(note);
+      if (!legacyExternalId) {
+        continue;
+      }
+
+      if (!localByExternalId.has(legacyExternalId)) {
+        const provenance = await upsertCommentProvenance(todu, actorState, {
+          localNoteId: note.id,
+          externalTaskId,
+          externalCommentId: legacyExternalId,
+          lastMirroredAt: note.createdAt,
+        });
+        localByExternalId.set(provenance.externalCommentId, note);
       }
     }
 
@@ -835,7 +982,7 @@ async function applyImportedComments(
           contentApproval: approval,
           entityType: "task",
           entityId: taskId,
-          tags: [createSyncExternalIdTag(pulled.externalId)],
+          tags: [],
           createdAt: normalizeImportedCommentTimestamp(pulled, "createdAt"),
         });
         if (!createResult.ok) {
@@ -843,6 +990,15 @@ async function applyImportedComments(
             `pulled comment create failed: externalId=${pulled.externalId} error=${formatToduError(createResult.error)}`,
           );
         }
+        await upsertCommentProvenance(todu, actorState, {
+          localNoteId: createResult.value.id,
+          externalTaskId: pulled.externalTaskId,
+          externalCommentId: pulled.externalId,
+          lastMirroredAt: normalizeImportedCommentTimestamp(
+            pulled,
+            pulled.updatedAt !== undefined ? "updatedAt" : "createdAt",
+          ),
+        });
         stats.created += 1;
       } else {
         const externalUpdatedAt = normalizeImportedCommentTimestamp(
@@ -864,6 +1020,12 @@ async function applyImportedComments(
           }
           stats.updated += 1;
         }
+        await upsertCommentProvenance(todu, actorState, {
+          localNoteId: localNote.id,
+          externalTaskId: pulled.externalTaskId,
+          externalCommentId: pulled.externalId,
+          lastMirroredAt: externalUpdatedAt,
+        });
       }
     }
 
@@ -875,6 +1037,7 @@ async function applyImportedComments(
             `pulled comment delete failed: note=${note.id} externalId=${externalId} error=${formatToduError(deleteResult.error)}`,
           );
         }
+        await deleteCommentProvenanceForNote(todu, note.id);
         stats.deleted += 1;
       }
     }
@@ -916,14 +1079,26 @@ async function buildPushPayloadsV3(
       assignees: buildOutboundV3Assignees(taskDetail, actorState, logger),
       sourceUrl: taskDetail.sourceUrl,
       updatedAt: taskDetail.updatedAt,
-      comments: comments.map((comment) => {
-        const exported: ExportedCommentInput = {
-          localNoteId: comment.id,
-          body: comment.content,
-          createdAt: comment.createdAt,
-        };
-        return exported;
-      }),
+      comments: await Promise.all(
+        comments.map(async (comment) => {
+          const provenance = await resolveExportedCommentProvenance(
+            todu,
+            actorState,
+            comment,
+            taskDetail.externalId,
+          );
+          const exported: ExportedCommentInput = {
+            localNoteId: comment.id,
+            body: comment.content,
+            createdAt: comment.createdAt,
+            ...(provenance?.sourceUrl !== undefined ? { sourceUrl: provenance.sourceUrl } : {}),
+            ...(provenance !== undefined
+              ? { provenance, externalId: provenance.externalCommentId }
+              : {}),
+          };
+          return exported;
+        }),
+      ),
     });
   }
 
@@ -1281,8 +1456,11 @@ function normalizeImportedCommentTimestamp(
 
 function getToduWithInternals(todu: Todu): ToduWithInternalTools {
   const internalTodu = todu as ToduWithInternalTools;
-  if (!internalTodu.__internal?.syncRuntime?.actors) {
-    throw new Error("daemon sync runtime requires engine syncRuntime actor internals");
+  if (
+    !internalTodu.__internal?.syncRuntime?.actors ||
+    !internalTodu.__internal.syncRuntime.commentProvenance
+  ) {
+    throw new Error("daemon sync runtime requires engine syncRuntime internals");
   }
 
   return internalTodu;

--- a/packages/engine/src/index.integration.test.ts
+++ b/packages/engine/src/index.integration.test.ts
@@ -3,9 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
-import { type CatalogDocument, createActorId } from "@todu/core";
+import {
+  type CatalogDocument,
+  createActorId,
+  createIntegrationBindingId,
+  createNoteId,
+} from "@todu/core";
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { Todu } from "./index.js";
+import type { Todu, ToduWithInternalTools } from "./index.js";
 import { createTodu } from "./index.js";
 
 async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
@@ -137,6 +142,47 @@ describe("createTodu", () => {
     expect(catalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
   });
 
+  it("persists structured comment sync provenance independently from note tags", async () => {
+    todu = await createTodu({ storagePath: tmpDir });
+    const internalTodu = todu as ToduWithInternalTools;
+    const upsertResult = await internalTodu.__internal.syncRuntime.commentProvenance.upsert({
+      bindingId: createIntegrationBindingId("ibind-1"),
+      provider: "github",
+      targetKind: "repository",
+      targetRef: "owner/repo",
+      localNoteId: createNoteId("note-1"),
+      externalTaskId: "gh-task-1",
+      externalCommentId: "gh-comment-1",
+      lastMirroredAt: "2026-03-10T10:00:00.000Z",
+    });
+    expect(upsertResult.ok).toBe(true);
+
+    await todu.close();
+    todu = null;
+    await new Promise((r) => setTimeout(r, 50));
+
+    todu = await createTodu({ storagePath: tmpDir });
+    const reopenedTodu = todu as ToduWithInternalTools;
+    const listResult = await reopenedTodu.__internal.syncRuntime.commentProvenance.list({
+      bindingId: createIntegrationBindingId("ibind-1"),
+      localNoteId: createNoteId("note-1"),
+    });
+
+    expect(listResult.ok).toBe(true);
+    expect(listResult.ok ? listResult.value : []).toEqual([
+      expect.objectContaining({
+        bindingId: "ibind-1",
+        provider: "github",
+        targetKind: "repository",
+        targetRef: "owner/repo",
+        localNoteId: "note-1",
+        externalTaskId: "gh-task-1",
+        externalCommentId: "gh-comment-1",
+        lastMirroredAt: "2026-03-10T10:00:00.000Z",
+      }),
+    ]);
+  });
+
   it("returns config via config.get()", async () => {
     todu = await createTodu({ storagePath: tmpDir });
     const config = todu.config.get();
@@ -229,7 +275,7 @@ describe("createTodu", () => {
     expect(migratedCatalog.integrationStatusDocIds).toEqual({});
     expect(migratedCatalog.recurringTemplates).toEqual([]);
     expect(migratedCatalog.habits).toEqual([]);
-    expect(migratedCatalog.settings.schemaVersion).toBe(2);
+    expect(migratedCatalog.settings.schemaVersion).toBe(3);
   });
 
   it("migrates old catalogs with the configured bootstrap owner actor", async () => {
@@ -258,6 +304,6 @@ describe("createTodu", () => {
     const migratedCatalog = await readCatalogDocument(tmpDir);
     expect(migratedCatalog.actors).toEqual([{ id: "erik", displayName: "Erik" }]);
     expect(migratedCatalog.ownerActorId).toBe("erik");
-    expect(migratedCatalog.settings.schemaVersion).toBe(2);
+    expect(migratedCatalog.settings.schemaVersion).toBe(3);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,7 +15,10 @@ import { createLabelNamespace } from "./labels.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
 import { createRecurringNamespace } from "./recurring.js";
-import { createSyncRuntimeActorTools } from "./runtime-internals.js";
+import {
+  createSyncRuntimeActorTools,
+  createSyncRuntimeCommentProvenanceTools,
+} from "./runtime-internals.js";
 import { processTemplates } from "./scheduling.js";
 import { initBootstrapStorage, initEphemeralStorage, type Storage } from "./storage.js";
 import { addRemoteSyncAdapter, connectSyncClient, isSyncServerAvailable } from "./sync-client.js";
@@ -351,6 +354,7 @@ export async function createTodu(
     __internal: {
       syncRuntime: {
         actors: createSyncRuntimeActorTools(storage.catalog),
+        commentProvenance: createSyncRuntimeCommentProvenanceTools(storage.catalog, storage.repo),
       },
     },
     actor: createActorNamespace(storage.catalog),

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -319,8 +319,8 @@ describe("note namespace", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       const catalog = await readCatalogDocument(tmpDir);
-      expect(catalog.version).toBe(2);
-      expect(catalog.settings.schemaVersion).toBe(2);
+      expect(catalog.version).toBe(3);
+      expect(catalog.settings.schemaVersion).toBe(3);
       expect(catalog.actors).toEqual([
         { id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" },
         { id: migratedFirst?.authorActorId, displayName: "Alice" },

--- a/packages/engine/src/runtime-internals.ts
+++ b/packages/engine/src/runtime-internals.ts
@@ -1,12 +1,233 @@
-import type { DocHandle } from "@automerge/automerge-repo/slim";
-import { type Actor, type ActorId, type CatalogDocument, ok, type Result } from "@todu/core";
-import type { SyncRuntimeActorTools } from "./todu.js";
+import crypto from "node:crypto";
+import type { DocHandle, DocumentId, Repo } from "@automerge/automerge-repo/slim";
+import {
+  type Actor,
+  type ActorId,
+  type CatalogDocument,
+  type CommentSyncProvenance,
+  type CommentSyncProvenanceDocument,
+  type CommentSyncProvenanceFilter,
+  createCommentSyncProvenanceDocument,
+  createCommentSyncProvenanceId,
+  type NoteId,
+  ok,
+  type Result,
+  type UpsertCommentSyncProvenanceInput,
+  validationError,
+} from "@todu/core";
+import type { SyncRuntimeActorTools, SyncRuntimeCommentProvenanceTools } from "./todu.js";
 
 function cloneActor(actor: Actor): Actor {
   return {
     id: actor.id,
     displayName: actor.displayName,
     ...(actor.archived !== undefined ? { archived: actor.archived } : {}),
+  };
+}
+
+function cloneCommentSyncProvenance(record: CommentSyncProvenance): CommentSyncProvenance {
+  return {
+    id: record.id,
+    bindingId: record.bindingId,
+    provider: record.provider,
+    targetKind: record.targetKind,
+    targetRef: record.targetRef,
+    localNoteId: record.localNoteId,
+    externalTaskId: record.externalTaskId,
+    externalCommentId: record.externalCommentId,
+    ...(record.sourceUrl !== undefined ? { sourceUrl: record.sourceUrl } : {}),
+    lastMirroredAt: record.lastMirroredAt,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function createStableCommentSyncProvenanceId(
+  input: Pick<UpsertCommentSyncProvenanceInput, "bindingId" | "localNoteId">,
+): ReturnType<typeof createCommentSyncProvenanceId> {
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${input.bindingId}:${input.localNoteId}`)
+    .digest("hex")
+    .slice(0, 16);
+  return createCommentSyncProvenanceId(`cprov-${hash}`);
+}
+
+function matchesCommentSyncProvenanceFilter(
+  record: CommentSyncProvenance,
+  filter?: CommentSyncProvenanceFilter,
+): boolean {
+  if (!filter) return true;
+  if (filter.bindingId !== undefined && record.bindingId !== filter.bindingId) return false;
+  if (filter.localNoteId !== undefined && record.localNoteId !== filter.localNoteId) return false;
+  if (filter.externalTaskId !== undefined && record.externalTaskId !== filter.externalTaskId) {
+    return false;
+  }
+  if (
+    filter.externalCommentId !== undefined &&
+    record.externalCommentId !== filter.externalCommentId
+  ) {
+    return false;
+  }
+  return true;
+}
+
+async function getOrCreateCommentSyncProvenanceHandle(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+): Promise<DocHandle<CommentSyncProvenanceDocument>> {
+  const existingDocId = catalog.doc()?.commentSyncProvenanceDocId;
+  if (existingDocId) {
+    const handle = await repo.find<CommentSyncProvenanceDocument>(existingDocId as DocumentId);
+    await handle.whenReady();
+    return handle;
+  }
+
+  const handle = repo.create<CommentSyncProvenanceDocument>();
+  const empty = createCommentSyncProvenanceDocument();
+  handle.change((doc) => {
+    doc.records = empty.records;
+  });
+
+  catalog.change((doc) => {
+    doc.commentSyncProvenanceDocId = handle.documentId;
+  });
+
+  return handle;
+}
+
+async function getCommentSyncProvenanceHandle(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+): Promise<DocHandle<CommentSyncProvenanceDocument> | null> {
+  const docId = catalog.doc()?.commentSyncProvenanceDocId;
+  if (!docId) return null;
+  const handle = await repo.find<CommentSyncProvenanceDocument>(docId as DocumentId);
+  await handle.whenReady();
+  return handle;
+}
+
+export function createSyncRuntimeCommentProvenanceTools(
+  catalog: DocHandle<CatalogDocument>,
+  repo: Repo,
+): SyncRuntimeCommentProvenanceTools {
+  return {
+    async list(filter?: CommentSyncProvenanceFilter): Promise<Result<CommentSyncProvenance[]>> {
+      const handle = await getCommentSyncProvenanceHandle(catalog, repo);
+      const records = handle?.doc()?.records ?? [];
+      return ok(
+        records
+          .filter((record) => matchesCommentSyncProvenanceFilter(record, filter))
+          .map(cloneCommentSyncProvenance),
+      );
+    },
+
+    async upsert(input: UpsertCommentSyncProvenanceInput): Promise<Result<CommentSyncProvenance>> {
+      const handle = await getOrCreateCommentSyncProvenanceHandle(catalog, repo);
+      const now = new Date().toISOString();
+      const existing = handle
+        .doc()
+        ?.records.find(
+          (record) =>
+            record.bindingId === input.bindingId && record.localNoteId === input.localNoteId,
+        );
+
+      if (existing && existing.externalCommentId !== input.externalCommentId) {
+        return {
+          ok: false,
+          error: validationError(
+            "externalCommentId",
+            `comment provenance conflict: note=${input.localNoteId} existing=${existing.externalCommentId} next=${input.externalCommentId}`,
+          ),
+        };
+      }
+
+      const existingByExternalCommentId = handle
+        .doc()
+        ?.records.find(
+          (record) =>
+            record.bindingId === input.bindingId &&
+            record.externalCommentId === input.externalCommentId &&
+            record.localNoteId !== input.localNoteId,
+        );
+      if (existingByExternalCommentId) {
+        return {
+          ok: false,
+          error: validationError(
+            "externalCommentId",
+            `comment provenance conflict: externalCommentId=${input.externalCommentId} existingNote=${existingByExternalCommentId.localNoteId} nextNote=${input.localNoteId}`,
+          ),
+        };
+      }
+
+      const recordId = existing?.id ?? createStableCommentSyncProvenanceId(input);
+      handle.change((doc) => {
+        const index = doc.records.findIndex(
+          (record) =>
+            record.bindingId === input.bindingId && record.localNoteId === input.localNoteId,
+        );
+        const next: CommentSyncProvenance = {
+          id: recordId,
+          bindingId: input.bindingId,
+          provider: input.provider,
+          targetKind: input.targetKind,
+          targetRef: input.targetRef,
+          localNoteId: input.localNoteId,
+          externalTaskId: input.externalTaskId,
+          externalCommentId: input.externalCommentId,
+          ...(input.sourceUrl !== undefined ? { sourceUrl: input.sourceUrl } : {}),
+          lastMirroredAt: input.lastMirroredAt,
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        };
+
+        if (index === -1) {
+          doc.records.push(next);
+        } else {
+          doc.records[index] = next;
+        }
+      });
+
+      const stored = handle
+        .doc()
+        ?.records.find(
+          (record) =>
+            record.bindingId === input.bindingId && record.localNoteId === input.localNoteId,
+        );
+      return ok(
+        cloneCommentSyncProvenance(
+          stored ?? {
+            id: recordId,
+            bindingId: input.bindingId,
+            provider: input.provider,
+            targetKind: input.targetKind,
+            targetRef: input.targetRef,
+            localNoteId: input.localNoteId,
+            externalTaskId: input.externalTaskId,
+            externalCommentId: input.externalCommentId,
+            ...(input.sourceUrl !== undefined ? { sourceUrl: input.sourceUrl } : {}),
+            lastMirroredAt: input.lastMirroredAt,
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: now,
+          },
+        ),
+      );
+    },
+
+    async deleteForNote(noteId: NoteId): Promise<Result<void>> {
+      const handle = await getCommentSyncProvenanceHandle(catalog, repo);
+      if (!handle) return ok(undefined);
+
+      handle.change((doc) => {
+        for (let index = doc.records.length - 1; index >= 0; index -= 1) {
+          if (doc.records[index].localNoteId === noteId) {
+            doc.records.splice(index, 1);
+          }
+        }
+      });
+
+      return ok(undefined);
+    },
   };
 }
 

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -694,6 +694,7 @@ function migrateCatalog(
       d.noteBucketByNoteId = structuredClone(defaults.noteBucketByNoteId);
     if (d.integrationStatusDocIds === undefined || d.integrationStatusDocIds === null)
       d.integrationStatusDocIds = structuredClone(defaults.integrationStatusDocIds);
+    if (d.commentSyncProvenanceDocId === null) delete d.commentSyncProvenanceDocId;
     if (d.settings === undefined || d.settings === null) {
       d.settings = { schemaVersion: d.version ?? 1 };
     } else if (d.settings.schemaVersion === undefined || d.settings.schemaVersion === null) {

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -500,8 +500,8 @@ describe("task namespace", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       const catalog = await readCatalogDocument(tmpDir);
-      expect(catalog.version).toBe(2);
-      expect(catalog.settings.schemaVersion).toBe(2);
+      expect(catalog.version).toBe(3);
+      expect(catalog.settings.schemaVersion).toBe(3);
       expect(catalog.actors).toEqual([
         { id: DEFAULT_OWNER_ACTOR_ID, displayName: "user" },
         { id: firstTask?.assigneeActorIds[0], displayName: "Alice" },
@@ -587,7 +587,7 @@ describe("task namespace", () => {
       await new Promise((r) => setTimeout(r, 50));
 
       const catalog = await readCatalogDocument(tmpDir);
-      expect(catalog.version).toBe(2);
+      expect(catalog.version).toBe(3);
       expect(catalog.actors).toContainEqual({
         id: repairedTask?.assigneeActorIds?.[0],
         displayName: "Alice",

--- a/packages/engine/src/todu.ts
+++ b/packages/engine/src/todu.ts
@@ -4,6 +4,8 @@ import type {
   ApprovalItem,
   ApprovalListFilter,
   BootstrapOwnerActor,
+  CommentSyncProvenance,
+  CommentSyncProvenanceFilter,
   CreateActorInput,
   CreateHabitInput,
   CreateIntegrationBindingInput,
@@ -49,6 +51,7 @@ import type {
   UpdateProjectInput,
   UpdateRecurringInput,
   UpdateTaskInput,
+  UpsertCommentSyncProvenanceInput,
 } from "@todu/core";
 import type { UpcomingOccurrence } from "./recurring.js";
 
@@ -299,9 +302,16 @@ export interface SyncRuntimeActorTools {
   ensure(input: { id: ActorId; displayName: string }): Promise<Result<Actor>>;
 }
 
+export interface SyncRuntimeCommentProvenanceTools {
+  list(filter?: CommentSyncProvenanceFilter): Promise<Result<CommentSyncProvenance[]>>;
+  upsert(input: UpsertCommentSyncProvenanceInput): Promise<Result<CommentSyncProvenance>>;
+  deleteForNote(noteId: NoteId): Promise<Result<void>>;
+}
+
 export interface ToduInternalTools {
   syncRuntime: {
     actors: SyncRuntimeActorTools;
+    commentProvenance: SyncRuntimeCommentProvenanceTools;
   };
 }
 


### PR DESCRIPTION
## Summary
- add core comment sync provenance records and engine sync-runtime internals for persistence/upsert/list/delete
- expose structured comment provenance on sync provider push payloads, with legacy externalId alias
- update comment import/export/linking to use provenance, lazily migrate legacy sync:externalId tags, and avoid tags on new imported comments
- document provider migration path and architecture ownership

## Verification
- make pre-pr
- npx vitest run --config vitest.all.config.ts packages/engine/src/index.integration.test.ts packages/engine/src/tasks.integration.test.ts packages/engine/src/notes.integration.test.ts

Task: #task-ef90d902