### PR TITLE
chore: update GitHub Actions runtime pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Prepare Electron binary
+        run: node scripts/install-electron-binary.mjs
 
       - name: Check (lint + format + typecheck)
         run: make check-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Extract and validate version
         id: version
@@ -74,10 +74,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -89,6 +89,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Prepare Electron binary
+        run: node scripts/install-electron-binary.mjs
 
       - name: Check (lint + test)
         env:
@@ -122,7 +125,7 @@ jobs:
           npm run --workspace=packages/electron dist:linux -- --linux AppImage deb
 
       - name: Upload CLI binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-linux
           path: |
@@ -130,7 +133,7 @@ jobs:
             dist/cli/todu-cli-linux-arm64
 
       - name: Upload Electron installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: electron-linux
           path: |
@@ -144,10 +147,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -159,6 +162,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Prepare Electron binary
+        run: node scripts/install-electron-binary.mjs
 
       - name: Build CLI binaries (macOS)
         run: |
@@ -177,7 +183,7 @@ jobs:
           npm run --workspace=packages/electron dist:mac
 
       - name: Upload CLI binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-macos
           path: |
@@ -185,7 +191,7 @@ jobs:
             dist/cli/todu-cli-darwin-arm64
 
       - name: Upload Electron installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: electron-macos
           path: |
@@ -195,13 +201,13 @@ jobs:
   build-windows:
     name: Build Windows CLI
     needs: validate
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -224,7 +230,7 @@ jobs:
         shell: bash
 
       - name: Upload CLI binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: cli-windows
           path: dist/cli/todu-cli-windows-x64.exe
@@ -240,10 +246,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
 
@@ -306,7 +312,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.1
         with:
           tag_name: v${{ needs.validate.outputs.version }}
           name: todu v${{ needs.validate.outputs.version }}
@@ -323,10 +329,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org

--- a/scripts/install-electron-binary.mjs
+++ b/scripts/install-electron-binary.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const electronPackagePath = require.resolve("electron/package.json");
+const electronRoot = dirname(electronPackagePath);
+const { version } = require(electronPackagePath);
+const { downloadArtifact } = require("@electron/get");
+
+function getPlatformPath(platform) {
+  switch (platform) {
+    case "darwin":
+      return "Electron.app/Contents/MacOS/Electron";
+    case "linux":
+      return "electron";
+    case "win32":
+      return "electron.exe";
+    default:
+      throw new Error(`Electron builds are not available on platform: ${platform}`);
+  }
+}
+
+const platform = process.env.npm_config_platform || process.platform;
+const arch = process.env.npm_config_arch || process.arch;
+const platformPath = getPlatformPath(platform);
+const distPath = join(electronRoot, "dist");
+const executablePath = join(distPath, platformPath);
+
+if (existsSync(executablePath)) {
+  writeFileSync(join(electronRoot, "path.txt"), platformPath);
+  console.log(`Electron ${version} binary already installed for ${platform}-${arch}`);
+  process.exit(0);
+}
+
+const zipPath = await downloadArtifact({
+  version,
+  artifactName: "electron",
+  platform,
+  arch,
+  force: process.env.force_no_cache === "true",
+  checksums: require(join(electronRoot, "checksums.json")),
+});
+
+rmSync(distPath, { recursive: true, force: true });
+mkdirSync(distPath, { recursive: true });
+
+const unzip = spawnSync("unzip", ["-q", "-o", zipPath, "-d", distPath], {
+  stdio: "inherit",
+});
+
+if (unzip.error) {
+  throw new Error(`Failed to run unzip for Electron ${version}: ${unzip.error.message}`);
+}
+
+if (unzip.status !== 0) {
+  throw new Error(`Failed to unzip Electron ${version} archive: exit ${unzip.status}`);
+}
+
+if (!existsSync(executablePath)) {
+  throw new Error(`Electron ${version} archive did not contain expected executable: ${executablePath}`);
+}
+
+writeFileSync(join(electronRoot, "path.txt"), platformPath);
+console.log(`Installed Electron ${version} binary for ${platform}-${arch}`);


### PR DESCRIPTION
## Summary

- Upgrade CI and release workflow actions to Node 24-compatible releases.
- Pin the Windows release build to `windows-2025` instead of `windows-latest`.
- Add an explicit Electron binary preparation step for CI/release Linux and macOS jobs so clean `npm ci` jobs can test/build Electron reliably under the updated hosted action/runtime path.
- Keep release packaging, artifact names, npm publish, and version validation behavior unchanged.

## Validation and annotation handoff

- PR CI run: https://github.com/evcraddock/todu/actions/runs/28373315977
- PR CI job: https://github.com/evcraddock/todu/actions/runs/28373315977/job/84056439615
- CI conclusion: passed.
- Annotation check: the PR CI check run has no annotations, including no Node.js 20 action deprecation warnings.
- Static release workflow check: the updated release workflow references only action versions whose `action.yml` reports `runs.using: node24` for the affected JavaScript actions.
- Remaining release annotations: none intentionally retained. A full release workflow execution is not triggered in this PR because `Release` publishes npm packages and creates a GitHub release for the supplied tag. The next real release run should confirm the release-specific annotation state.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `make pre-pr`
- push hook: `npm test`
- clean temp install smoke: `npm ci && node scripts/install-electron-binary.mjs && node -e "console.log(require(\'electron\'))"`
- Static action metadata check: all updated JavaScript actions report `runs.using: node24`.

Task: #task-3001ba6e