### PR TITLE
Make release skill infer changesets

### DIFF
--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -10,7 +10,7 @@ Todu has two release paths:
 1. **NPM package releases** use Changesets and independent package versions.
 2. **Desktop/standalone binary GitHub releases** use the tag-based `Release` workflow.
 
-Prefer the Changesets npm flow when the user wants to publish packages like `@todu/tui`, `@todu/cli`, `@todu/core`, `@todu/engine`, `@todu/daemon`, or `@todu/recurring-worker`.
+Prefer the Changesets npm flow when the user wants to publish packages like `@todu/tui`, `@todu/cli`, `@todu/core`, `@todu/engine`, or `@todu/daemon`. The assistant owns Changesets details; do not make the user choose packages unless the inferred scope is ambiguous or risky.
 
 ## NPM package release flow
 
@@ -27,23 +27,26 @@ npm test
 make version-check
 ```
 
-### 2. Add a changeset in feature PRs
+### 2. Infer and add changesets
 
-If the current PR changes an npm package and does not already include a changeset:
+If the current PR changes a published npm package and does not already include a changeset, infer the package list and create the changeset yourself:
 
 ```bash
-npm run changeset
+npm run changeset:infer -- --bump patch --summary "Release updated package."
 ```
 
-Select only changed packages. For a TUI-only change, select only `@todu/tui`.
+Rules:
 
-Choose semantic bumps:
+- Use `patch` for fixes, small UI changes, docs shipped with a package, and internal implementation changes.
+- Use `minor` for new backwards-compatible user-facing features.
+- Use `major` only for intentional breaking API or CLI behavior changes, and ask first.
+- If multiple published packages changed, include all changed published packages.
+- If a core/engine change requires dependent package changes, include the affected dependents too.
+- Skip private or ignored workspaces such as `@todu/electron` and `@todu/recurring-worker`.
+- If the helper output is clearly wrong, edit the generated `.changeset/*.md` before committing.
+- Ask the user only when package impact or bump level is genuinely ambiguous.
 
-- `patch` for fixes and small internal changes.
-- `minor` for backwards-compatible features.
-- `major` for breaking changes.
-
-Commit the generated `.changeset/*.md` file with the PR.
+Commit the generated `.changeset/*.md` file with the PR. Do not tell the user they need to understand or run Changesets manually.
 
 ### 3. Version PR
 
@@ -82,7 +85,8 @@ The tag-based `Release` workflow no longer publishes npm packages; npm publishin
 
 - Never force push or use `--force` flags.
 - Never publish without user approval.
-- For package releases, do not bump unchanged packages manually.
+- For package releases, infer and add the needed changeset; do not ask the user to manage Changesets details.
+- Do not bump unchanged packages manually.
 - If anything fails, stop and report; do not retry blindly.
 
 See `docs/release.md` for full details.

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cat >&2 <<'MSG'
-The legacy lockstep npm release script has been retired.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
 
-NPM package releases now use Changesets:
-
-  npm run changeset          # add package release intent in a feature PR
-  npm run version-packages   # apply pending changesets in a version PR
-  npm run release-packages   # publish changed packages from CI
-
-See docs/release.md and .pi/skills/release/SKILL.md.
-
-Desktop/binary GitHub releases still use the tag-based Release workflow, but npm publishing is owned by Changesets.
-MSG
-
-exit 1
+npm run changeset:infer -- "$@"

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,13 +11,13 @@ Use Changesets for published npm packages such as `@todu/core`, `@todu/engine`, 
 
 ### Add a changeset in feature PRs
 
-When a PR should publish an npm package, add a changeset before the PR is merged:
+When a PR should publish an npm package, the release flow should infer and add the changeset. Humans should not need to know Changesets details for normal work.
 
 ```bash
-npm run changeset
+npm run changeset:infer -- --bump patch --summary "Release updated package."
 ```
 
-Select only the published packages changed by the PR. For example, a TUI-only change should select only `@todu/tui`.
+The helper detects changed published workspace packages and skips private/ignored workspaces. For example, a TUI-only change creates a changeset for only `@todu/tui`.
 
 Choose the semantic bump for each selected package:
 
@@ -25,7 +25,7 @@ Choose the semantic bump for each selected package:
 - `minor` for new backwards-compatible functionality.
 - `major` for breaking changes.
 
-Commit the generated `.changeset/*.md` file with the PR.
+If the inferred package list or bump is wrong, adjust it before committing. Commit the generated `.changeset/*.md` file with the PR.
 
 ### Version PR
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:storage-stability": "node scripts/test-storage-stability.mjs",
     "test:watch": "vitest",
     "changeset": "changeset",
+    "changeset:infer": "node scripts/create-inferred-changeset.mjs",
     "version-packages": "changeset version && node scripts/generate-package-versions.mjs && npm install --package-lock-only --ignore-scripts",
     "release-packages": "npm run build && changeset publish",
     "postinstall": "node scripts/patch-automerge-repo.mjs",

--- a/scripts/create-inferred-changeset.mjs
+++ b/scripts/create-inferred-changeset.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = new URL("..", import.meta.url).pathname;
+
+function parseArgs(argv) {
+  const options = {
+    base: "origin/main",
+    bump: "patch",
+    dryRun: false,
+    summary: "Release updated packages.",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") {
+      options.base = argv[++index];
+    } else if (arg === "--bump") {
+      options.bump = argv[++index];
+    } else if (arg === "--summary") {
+      options.summary = argv[++index];
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      printHelp();
+      process.exit(1);
+    }
+  }
+
+  if (!["patch", "minor", "major"].includes(options.bump)) {
+    console.error(`Invalid bump: ${options.bump}`);
+    process.exit(1);
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Create a Changesets entry from changed workspace package files.
+
+Usage:
+  node scripts/create-inferred-changeset.mjs [--base origin/main] [--bump patch|minor|major] [--summary "..."] [--dry-run]
+
+Defaults to a patch bump for changed published packages. Private and ignored workspaces are skipped.`);
+}
+
+function runGit(args) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    return null;
+  }
+
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function getIgnoredPackages() {
+  const configPath = join(repoRoot, ".changeset/config.json");
+  if (!existsSync(configPath)) {
+    return new Set();
+  }
+
+  const config = readJson(configPath);
+  return new Set(config.ignore ?? []);
+}
+
+function getWorkspacePackages() {
+  const ignored = getIgnoredPackages();
+  const packagesDir = join(repoRoot, "packages");
+
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const packageDir = join(packagesDir, entry.name);
+      const packageJsonPath = join(packageDir, "package.json");
+      if (!existsSync(packageJsonPath)) {
+        return null;
+      }
+
+      const packageJson = readJson(packageJsonPath);
+      return {
+        name: packageJson.name,
+        dir: relative(repoRoot, packageDir).replaceAll("\\", "/"),
+        private: packageJson.private === true,
+        ignored: ignored.has(packageJson.name),
+      };
+    })
+    .filter(Boolean);
+}
+
+function getChangedFiles(base) {
+  const files = new Set();
+  const diffs = [
+    ["diff", "--name-only", "--diff-filter=ACMRTUXB", `${base}...HEAD`],
+    ["diff", "--name-only", "--diff-filter=ACMRTUXB"],
+    ["diff", "--cached", "--name-only", "--diff-filter=ACMRTUXB"],
+    ["ls-files", "--others", "--exclude-standard"],
+  ];
+
+  for (const args of diffs) {
+    for (const file of runGit(args) ?? []) {
+      files.add(file);
+    }
+  }
+
+  return [...files];
+}
+
+function getExistingChangesetPackages() {
+  const changesetDir = join(repoRoot, ".changeset");
+  if (!existsSync(changesetDir)) {
+    return new Set();
+  }
+
+  const packages = new Set();
+  for (const entry of readdirSync(changesetDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "README.md") {
+      continue;
+    }
+
+    const content = readFileSync(join(changesetDir, entry.name), "utf8");
+    const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      continue;
+    }
+
+    for (const match of frontmatter[1].matchAll(/["']([^"']+)["']:\s+(patch|minor|major)/g)) {
+      packages.add(match[1]);
+    }
+  }
+
+  return packages;
+}
+
+function createChangeset(packages, bump, summary) {
+  const body = [
+    "---",
+    ...packages.map((packageName) => `"${packageName}": ${bump}`),
+    "---",
+    "",
+    summary,
+    "",
+  ].join("\n");
+
+  const name = `inferred-${Date.now().toString(36)}.md`;
+  return {
+    path: join(repoRoot, ".changeset", name),
+    body,
+  };
+}
+
+const options = parseArgs(process.argv.slice(2));
+const packages = getWorkspacePackages();
+const changedFiles = getChangedFiles(options.base);
+const existingChangesetPackages = getExistingChangesetPackages();
+const changedPackages = packages.filter((workspacePackage) =>
+  changedFiles.some((file) => file === workspacePackage.dir || file.startsWith(`${workspacePackage.dir}/`)),
+);
+const publishablePackages = changedPackages.filter(
+  (workspacePackage) => !workspacePackage.private && !workspacePackage.ignored,
+);
+const packagesNeedingChangeset = publishablePackages
+  .map((workspacePackage) => workspacePackage.name)
+  .filter((packageName) => !existingChangesetPackages.has(packageName))
+  .sort();
+
+if (changedFiles.length === 0) {
+  console.error("No changed files found.");
+  process.exit(1);
+}
+
+if (changedPackages.length === 0) {
+  console.error("No changed workspace packages found.");
+  console.error("Changed files:");
+  for (const file of changedFiles) {
+    console.error(`- ${file}`);
+  }
+  process.exit(1);
+}
+
+const skippedPackages = changedPackages.filter(
+  (workspacePackage) => workspacePackage.private || workspacePackage.ignored,
+);
+if (skippedPackages.length > 0) {
+  console.error("Skipped private/ignored packages:");
+  for (const workspacePackage of skippedPackages) {
+    console.error(`- ${workspacePackage.name}`);
+  }
+}
+
+if (packagesNeedingChangeset.length === 0) {
+  console.log("No new changeset needed. Changed publishable packages already have changesets or are ignored/private.");
+  process.exit(0);
+}
+
+const changeset = createChangeset(packagesNeedingChangeset, options.bump, options.summary);
+
+if (options.dryRun) {
+  console.log(`Would create ${relative(repoRoot, changeset.path)}:`);
+  console.log(changeset.body);
+  process.exit(0);
+}
+
+mkdirSync(join(repoRoot, ".changeset"), { recursive: true });
+writeFileSync(changeset.path, changeset.body);
+
+console.log(`Created ${relative(repoRoot, changeset.path)} for:`);
+for (const packageName of packagesNeedingChangeset) {
+  console.log(`- ${packageName}: ${options.bump}`);
+}
+console.log(`Summary: ${options.summary}`);


### PR DESCRIPTION
## Summary
- update the release skill so the assistant owns package/bump inference instead of asking the user to manage Changesets
- add npm run changeset:infer to generate a changeset from changed published workspace packages
- replace the retired release skill script with a wrapper around the inference helper
- update release docs to describe the inferred flow

## Verification
- npm run changeset:infer -- --dry-run
- temporary TUI file change + npm run changeset:infer -- --dry-run --summary "Test inferred release."
- npm run check:ci
- npm test