### PR TITLE
Fix partial sync comment deletions

### DIFF
--- a/docs/plugin-sync-provider-api.md
+++ b/docs/plugin-sync-provider-api.md
@@ -90,6 +90,20 @@ interface ImportedCommentInput {
   raw?: unknown;
 }
 
+interface DeletedImportedCommentInput {
+  externalId: string;
+  externalTaskId: string;
+  deletedAt?: string;
+  raw?: unknown;
+}
+
+interface SyncProviderPullResultV3 {
+  tasks: ImportedTaskInput[];
+  comments?: ImportedCommentInput[];
+  deletedComments?: DeletedImportedCommentInput[];
+  completeCommentExternalTaskIds?: string[];
+}
+
 interface CommentSyncProvenance {
   bindingId: IntegrationBindingId;
   provider: string;
@@ -157,7 +171,7 @@ interface SyncProviderV3 {
 
 ### Pull behavior
 
-`SyncProviderPullResultV3.tasks` accepts `ImportedTaskInput[]` and `comments` accepts `ImportedCommentInput[]`.
+`SyncProviderPullResultV3.tasks` accepts `ImportedTaskInput[]`. `comments` accepts `ImportedCommentInput[]` and is treated as an upsert/import batch. Comment pulls are partial/incremental by default; omitted comments are unchanged unless the provider also supplies explicit deletion metadata.
 
 In v3:
 
@@ -206,13 +220,14 @@ The runtime then applies each returned comment link idempotently by writing stru
 
 ### Comment pull path
 
-Pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalActorRef`.
+Pulled comments are `ImportedCommentInput[]` with structured `author?: ExternalActorRef`. The runtime treats this array as a partial upsert batch unless the provider opts into deletion semantics.
 
-The runtime reconciles pulled comments with local notes using a snapshot model:
+The runtime reconciles pulled comments with local notes using a partial-by-default model:
 
 - comments with an `externalId` not present locally are created as new notes and linked through structured comment provenance, not user-visible tags
 - comments matching an existing local note are updated if the external `updatedAt` is newer than the local `createdAt`
-- local synced notes whose external IDs are absent from the pull result are deleted
+- local synced notes whose external IDs are absent from a partial pull are preserved
+- local synced notes are deleted only when their external ID appears in `deletedComments`, or when their `externalTaskId` appears in `completeCommentExternalTaskIds` and their external ID is absent from the complete comment snapshot for that task/thread
 - existing notes with legacy `sync:externalId:*` tags are resolved lazily into provenance records when encountered; notes without sync tags are not rewritten by this migration
 
 ### Comment provenance migration path

--- a/packages/core/src/sync-provider.ts
+++ b/packages/core/src/sync-provider.ts
@@ -55,6 +55,13 @@ export interface ImportedCommentInput {
   raw?: unknown;
 }
 
+export interface DeletedImportedCommentInput {
+  externalId: string;
+  externalTaskId: string;
+  deletedAt?: string;
+  raw?: unknown;
+}
+
 export interface ExportedCommentInput {
   localNoteId: NoteId;
   body: string;
@@ -91,6 +98,8 @@ export interface SyncProviderConfig {
 export interface SyncProviderPullResultV3 {
   tasks: ImportedTaskInput[];
   comments?: ImportedCommentInput[];
+  deletedComments?: DeletedImportedCommentInput[];
+  completeCommentExternalTaskIds?: string[];
 }
 
 export interface SyncProviderPushCommentLink {

--- a/packages/daemon/src/sync-worker-runtime.test.ts
+++ b/packages/daemon/src/sync-worker-runtime.test.ts
@@ -764,7 +764,7 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
-  it("linked local-origin comments later delete remotely through the same local note", async () => {
+  it("linked local-origin comments later delete remotely through explicit tombstones", async () => {
     const project = createProject();
     const task = createTask(project.id, { externalId: "gh-task-1" });
     const binding = createBinding(project.id, { strategy: "bidirectional" });
@@ -779,12 +779,12 @@ describe("sync-worker-runtime", () => {
         .mockResolvedValueOnce({ tasks: [], comments: [] })
         .mockResolvedValue({
           tasks: [],
-          comments: [
+          comments: [],
+          deletedComments: [
             {
-              externalId: "gh-comment-other",
+              externalId: "gh-comment-1",
               externalTaskId: task.externalId!,
-              body: "other remote comment",
-              createdAt: "2026-03-10T10:00:00Z",
+              deletedAt: "2026-03-10T10:00:00Z",
             },
           ],
         }),
@@ -1328,15 +1328,15 @@ describe("sync-worker-runtime", () => {
     handle.stop();
   });
 
-  it("pull deletes local synced notes absent from pull result", async () => {
+  it("pull preserves local synced notes absent from partial pull result", async () => {
     const project = createProject();
     const task = createTask(project.id, { externalId: "gh-task-1" });
     const binding = createBinding(project.id, { strategy: "pull" });
-    const orphanedNote = createNote({
+    const omittedNote = createNote({
       entityType: "task",
       entityId: task.id,
-      content: "will be deleted",
-      tags: ["sync:externalId:gh-comment-deleted"],
+      content: "omitted from partial pull",
+      tags: ["sync:externalId:gh-comment-omitted"],
     });
     const provider = createProvider({
       pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
@@ -1345,13 +1345,64 @@ describe("sync-worker-runtime", () => {
           {
             externalId: "gh-comment-other",
             externalTaskId: task.externalId!,
-            body: "still exists",
+            body: "changed in partial pull",
             createdAt: "2026-03-10T10:00:00Z",
           },
         ],
       }),
     });
-    const todu = createTodu(project, [task], [binding], { notes: [orphanedNote] });
+    const todu = createTodu(project, [task], [binding], { notes: [omittedNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.delete).not.toHaveBeenCalled();
+    expect(todu.note.create).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+
+  it("pull deletes local synced notes from explicit comment tombstones", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const deletedNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "will be deleted",
+      tags: ["sync:externalId:gh-comment-deleted"],
+    });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [],
+        deletedComments: [
+          {
+            externalId: "gh-comment-deleted",
+            externalTaskId: task.externalId!,
+            deletedAt: "2026-03-10T10:00:00Z",
+          },
+        ],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [deletedNote] });
 
     const runtime = createSyncPluginWorkerRuntime({
       pluginName: "github",
@@ -1374,8 +1425,59 @@ describe("sync-worker-runtime", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(todu.note.delete).toHaveBeenCalledTimes(1);
-    expect(todu.note.delete).toHaveBeenCalledWith(orphanedNote.id);
-    // The new comment should be created
+    expect(todu.note.delete).toHaveBeenCalledWith(deletedNote.id);
+
+    handle.stop();
+  });
+
+  it("pull deletes local synced notes absent from complete comment snapshots", async () => {
+    const project = createProject();
+    const task = createTask(project.id, { externalId: "gh-task-1" });
+    const binding = createBinding(project.id, { strategy: "pull" });
+    const deletedNote = createNote({
+      entityType: "task",
+      entityId: task.id,
+      content: "missing from complete snapshot",
+      tags: ["sync:externalId:gh-comment-deleted"],
+    });
+    const provider = createProvider({
+      pull: vi.fn<SyncProvider["pull"]>().mockResolvedValue({
+        tasks: [],
+        comments: [
+          {
+            externalId: "gh-comment-other",
+            externalTaskId: task.externalId!,
+            body: "still exists",
+            createdAt: "2026-03-10T10:00:00Z",
+          },
+        ],
+        completeCommentExternalTaskIds: [task.externalId!],
+      }),
+    });
+    const todu = createTodu(project, [task], [binding], { notes: [deletedNote] });
+
+    const runtime = createSyncPluginWorkerRuntime({
+      pluginName: "github",
+      pluginVersion: "1.0.0",
+      modulePath: "/plugins/github.js",
+      authorityId: "daemon://authority-1",
+      provider,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        retryInitialMs: 100,
+        retryMaxMs: 800,
+        settings: {},
+      },
+      logger: createLogger(),
+      getTodu: () => todu.instance,
+    });
+
+    const handle = runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(todu.note.delete).toHaveBeenCalledTimes(1);
+    expect(todu.note.delete).toHaveBeenCalledWith(deletedNote.id);
     expect(todu.note.create).toHaveBeenCalledTimes(1);
 
     handle.stop();

--- a/packages/daemon/src/sync-worker-runtime.ts
+++ b/packages/daemon/src/sync-worker-runtime.ts
@@ -5,6 +5,7 @@ import {
   type CommentSyncProvenance,
   createActorId,
   createProjectId,
+  type DeletedImportedCommentInput,
   type ExportedCommentInput,
   type ExportedTaskInput,
   type ExternalActorRef,
@@ -96,6 +97,11 @@ interface RuntimeImportedComment {
   author?: ExternalActorRef;
   createdAt: string;
   updatedAt?: string;
+}
+
+interface RuntimeDeletedComment {
+  externalId: string;
+  externalTaskId: string;
 }
 
 export function resolveSyncPluginExecutionConfig(
@@ -304,8 +310,16 @@ export function createSyncPluginWorkerRuntime(
             project = pullStats.project;
           }
 
-          if (pullResult.comments && pullResult.comments.length > 0) {
-            await applyPulledCommentsV3(activeTodu, actorState, project.id, pullResult.comments);
+          const hasPulledCommentChanges =
+            (pullResult.comments?.length ?? 0) > 0 ||
+            (pullResult.deletedComments?.length ?? 0) > 0 ||
+            (pullResult.completeCommentExternalTaskIds?.length ?? 0) > 0;
+          if (hasPulledCommentChanges) {
+            await applyPulledCommentsV3(activeTodu, actorState, project.id, {
+              comments: pullResult.comments ?? [],
+              deletedComments: pullResult.deletedComments ?? [],
+              completeCommentExternalTaskIds: pullResult.completeCommentExternalTaskIds ?? [],
+            });
           }
         }
 
@@ -868,9 +882,13 @@ async function applyPulledCommentsV3(
   todu: Todu,
   actorState: SyncBindingActorState,
   projectId: Project["id"],
-  comments: ImportedCommentInput[],
+  input: {
+    comments: ImportedCommentInput[];
+    deletedComments: DeletedImportedCommentInput[];
+    completeCommentExternalTaskIds: string[];
+  },
 ): Promise<{ created: number; updated: number; deleted: number }> {
-  const importedComments = comments.map((comment) => ({
+  const importedComments = input.comments.map((comment) => ({
     externalId: comment.externalId,
     externalTaskId: comment.externalTaskId,
     body: comment.body,
@@ -878,15 +896,27 @@ async function applyPulledCommentsV3(
     createdAt: comment.createdAt,
     updatedAt: comment.updatedAt,
   })) satisfies RuntimeImportedComment[];
+  const deletedComments = input.deletedComments.map((comment) => ({
+    externalId: comment.externalId,
+    externalTaskId: comment.externalTaskId,
+  })) satisfies RuntimeDeletedComment[];
 
-  return applyImportedComments(todu, actorState, projectId, importedComments);
+  return applyImportedComments(todu, actorState, projectId, {
+    comments: importedComments,
+    deletedComments,
+    completeCommentExternalTaskIds: input.completeCommentExternalTaskIds,
+  });
 }
 
 async function applyImportedComments(
   todu: Todu,
   actorState: SyncBindingActorState,
   projectId: Project["id"],
-  comments: RuntimeImportedComment[],
+  input: {
+    comments: RuntimeImportedComment[];
+    deletedComments: RuntimeDeletedComment[];
+    completeCommentExternalTaskIds: string[];
+  },
 ): Promise<{ created: number; updated: number; deleted: number }> {
   const stats = { created: 0, updated: 0, deleted: 0 };
 
@@ -905,7 +935,11 @@ async function applyImportedComments(
   }
 
   const commentsByTask = new Map<string, RuntimeImportedComment[]>();
-  for (const comment of comments) {
+  const deletedCommentIdsByTask = new Map<string, Set<string>>();
+  const completeTaskIds = new Set<string>();
+  const affectedTaskIds = new Set<string>();
+
+  for (const comment of input.comments) {
     const localTaskId = localTaskIdByExternalId.get(comment.externalTaskId);
     if (!localTaskId) {
       continue;
@@ -917,10 +951,38 @@ async function applyImportedComments(
     } else {
       commentsByTask.set(localTaskId, [comment]);
     }
+    affectedTaskIds.add(localTaskId);
   }
 
-  for (const taskId of commentsByTask.keys()) {
+  for (const comment of input.deletedComments) {
+    const localTaskId = localTaskIdByExternalId.get(comment.externalTaskId);
+    if (!localTaskId) {
+      continue;
+    }
+
+    const existing = deletedCommentIdsByTask.get(localTaskId);
+    if (existing) {
+      existing.add(comment.externalId);
+    } else {
+      deletedCommentIdsByTask.set(localTaskId, new Set([comment.externalId]));
+    }
+    affectedTaskIds.add(localTaskId);
+  }
+
+  for (const externalTaskId of input.completeCommentExternalTaskIds) {
+    const localTaskId = localTaskIdByExternalId.get(externalTaskId);
+    if (!localTaskId) {
+      continue;
+    }
+
+    completeTaskIds.add(localTaskId);
+    affectedTaskIds.add(localTaskId);
+  }
+
+  for (const taskId of affectedTaskIds) {
     const pulledComments = commentsByTask.get(taskId) ?? [];
+    const explicitlyDeletedExternalIds = deletedCommentIdsByTask.get(taskId) ?? new Set<string>();
+    const isCompleteCommentSnapshot = completeTaskIds.has(taskId);
     const localNotesResult = await todu.note.list({
       entityType: "task",
       entityId: taskId,
@@ -1030,16 +1092,21 @@ async function applyImportedComments(
     }
 
     for (const [externalId, note] of localByExternalId) {
-      if (!pulledExternalIds.has(externalId)) {
-        const deleteResult = await todu.note.delete(note.id);
-        if (!deleteResult.ok) {
-          throw new Error(
-            `pulled comment delete failed: note=${note.id} externalId=${externalId} error=${formatToduError(deleteResult.error)}`,
-          );
-        }
-        await deleteCommentProvenanceForNote(todu, note.id);
-        stats.deleted += 1;
+      const shouldDelete =
+        explicitlyDeletedExternalIds.has(externalId) ||
+        (isCompleteCommentSnapshot && !pulledExternalIds.has(externalId));
+      if (!shouldDelete) {
+        continue;
       }
+
+      const deleteResult = await todu.note.delete(note.id);
+      if (!deleteResult.ok) {
+        throw new Error(
+          `pulled comment delete failed: note=${note.id} externalId=${externalId} error=${formatToduError(deleteResult.error)}`,
+        );
+      }
+      await deleteCommentProvenanceForNote(todu, note.id);
+      stats.deleted += 1;
     }
   }
 


### PR DESCRIPTION
## Summary
- Treat pulled sync comments as partial upsert batches by default.
- Add explicit deleted-comment tombstones and complete-comment snapshot markers to the sync provider pull contract.
- Preserve omitted provenanced notes unless deletion is explicit or the provider marks the task/thread comment set complete.
- Update regression tests and provider API docs.

## Verification
- npm test -- packages/daemon/src/sync-worker-runtime.test.ts
- make check
- make pre-pr

Task: #task-2655d7ed