### PR TITLE
Make release command infer package changes

### DIFF
--- a/.pi/skills/release/SKILL.md
+++ b/.pi/skills/release/SKILL.md
@@ -14,41 +14,48 @@ Prefer the Changesets npm flow when the user wants to publish packages like `@to
 
 ## NPM package release flow
 
-### 1. Pre-flight
+When the user says "release", do the release work. Do not ask them to manage Changesets.
 
-Verify readiness and stop if any check fails:
+### 1. Inspect changed packages
+
+Fetch the release base and run the inference helper:
 
 ```bash
-git branch --show-current          # normally main, unless adding a changeset in a feature branch
-git status --short                 # must be clean unless intentionally adding a changeset
 git fetch origin main
+npm run release -- --bump patch --summary "Release updated package."
+```
+
+The helper checks what changed and creates the needed changeset:
+
+- On feature branches, it compares the branch with `origin/main` plus working tree changes.
+- On `main`, it compares each package with the commit where that package's current version was set, so it can still find package changes that landed without a changeset.
+- It skips private or ignored workspaces such as `@todu/electron` and `@todu/recurring-worker`.
+
+### 2. Pick the bump yourself
+
+Default to `patch` unless evidence says otherwise:
+
+- `patch` for fixes, small UI changes, docs shipped with a package, and internal implementation changes.
+- `minor` for new backwards-compatible user-facing features.
+- `major` only for intentional breaking API or CLI behavior changes; ask before using it.
+
+If multiple published packages changed, include all changed published packages. If a core/engine change requires dependent package changes, include the affected dependents too. If the helper output is clearly wrong, edit the generated `.changeset/*.md` before committing.
+
+Ask the user only when package impact, bump level, or publish timing is genuinely ambiguous.
+
+### 3. Verify and commit
+
+After adding or confirming the changeset:
+
+```bash
 npm run check:ci
 npm test
 make version-check
 ```
 
-### 2. Infer and add changesets
+Commit the generated `.changeset/*.md` file with the package changes. If the release is being done directly from `main`, open a short PR containing the inferred changeset.
 
-If the current PR changes a published npm package and does not already include a changeset, infer the package list and create the changeset yourself:
-
-```bash
-npm run changeset:infer -- --bump patch --summary "Release updated package."
-```
-
-Rules:
-
-- Use `patch` for fixes, small UI changes, docs shipped with a package, and internal implementation changes.
-- Use `minor` for new backwards-compatible user-facing features.
-- Use `major` only for intentional breaking API or CLI behavior changes, and ask first.
-- If multiple published packages changed, include all changed published packages.
-- If a core/engine change requires dependent package changes, include the affected dependents too.
-- Skip private or ignored workspaces such as `@todu/electron` and `@todu/recurring-worker`.
-- If the helper output is clearly wrong, edit the generated `.changeset/*.md` before committing.
-- Ask the user only when package impact or bump level is genuinely ambiguous.
-
-Commit the generated `.changeset/*.md` file with the PR. Do not tell the user they need to understand or run Changesets manually.
-
-### 3. Version PR
+### 4. Version PR
 
 After changesets land on `main`, the `NPM Release` workflow opens or updates a Changesets version PR. That PR runs:
 
@@ -60,7 +67,7 @@ It bumps only packages named by changesets, updates changelogs, regenerates pack
 
 Review and merge the version PR when ready to publish.
 
-### 4. Publish
+### 5. Publish
 
 When the version PR lands on `main`, the `NPM Release` workflow runs:
 

--- a/.pi/skills/release/scripts/release.sh
+++ b/.pi/skills/release/scripts/release.sh
@@ -4,4 +4,5 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-npm run changeset:infer -- "$@"
+git fetch origin main
+npm run release -- "$@"

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,23 +9,25 @@ Todu uses two release paths:
 
 Use Changesets for published npm packages such as `@todu/core`, `@todu/engine`, `@todu/daemon`, `@todu/cli`, and `@todu/tui`.
 
-### Add a changeset in feature PRs
+### Release command infers changesets
 
-When a PR should publish an npm package, the release flow should infer and add the changeset. Humans should not need to know Changesets details for normal work.
+For normal package releases, say "release" and let the assistant infer the Changesets details.
+
+The command behind that flow is:
 
 ```bash
-npm run changeset:infer -- --bump patch --summary "Release updated package."
+npm run release -- --bump patch --summary "Release updated package."
 ```
 
 The helper detects changed published workspace packages and skips private/ignored workspaces. For example, a TUI-only change creates a changeset for only `@todu/tui`.
 
-Choose the semantic bump for each selected package:
+Default bump selection:
 
 - `patch` for fixes and small internal changes.
 - `minor` for new backwards-compatible functionality.
 - `major` for breaking changes.
 
-If the inferred package list or bump is wrong, adjust it before committing. Commit the generated `.changeset/*.md` file with the PR.
+If the inferred package list or bump is wrong, the assistant adjusts it before committing. Commit the generated `.changeset/*.md` file with the PR.
 
 ### Version PR
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:watch": "vitest",
     "changeset": "changeset",
     "changeset:infer": "node scripts/create-inferred-changeset.mjs",
+    "release": "node scripts/create-inferred-changeset.mjs",
     "version-packages": "changeset version && node scripts/generate-package-versions.mjs && npm install --package-lock-only --ignore-scripts",
     "release-packages": "npm run build && changeset publish",
     "postinstall": "node scripts/patch-automerge-repo.mjs",

--- a/scripts/create-inferred-changeset.mjs
+++ b/scripts/create-inferred-changeset.mjs
@@ -7,7 +7,7 @@ const repoRoot = new URL("..", import.meta.url).pathname;
 
 function parseArgs(argv) {
   const options = {
-    base: "origin/main",
+    base: "auto",
     bump: "patch",
     dryRun: false,
     summary: "Release updated packages.",
@@ -45,19 +45,25 @@ function printHelp() {
   console.log(`Create a Changesets entry from changed workspace package files.
 
 Usage:
-  node scripts/create-inferred-changeset.mjs [--base origin/main] [--bump patch|minor|major] [--summary "..."] [--dry-run]
+  node scripts/create-inferred-changeset.mjs [--base auto|origin/main|<ref>] [--bump patch|minor|major] [--summary "..."] [--dry-run]
 
-Defaults to a patch bump for changed published packages. Private and ignored workspaces are skipped.`);
+Default behavior:
+  - On feature branches, compare with origin/main plus working tree changes.
+  - On main, compare each package with the commit where its current package version was set.
+  - Private and ignored workspaces are skipped.`);
 }
 
-function runGit(args) {
-  const result = spawnSync("git", args, {
+function run(args) {
+  return spawnSync(args[0], args.slice(1), {
     cwd: repoRoot,
     encoding: "utf8",
   });
+}
 
+function gitLines(args) {
+  const result = run(["git", ...args]);
   if (result.status !== 0) {
-    return null;
+    return [];
   }
 
   return result.stdout
@@ -66,8 +72,16 @@ function runGit(args) {
     .filter(Boolean);
 }
 
+function gitLine(args) {
+  return gitLines(args)[0] ?? null;
+}
+
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function getCurrentBranch() {
+  return gitLine(["branch", "--show-current"]);
 }
 
 function getIgnoredPackages() {
@@ -104,22 +118,68 @@ function getWorkspacePackages() {
     .filter(Boolean);
 }
 
-function getChangedFiles(base) {
-  const files = new Set();
-  const diffs = [
-    ["diff", "--name-only", "--diff-filter=ACMRTUXB", `${base}...HEAD`],
-    ["diff", "--name-only", "--diff-filter=ACMRTUXB"],
-    ["diff", "--cached", "--name-only", "--diff-filter=ACMRTUXB"],
-    ["ls-files", "--others", "--exclude-standard"],
+function getWorkingTreeFiles() {
+  return [
+    ...gitLines(["diff", "--name-only", "--diff-filter=ACMRTUXB"]),
+    ...gitLines(["diff", "--cached", "--name-only", "--diff-filter=ACMRTUXB"]),
+    ...gitLines(["ls-files", "--others", "--exclude-standard"]),
   ];
+}
 
-  for (const args of diffs) {
-    for (const file of runGit(args) ?? []) {
+function getChangedFilesFromBase(base) {
+  return [
+    ...gitLines(["diff", "--name-only", "--diff-filter=ACMRTUXB", `${base}...HEAD`]),
+    ...getWorkingTreeFiles(),
+  ];
+}
+
+function getLastVersionCommit(workspacePackage) {
+  return gitLine([
+    "log",
+    "-G",
+    '"version"\\s*:',
+    "--format=%H",
+    "-n",
+    "1",
+    "--",
+    `${workspacePackage.dir}/package.json`,
+  ]);
+}
+
+function getChangedFilesOnMain(packages) {
+  const files = new Set(getWorkingTreeFiles());
+
+  for (const workspacePackage of packages) {
+    const versionCommit = getLastVersionCommit(workspacePackage);
+    if (!versionCommit) {
+      continue;
+    }
+
+    for (const file of gitLines([
+      "diff",
+      "--name-only",
+      "--diff-filter=ACMRTUXB",
+      `${versionCommit}..HEAD`,
+      "--",
+      workspacePackage.dir,
+    ])) {
       files.add(file);
     }
   }
 
   return [...files];
+}
+
+function getChangedFiles(base, packages) {
+  if (base !== "auto") {
+    return getChangedFilesFromBase(base);
+  }
+
+  if (getCurrentBranch() === "main") {
+    return getChangedFilesOnMain(packages);
+  }
+
+  return getChangedFilesFromBase("origin/main");
 }
 
 function getExistingChangesetPackages() {
@@ -167,7 +227,7 @@ function createChangeset(packages, bump, summary) {
 
 const options = parseArgs(process.argv.slice(2));
 const packages = getWorkspacePackages();
-const changedFiles = getChangedFiles(options.base);
+const changedFiles = [...new Set(getChangedFiles(options.base, packages))];
 const existingChangesetPackages = getExistingChangesetPackages();
 const changedPackages = packages.filter((workspacePackage) =>
   changedFiles.some((file) => file === workspacePackage.dir || file.startsWith(`${workspacePackage.dir}/`)),
@@ -181,26 +241,26 @@ const packagesNeedingChangeset = publishablePackages
   .sort();
 
 if (changedFiles.length === 0) {
-  console.error("No changed files found.");
-  process.exit(1);
+  console.log("No changed files found.");
+  process.exit(0);
 }
 
 if (changedPackages.length === 0) {
-  console.error("No changed workspace packages found.");
-  console.error("Changed files:");
+  console.log("No changed workspace packages found.");
+  console.log("Changed files:");
   for (const file of changedFiles) {
-    console.error(`- ${file}`);
+    console.log(`- ${file}`);
   }
-  process.exit(1);
+  process.exit(0);
 }
 
 const skippedPackages = changedPackages.filter(
   (workspacePackage) => workspacePackage.private || workspacePackage.ignored,
 );
 if (skippedPackages.length > 0) {
-  console.error("Skipped private/ignored packages:");
+  console.log("Skipped private/ignored packages:");
   for (const workspacePackage of skippedPackages) {
-    console.error(`- ${workspacePackage.name}`);
+    console.log(`- ${workspacePackage.name}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- make `npm run release` infer changed published packages and create the needed changeset
- update the release skill so saying "release" means inspect changes, choose package scope, and add the changeset without user involvement
- improve inference on `main` by comparing each package against the commit where its current version was set
- keep private/ignored packages skipped

## Verification
- `npm run release -- --dry-run`
- temporary TUI file change + `npm run release -- --dry-run --summary "Test inferred release."`
- `npm run check:ci`
- `npm test`
