### PR TITLE
chore: remove deprecated CLI install dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Verify CLI install deprecations
+        run: npm run verify:cli-install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,9 @@ jobs:
       - name: Build packages
         run: npm run build
 
+      - name: Verify CLI install deprecations
+        run: npm run verify:cli-install
+
       - name: Publish npm packages
         run: |
           publish_package() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todu",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todu",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -142,16 +142,6 @@
         "fast-sha256": "^1.3.0",
         "uuid": "^9.0.0",
         "xstate": "^5.9.1"
-      }
-    },
-    "node_modules/@automerge/automerge-repo-storage-nodefs": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-storage-nodefs/-/automerge-repo-storage-nodefs-2.5.6.tgz",
-      "integrity": "sha512-euCoSvlcGLVBMzBHSr7txUXIdVI0WwkdXqIbRgGtltdynS/Id2Ps4ngbKSI/1kocRsrTzvx1dW77DxwjArV8xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@automerge/automerge-repo": "2.5.6",
-        "rimraf": "^5.0.1"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -615,7 +605,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1254,7 +1243,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1295,7 +1283,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1791,6 +1778,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1812,6 +1800,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1828,6 +1817,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1842,6 +1832,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2334,6 +2325,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -2570,6 +2562,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3193,7 +3186,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3268,7 +3260,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.19.0.tgz",
       "integrity": "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3491,7 +3482,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.19.0.tgz",
       "integrity": "sha512-N6nKbFB2VwMsPlCw67RlAtYSK48TAsAUgjnD+vd3ieSlIufdQnLXDFUP6hFKx9mwoUVUgZGz02RA6bkxOdYyTw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3610,7 +3600,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.19.0.tgz",
       "integrity": "sha512-ZmGUhLbMWaGqnJh2Bry+6V4M6gMpUDYo4D1xNux5Gng/E/eYtc+PMxMZ/6F7tNTAuujLBOQKj6D+4SsSm457jw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3625,7 +3614,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.19.0.tgz",
       "integrity": "sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3920,7 +3908,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3930,7 +3917,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4308,7 +4294,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4334,6 +4319,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4346,6 +4332,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4726,6 +4713,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base-x": {
@@ -4814,6 +4802,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4839,7 +4828,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5417,6 +5405,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5429,6 +5418,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -5508,12 +5498,14 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5793,7 +5785,6 @@
       "integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",
@@ -5925,6 +5916,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -5959,7 +5951,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -6698,6 +6689,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6718,6 +6710,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6741,6 +6734,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding": {
@@ -7136,6 +7130,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -7358,6 +7353,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -7793,6 +7789,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7845,6 +7842,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
@@ -7899,6 +7897,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8202,6 +8201,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/lz-string": {
@@ -8418,6 +8418,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8443,6 +8444,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8597,6 +8599,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9069,6 +9072,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse5": {
@@ -9132,6 +9136,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9141,6 +9146,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -9194,7 +9200,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9253,6 +9258,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -9270,6 +9276,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -9477,7 +9484,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9507,7 +9513,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9556,7 +9561,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9635,7 +9639,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9645,7 +9648,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9809,21 +9811,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/roarr": {
@@ -10010,6 +9997,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10022,6 +10010,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10038,6 +10027,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -10236,6 +10226,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -10254,6 +10245,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10268,6 +10260,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10277,12 +10270,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10295,6 +10290,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -10311,6 +10307,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10323,6 +10320,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10419,6 +10417,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10482,6 +10481,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10494,6 +10494,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10515,6 +10516,7 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10529,6 +10531,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10734,7 +10737,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10940,7 +10942,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11016,7 +11017,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11166,6 +11166,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11198,6 +11199,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -11216,6 +11218,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11233,6 +11236,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11242,6 +11246,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11257,12 +11262,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11277,6 +11284,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11297,7 +11305,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11501,7 +11508,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11517,7 +11523,7 @@
     },
     "packages/cli": {
       "name": "@todu/cli",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
         "@todu/daemon": "*",
@@ -11535,7 +11541,7 @@
     },
     "packages/core": {
       "name": "@todu/core",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -11543,11 +11549,10 @@
     },
     "packages/daemon": {
       "name": "@todu/daemon",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge-repo": "2.5.6",
-        "@automerge/automerge-repo-storage-nodefs": "2.5.6",
         "@todu/core": "*",
         "@todu/engine": "*",
         "yaml": "^2.8.2"
@@ -11561,7 +11566,7 @@
     },
     "packages/electron": {
       "name": "@todu/electron",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.75.4",
         "@earendil-works/pi-ai": "^0.75.4",
@@ -11595,13 +11600,12 @@
     },
     "packages/engine": {
       "name": "@todu/engine",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "3.2.6",
         "@automerge/automerge-repo": "2.5.6",
         "@automerge/automerge-repo-network-websocket": "2.5.6",
-        "@automerge/automerge-repo-storage-nodefs": "2.5.6",
         "@todu/core": "*",
         "rrule": "^2.8.1",
         "ws": "^8.19.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:sync-server-integration": "TODU_RUN_SYNC_SERVER_TESTS=1 vitest run --config vitest.all.config.ts packages/daemon/src/events-parity.integration.test.ts packages/daemon/src/join-safety.integration.test.ts packages/engine/src/remote-sync.integration.test.ts packages/engine/src/sync-status.integration.test.ts packages/engine/src/sync.integration.test.ts",
     "test:conformance": "vitest run --config vitest.all.config.ts packages/daemon/src/protocol-conformance.integration.test.ts",
     "test:storage-stability": "node scripts/test-storage-stability.mjs",
+    "verify:cli-install": "node scripts/verify-cli-install-deprecations.mjs",
     "test:watch": "vitest",
     "postinstall": "node scripts/patch-automerge-repo.mjs",
     "check": "biome check --write --error-on-warnings . && npm run typecheck",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@automerge/automerge-repo": "2.5.6",
-    "@automerge/automerge-repo-storage-nodefs": "2.5.6",
     "@todu/core": "*",
     "@todu/engine": "*",
     "yaml": "^2.8.2"

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -1,6 +1,5 @@
 import type { DocumentId } from "@automerge/automerge-repo";
 import { Repo } from "@automerge/automerge-repo/slim";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type BootstrapOwnerActor,
   err,
@@ -14,6 +13,7 @@ import {
   beginCatalogJoinSwitch,
   createTodu,
   initJoinStorage,
+  NodeFSStorageAdapter,
   registerHabitProcessor,
   type Todu,
 } from "@todu/engine";

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -22,7 +22,6 @@
     "@automerge/automerge": "3.2.6",
     "@automerge/automerge-repo": "2.5.6",
     "@automerge/automerge-repo-network-websocket": "2.5.6",
-    "@automerge/automerge-repo-storage-nodefs": "2.5.6",
     "@todu/core": "*",
     "rrule": "^2.8.1",
     "ws": "^8.19.0"

--- a/packages/engine/src/index.integration.test.ts
+++ b/packages/engine/src/index.integration.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type CatalogDocument,
   createActorId,
@@ -12,6 +11,7 @@ import {
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu, ToduWithInternalTools } from "./index.js";
 import { createTodu } from "./index.js";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 
 async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
   const markerPath = path.join(storagePath, "todu-catalog.id");

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,7 +4,6 @@ import {
   Repo,
 } from "@automerge/automerge-repo/slim";
 import type { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import { createActorNamespace } from "./actors.js";
 import { createApprovalNamespace } from "./approvals.js";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
@@ -12,6 +11,7 @@ import { observeAllChanges } from "./change-observer.js";
 import { createHabitNamespace } from "./habits.js";
 import { createIntegrationNamespace } from "./integrations.js";
 import { createLabelNamespace } from "./labels.js";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 import { createNoteNamespace } from "./notes.js";
 import { createProjectNamespace } from "./projects.js";
 import { createRecurringNamespace } from "./recurring.js";
@@ -35,6 +35,7 @@ import {
 
 export type { RemoteSyncConfig } from "@todu/core";
 export { registerHabitProcessor } from "./habits.js";
+export { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 export type { UpcomingOccurrence } from "./recurring.js";
 // Re-export schedule utilities for consumers
 export {

--- a/packages/engine/src/nodefs-storage-adapter.test.ts
+++ b/packages/engine/src/nodefs-storage-adapter.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
+
+describe("NodeFSStorageAdapter", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "todu-nodefs-storage-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("saves, loads, lists, and removes key ranges", async () => {
+    const adapter = new NodeFSStorageAdapter(tempDir);
+    const key = ["document-a", "snapshot"];
+
+    await adapter.save(key, new Uint8Array([1, 2, 3]));
+
+    await expect(adapter.load(key)).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    await expect(adapter.loadRange(["document-a"])).resolves.toEqual([
+      { key, data: new Uint8Array([1, 2, 3]) },
+    ]);
+
+    await adapter.removeRange(["document-a"]);
+
+    await expect(adapter.load(key)).resolves.toBeUndefined();
+    await expect(adapter.loadRange(["document-a"])).resolves.toEqual([]);
+  });
+});

--- a/packages/engine/src/nodefs-storage-adapter.ts
+++ b/packages/engine/src/nodefs-storage-adapter.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Chunk, StorageAdapterInterface, StorageKey } from "@automerge/automerge-repo/slim";
+
+/**
+ * Filesystem storage adapter for Automerge Repo.
+ *
+ * This mirrors the upstream NodeFS adapter layout without depending on the
+ * upstream package's deprecated `rimraf -> glob@10.5.0` install path.
+ */
+export class NodeFSStorageAdapter implements StorageAdapterInterface {
+  private readonly baseDirectory: string;
+  private readonly cache = new Map<string, Uint8Array>();
+
+  constructor(baseDirectory = "automerge-repo-data") {
+    this.baseDirectory = baseDirectory;
+  }
+
+  async load(keyArray: StorageKey): Promise<Uint8Array | undefined> {
+    const key = getKey(keyArray);
+    const cached = this.cache.get(key);
+    if (cached) return cached;
+
+    try {
+      const fileContent = await fs.promises.readFile(this.getFilePath(keyArray));
+      return new Uint8Array(fileContent);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  async save(keyArray: StorageKey, binary: Uint8Array): Promise<void> {
+    this.cache.set(getKey(keyArray), binary);
+
+    const filePath = this.getFilePath(keyArray);
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.promises.writeFile(filePath, binary);
+  }
+
+  async remove(keyArray: StorageKey): Promise<void> {
+    this.cache.delete(getKey(keyArray));
+
+    try {
+      await fs.promises.unlink(this.getFilePath(keyArray));
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "ENOENT") throw error;
+    }
+  }
+
+  async loadRange(keyPrefix: StorageKey): Promise<Chunk[]> {
+    const dirPath = this.getFilePath(keyPrefix);
+    const cachedKeys = this.cachedKeys(keyPrefix);
+    const diskFiles = await walkdir(dirPath);
+    const diskKeys = diskFiles.map((fileName) => {
+      const key = getKey([path.relative(this.baseDirectory, fileName)]);
+      return key.slice(0, 2) + key.slice(3);
+    });
+    const allKeys = [...new Set([...cachedKeys, ...diskKeys])];
+
+    return Promise.all(
+      allKeys.map(async (keyString) => {
+        const key: StorageKey = keyString.split(path.sep);
+        const data = await this.load(key);
+        return { data, key };
+      }),
+    );
+  }
+
+  async removeRange(keyPrefix: StorageKey): Promise<void> {
+    for (const key of this.cachedKeys(keyPrefix)) {
+      this.cache.delete(key);
+    }
+
+    await fs.promises.rm(this.getFilePath(keyPrefix), { recursive: true, force: true });
+  }
+
+  private cachedKeys(keyPrefix: StorageKey): string[] {
+    const cacheKeyPrefixString = getKey(keyPrefix);
+    return [...this.cache.keys()].filter((key) => key.startsWith(cacheKeyPrefixString));
+  }
+
+  private getFilePath(keyArray: StorageKey): string {
+    const [firstKey, ...remainingKeys] = keyArray;
+    return path.join(this.baseDirectory, firstKey.slice(0, 2), firstKey.slice(2), ...remainingKeys);
+  }
+}
+
+function getKey(key: StorageKey): string {
+  return path.join(...key);
+}
+
+async function walkdir(dirPath: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+    const files = await Promise.all(
+      entries.map((entry) => {
+        const subpath = path.resolve(dirPath, entry.name);
+        return entry.isDirectory() ? walkdir(subpath) : subpath;
+      }),
+    );
+    return files.flat();
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/engine/src/notes.integration.test.ts
+++ b/packages/engine/src/notes.integration.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import type { DocumentId } from "@automerge/automerge-repo";
 import { Repo } from "@automerge/automerge-repo";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type CatalogDocument,
   createActorId,
@@ -18,6 +17,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 
 async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
   const markerPath = path.join(storagePath, "todu-catalog.id");

--- a/packages/engine/src/storage.ts
+++ b/packages/engine/src/storage.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import type { DocHandle, DocumentId } from "@automerge/automerge-repo/slim";
 import { Repo } from "@automerge/automerge-repo/slim";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import {
   type Actor,
   type BootstrapOwnerActor,
@@ -22,6 +21,7 @@ import {
   type TaskListDocument,
 } from "@todu/core";
 import { ensureAutomergeWasmInitialized } from "./automerge-init.js";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 
 // ============================================================================
 // Storage layer — Automerge repo + document management

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Repo } from "@automerge/automerge-repo";
-import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
 import {
   createActorId,
@@ -14,6 +13,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Todu } from "./index.js";
 import { createTodu } from "./index.js";
+import { NodeFSStorageAdapter } from "./nodefs-storage-adapter.js";
 
 async function readCatalogDocument(storagePath: string): Promise<CatalogDocument> {
   const markerPath = path.join(storagePath, "todu-catalog.id");

--- a/scripts/verify-cli-install-deprecations.mjs
+++ b/scripts/verify-cli-install-deprecations.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const deprecatedGlobPattern = /deprecated glob@10\.5\.0/i;
+const tempDir = mkdtempSync(path.join(tmpdir(), "todu-cli-install-"));
+const prefixDir = path.join(tempDir, "prefix");
+const workspaces = ["packages/core", "packages/engine", "packages/daemon", "packages/cli"];
+
+try {
+  for (const workspace of workspaces) {
+    const distPath = path.join(workspace, "dist", "index.js");
+    run("node", ["-e", `const fs=require('fs'); if (!fs.existsSync(${JSON.stringify(distPath)})) process.exit(1)`], {
+      failureMessage: `${distPath} is missing; run npm run build before verifying packed CLI install.`,
+    });
+  }
+
+  const tarballs = workspaces.map((workspace) => packWorkspace(workspace));
+  const install = run("npm", ["install", "-g", "--prefix", prefixDir, ...tarballs]);
+  if (deprecatedGlobPattern.test(install.combinedOutput)) {
+    throw new Error(`npm install emitted deprecated glob@10.5.0 warning:\n${install.combinedOutput}`);
+  }
+
+  console.log("CLI install verification passed: no glob@10.5.0 deprecation warning.");
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function packWorkspace(workspace) {
+  const pack = run("npm", ["pack", "--workspace", workspace, "--pack-destination", tempDir, "--json"]);
+  const packed = JSON.parse(pack.stdout.trim());
+  const filename = packed[0]?.filename;
+  if (typeof filename !== "string" || filename.length === 0) {
+    throw new Error(`Unable to determine packed tarball from npm pack output for ${workspace}: ${pack.stdout}`);
+  }
+  return path.join(tempDir, filename);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const combinedOutput = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  if (result.error) {
+    throw new Error(`${options.failureMessage ?? `Command failed: ${command}`}\n${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${options.failureMessage ?? `Command failed: ${command} ${args.join(" ")}`}\n${combinedOutput}`,
+    );
+  }
+
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    combinedOutput,
+  };
+}


### PR DESCRIPTION
## Summary

- Keep `@todu/cli` self-contained and daemon-capable.
- Replace `@automerge/automerge-repo-storage-nodefs` with an in-repo filesystem storage adapter so the CLI install path no longer pulls `rimraf -> glob@10.5.0`.
- Keep stable Automerge packages (`@automerge/automerge@3.2.6`, `@automerge/automerge-repo@2.5.6`) and do not use alpha releases.
- Add packed local package install verification for the `glob@10.5.0` warning in CI and release publish flow.

## Dependency source

Fresh `npm install -g @todu/cli@latest` emitted the `glob@10.5.0` warning before this change:

```text
@todu/cli@0.23.2
└─ @todu/daemon@0.23.2
   └─ @todu/engine@0.23.2
      └─ @automerge/automerge-repo-storage-nodefs@2.5.6
         └─ rimraf@5.0.10
            └─ glob@10.5.0
```

The newer Automerge repo/storage packages that remove these paths are only published under `next`/alpha, so this PR avoids them. The existing `uuid@9.0.1` warning comes from stable `@automerge/automerge-repo@2.5.6`; that warning is intentionally left as upstream-blocked until Automerge publishes a stable repo release that removes it.

## Verification

- `make pre-pr`
- `npm run verify:cli-install`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- push hook: `npm test`

Task: #task-fe1b2813