### PR TITLE
Add TUI daemon connection lifecycle

### DIFF
--- a/.changeset/inferred-mqzu2g37.md
+++ b/.changeset/inferred-mqzu2g37.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add daemon connection lifecycle to the TUI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13347,9 +13347,11 @@
       "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
+        "@todu/core": "*",
         "ink": "^7.1.0",
         "react": "^19.2.0",
-        "react-devtools-core": "^7.0.1"
+        "react-devtools-core": "^7.0.1",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "todu-tui": "dist/index.js"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -19,9 +19,11 @@
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
+    "@todu/core": "*",
     "ink": "^7.1.0",
     "react": "^19.2.0",
-    "react-devtools-core": "^7.0.1"
+    "react-devtools-core": "^7.0.1",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "ink-testing-library": "^4.0.0"

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -1,12 +1,44 @@
 import { render } from "ink-testing-library";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  DaemonConnection,
+  DaemonConnectionListener,
+  DaemonConnectionSnapshot,
+} from "../daemon/connection.js";
 import { App } from "./App.js";
 
-describe("App", () => {
-  it("renders the initial TUI shell", () => {
-    const { lastFrame } = render(<App />);
+function createFakeConnection(snapshot: DaemonConnectionSnapshot): DaemonConnection {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    getSnapshot: () => snapshot,
+    subscribe: (listener: DaemonConnectionListener) => {
+      listener(snapshot);
+      return vi.fn();
+    },
+    request: vi.fn(),
+  };
+}
 
-    expect(lastFrame()).toContain("todu TUI coming online");
+describe("App", () => {
+  it("renders the initial TUI shell with daemon connection guidance", () => {
+    const connection = createFakeConnection({
+      state: "failed",
+      socketPath: "/tmp/todu.sock",
+      hello: null,
+      error: {
+        code: "DAEMON_UNAVAILABLE",
+        message: "Daemon unavailable at socket: /tmp/todu.sock",
+      },
+      reconnectAttempt: 1,
+      reconnectDelayMs: 250,
+    });
+
+    const { lastFrame } = render(<App connection={connection} />);
+
+    expect(lastFrame()).toContain("todu TUI");
+    expect(lastFrame()).toContain("Daemon unavailable");
+    expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("Press q or Ctrl+C to quit.");
   });
 });

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -1,8 +1,25 @@
 import { Box, Text, useApp, useInput } from "ink";
-import type { JSX } from "react";
+import { type JSX, useEffect, useMemo, useState } from "react";
+import { ConnectionState } from "../components/ConnectionState.js";
+import {
+  createDaemonConnection,
+  type DaemonConnection,
+  type DaemonConnectionSnapshot,
+} from "../daemon/connection.js";
 
-export function App(): JSX.Element {
+export interface AppProps {
+  connection?: DaemonConnection;
+}
+
+export function App({ connection: providedConnection }: AppProps = {}): JSX.Element {
   const { exit } = useApp();
+  const connection = useMemo(
+    () => providedConnection ?? createDaemonConnection(),
+    [providedConnection],
+  );
+  const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
+    connection.getSnapshot(),
+  );
 
   useInput((input, key) => {
     if (input === "q" || (key.ctrl && input === "c")) {
@@ -10,11 +27,22 @@ export function App(): JSX.Element {
     }
   });
 
+  useEffect(() => {
+    const unsubscribe = connection.subscribe(setConnectionSnapshot);
+    connection.start();
+
+    return () => {
+      unsubscribe();
+      connection.stop();
+    };
+  }, [connection]);
+
   return (
     <Box flexDirection="column" paddingX={1} paddingY={1}>
       <Text color="cyan" bold>
-        todu TUI coming online
+        todu TUI
       </Text>
+      <ConnectionState connection={connectionSnapshot} />
       <Text color="gray">Press q or Ctrl+C to quit.</Text>
     </Box>
   );

--- a/packages/tui/src/components/ConnectionState.tsx
+++ b/packages/tui/src/components/ConnectionState.tsx
@@ -1,0 +1,49 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+
+export interface ConnectionStateProps {
+  connection: DaemonConnectionSnapshot;
+}
+
+export function ConnectionState({ connection }: ConnectionStateProps): JSX.Element {
+  if (connection.state === "connected") {
+    return (
+      <Box flexDirection="column">
+        <Text color="green">Daemon connected</Text>
+        <Text color="gray">Handshake: daemon.hello OK</Text>
+        {connection.hello?.daemonVersion ? (
+          <Text color="gray">Daemon version: {connection.hello.daemonVersion}</Text>
+        ) : null}
+      </Box>
+    );
+  }
+
+  if (connection.state === "connecting") {
+    return <Text color="yellow">Connecting to daemon at {connection.socketPath}…</Text>;
+  }
+
+  if (connection.state === "reconnecting") {
+    return (
+      <Box flexDirection="column">
+        <Text color="yellow">Daemon disconnected; reconnecting…</Text>
+        <Text color="gray">
+          Attempt {connection.reconnectAttempt} in {connection.reconnectDelayMs ?? 0}ms
+        </Text>
+      </Box>
+    );
+  }
+
+  if (connection.state === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Daemon unavailable</Text>
+        <Text color="gray">Start it with: todu daemon start</Text>
+        <Text color="gray">Socket: {connection.socketPath}</Text>
+        {connection.error ? <Text color="gray">Reason: {connection.error.message}</Text> : null}
+      </Box>
+    );
+  }
+
+  return <Text color="gray">Daemon disconnected</Text>;
+}

--- a/packages/tui/src/daemon/connection.test.ts
+++ b/packages/tui/src/daemon/connection.test.ts
@@ -1,0 +1,197 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDaemonConnection,
+  DAEMON_PROTOCOL_VERSION,
+  type DaemonConnectionSnapshot,
+  type DaemonSocket,
+} from "./connection.js";
+
+class FakeSocket extends EventEmitter implements DaemonSocket {
+  readonly writes: string[] = [];
+  destroyed = false;
+
+  setEncoding(_encoding: BufferEncoding): this {
+    return this;
+  }
+
+  write(payload: string): boolean {
+    this.writes.push(payload);
+    return true;
+  }
+
+  end(): this {
+    return this;
+  }
+
+  destroy(_error?: Error): this {
+    this.destroyed = true;
+    return this;
+  }
+}
+
+function readLastRequest(socket: FakeSocket): { id: string; method: string } {
+  const payload = socket.writes.at(-1);
+  if (!payload) {
+    throw new Error("Expected socket write");
+  }
+
+  const parsed = JSON.parse(payload.trim()) as Record<string, unknown>;
+  if (typeof parsed.id !== "string" || typeof parsed.method !== "string") {
+    throw new Error("Expected request id and method");
+  }
+
+  return { id: parsed.id, method: parsed.method };
+}
+
+function sendSuccess(socket: FakeSocket, id: string, result: Record<string, unknown>): void {
+  socket.emit("data", `${JSON.stringify({ id, result })}\n`);
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("TUI daemon connection", () => {
+  it("connects and runs daemon.hello", async () => {
+    const socket = new FakeSocket();
+    const states: DaemonConnectionSnapshot[] = [];
+    const connection = createDaemonConnection({
+      socketPath: "/tmp/todu.sock",
+      connect: () => socket,
+      requestIdFactory: () => "hello-1",
+    });
+
+    connection.subscribe((snapshot) => states.push(snapshot));
+    connection.start();
+    socket.emit("connect");
+    await flushPromises();
+
+    const helloRequest = readLastRequest(socket);
+    expect(helloRequest.method).toBe("daemon.hello");
+
+    sendSuccess(socket, helloRequest.id, {
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      daemonVersion: "1.2.3",
+    });
+    await flushPromises();
+
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "connected",
+      hello: { protocolVersion: DAEMON_PROTOCOL_VERSION, daemonVersion: "1.2.3" },
+    });
+    expect(states.map((state) => state.state)).toContain("connecting");
+
+    connection.stop();
+  });
+
+  it("reports failed state and schedules capped reconnect after connect failure", async () => {
+    vi.useFakeTimers();
+    const sockets = [new FakeSocket(), new FakeSocket(), new FakeSocket()];
+    let connectCount = 0;
+    const states: DaemonConnectionSnapshot[] = [];
+    const connection = createDaemonConnection({
+      socketPath: "/tmp/missing.sock",
+      reconnectBackoffMs: [10, 20],
+      connect: () => sockets[connectCount++] ?? new FakeSocket(),
+    });
+
+    connection.subscribe((snapshot) => states.push(snapshot));
+    connection.start();
+    sockets[0].emit("error", Object.assign(new Error("missing socket"), { code: "ENOENT" }));
+    await flushPromises();
+
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "failed",
+      reconnectAttempt: 1,
+      reconnectDelayMs: 10,
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    sockets[1].emit("error", Object.assign(new Error("still missing"), { code: "ENOENT" }));
+    await flushPromises();
+
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "failed",
+      reconnectAttempt: 2,
+      reconnectDelayMs: 20,
+    });
+
+    await vi.advanceTimersByTimeAsync(20);
+    sockets[2].emit("error", Object.assign(new Error("still missing"), { code: "ENOENT" }));
+    await flushPromises();
+
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "failed",
+      reconnectAttempt: 3,
+      reconnectDelayMs: 20,
+    });
+    expect(states.some((state) => state.error?.message.includes("Daemon unavailable"))).toBe(true);
+
+    connection.stop();
+    vi.useRealTimers();
+  });
+
+  it("times out daemon.hello requests", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const connection = createDaemonConnection({
+      socketPath: "/tmp/todu.sock",
+      connect: () => socket,
+      requestTimeoutMs: 25,
+      reconnectBackoffMs: [100],
+    });
+
+    connection.start();
+    socket.emit("connect");
+    await flushPromises();
+
+    expect(readLastRequest(socket).method).toBe("daemon.hello");
+
+    await vi.advanceTimersByTimeAsync(25);
+    await flushPromises();
+
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "failed",
+      error: { code: "TIMEOUT" },
+      reconnectDelayMs: 100,
+    });
+
+    connection.stop();
+    vi.useRealTimers();
+  });
+
+  it("transitions through disconnected to reconnecting when a connected socket closes", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const states: DaemonConnectionSnapshot[] = [];
+    const connection = createDaemonConnection({
+      socketPath: "/tmp/todu.sock",
+      connect: () => socket,
+      reconnectBackoffMs: [50],
+      requestIdFactory: () => "hello-close",
+    });
+
+    connection.subscribe((snapshot) => states.push(snapshot));
+    connection.start();
+    socket.emit("connect");
+    await flushPromises();
+    sendSuccess(socket, readLastRequest(socket).id, { protocolVersion: DAEMON_PROTOCOL_VERSION });
+    await flushPromises();
+
+    socket.emit("close");
+    await flushPromises();
+
+    expect(states.map((state) => state.state)).toEqual(
+      expect.arrayContaining(["connected", "disconnected", "reconnecting"]),
+    );
+    expect(connection.getSnapshot()).toMatchObject({
+      state: "reconnecting",
+      reconnectDelayMs: 50,
+    });
+
+    connection.stop();
+    vi.useRealTimers();
+  });
+});

--- a/packages/tui/src/daemon/connection.ts
+++ b/packages/tui/src/daemon/connection.ts
@@ -1,0 +1,727 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import {
+  normalizeConfigPaths,
+  resolveConfigPath,
+  resolveDataDir,
+  type ToduFileConfig,
+} from "@todu/core";
+import { parse } from "yaml";
+
+export const DAEMON_PROTOCOL_VERSION = "1";
+export const DEFAULT_TUI_DAEMON_CONNECT_TIMEOUT_MS = 2_000;
+export const DEFAULT_TUI_DAEMON_REQUEST_TIMEOUT_MS = 10_000;
+export const DEFAULT_TUI_RECONNECT_BACKOFF_MS = [250, 500, 1_000, 2_000] as const;
+
+export type DaemonConnectionStateName =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "failed";
+
+export interface DaemonConnectionError {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export type DaemonConnectionResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: DaemonConnectionError };
+
+export interface DaemonHelloResult {
+  protocolVersion: string;
+  daemonVersion?: string;
+  role?: string;
+  capabilities?: unknown;
+  catalog?: unknown;
+}
+
+export interface DaemonConnectionSnapshot {
+  state: DaemonConnectionStateName;
+  socketPath: string;
+  hello: DaemonHelloResult | null;
+  error: DaemonConnectionError | null;
+  reconnectAttempt: number;
+  reconnectDelayMs: number | null;
+}
+
+export type DaemonConnectionListener = (snapshot: DaemonConnectionSnapshot) => void;
+
+export interface DaemonConnection {
+  start(): void;
+  stop(): void;
+  getSnapshot(): DaemonConnectionSnapshot;
+  subscribe(listener: DaemonConnectionListener): () => void;
+  request<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { timeoutMs?: number },
+  ): Promise<DaemonConnectionResult<T>>;
+}
+
+export interface DaemonSocket {
+  setEncoding(encoding: BufferEncoding): this;
+  on(event: "connect", listener: () => void): this;
+  on(event: "data", listener: (chunk: string) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "close", listener: () => void): this;
+  once(event: "connect", listener: () => void): this;
+  once(event: "error", listener: (error: Error) => void): this;
+  off(event: "connect", listener: () => void): this;
+  off(event: "data", listener: (chunk: string) => void): this;
+  off(event: "error", listener: (error: Error) => void): this;
+  off(event: "close", listener: () => void): this;
+  write(payload: string): boolean;
+  end(): this;
+  destroy(error?: Error): this;
+}
+
+export interface DaemonConnectionOptions {
+  socketPath?: string;
+  connectTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  reconnectBackoffMs?: readonly number[];
+  connect?: (socketPath: string) => DaemonSocket;
+  requestIdFactory?: () => string;
+}
+
+interface PendingRequest {
+  id: string;
+  method: string;
+  resolve: (result: DaemonConnectionResult<unknown>) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface ActiveConnection {
+  socket: DaemonSocket;
+  pending: Map<string, PendingRequest>;
+  buffer: string;
+  closed: boolean;
+  dispose(): void;
+}
+
+interface ProtocolRequestFrame {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+interface ProtocolSuccessFrame {
+  id: string;
+  result: unknown;
+}
+
+interface ProtocolErrorFrame {
+  id: string | null;
+  error: DaemonConnectionError;
+}
+
+export function createDaemonConnection(options: DaemonConnectionOptions = {}): DaemonConnection {
+  return new TuiDaemonConnection(options);
+}
+
+export function resolveTuiDaemonSocketPath(): string {
+  const socketOverride = process.env.TODU_DAEMON_SOCKET;
+  if (socketOverride && socketOverride.trim().length > 0) {
+    return path.resolve(socketOverride);
+  }
+
+  const configPath = resolveConfigPath();
+  const config = loadTuiFileConfig(configPath);
+  const dataDir = resolveDataDir(configPath, config, { env: process.env });
+  return path.join(dataDir, "daemon.sock");
+}
+
+function loadTuiFileConfig(configPath: string): ToduFileConfig {
+  try {
+    const content = fs.readFileSync(configPath, "utf-8");
+    return normalizeConfigPaths((parse(content) as ToduFileConfig) ?? {}, configPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {};
+    }
+
+    throw error;
+  }
+}
+
+class TuiDaemonConnection implements DaemonConnection {
+  private readonly socketPath: string;
+  private readonly connectTimeoutMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly reconnectBackoffMs: readonly number[];
+  private readonly connect: (socketPath: string) => DaemonSocket;
+  private readonly requestIdFactory: () => string;
+  private readonly listeners = new Set<DaemonConnectionListener>();
+
+  private running = false;
+  private connecting = false;
+  private hasConnectedOnce = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private activeConnection: ActiveConnection | null = null;
+  private snapshot: DaemonConnectionSnapshot;
+
+  constructor(options: DaemonConnectionOptions) {
+    this.socketPath = options.socketPath ?? resolveTuiDaemonSocketPath();
+    this.connectTimeoutMs = normalizeTimeout(
+      options.connectTimeoutMs,
+      DEFAULT_TUI_DAEMON_CONNECT_TIMEOUT_MS,
+    );
+    this.requestTimeoutMs = normalizeTimeout(
+      options.requestTimeoutMs,
+      DEFAULT_TUI_DAEMON_REQUEST_TIMEOUT_MS,
+    );
+    const backoff =
+      options.reconnectBackoffMs && options.reconnectBackoffMs.length > 0
+        ? options.reconnectBackoffMs
+        : DEFAULT_TUI_RECONNECT_BACKOFF_MS;
+    this.reconnectBackoffMs = backoff.map((value) => normalizeTimeout(value, 250));
+    this.connect = options.connect ?? ((socketPath: string) => net.createConnection(socketPath));
+    this.requestIdFactory = options.requestIdFactory ?? createRequestId;
+    this.snapshot = {
+      state: "disconnected",
+      socketPath: this.socketPath,
+      hello: null,
+      error: null,
+      reconnectAttempt: 0,
+      reconnectDelayMs: null,
+    };
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    void this.attemptConnect();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.connecting = false;
+    this.hasConnectedOnce = false;
+    this.reconnectAttempt = 0;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.activeConnection) {
+      this.closeConnection(this.activeConnection, {
+        reason: { code: "DAEMON_UNAVAILABLE", message: "Daemon connection stopped" },
+        shouldReconnect: false,
+      });
+    }
+
+    this.setSnapshot({
+      state: "disconnected",
+      hello: null,
+      error: null,
+      reconnectAttempt: 0,
+      reconnectDelayMs: null,
+    });
+  }
+
+  getSnapshot(): DaemonConnectionSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: DaemonConnectionListener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async request<T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    options?: { timeoutMs?: number },
+  ): Promise<DaemonConnectionResult<T>> {
+    return this.sendRequest<T>(
+      method,
+      params,
+      normalizeTimeout(options?.timeoutMs, this.requestTimeoutMs),
+    );
+  }
+
+  private async attemptConnect(): Promise<void> {
+    if (!this.running || this.connecting || this.activeConnection) {
+      return;
+    }
+
+    this.connecting = true;
+    this.setSnapshot({
+      state: this.hasConnectedOnce ? "reconnecting" : "connecting",
+      error: null,
+      reconnectDelayMs: null,
+    });
+
+    const socketResult = await connectSocket(this.socketPath, this.connectTimeoutMs, this.connect);
+    this.connecting = false;
+
+    if (!this.running) {
+      if (socketResult.ok) {
+        socketResult.value.destroy();
+      }
+      return;
+    }
+
+    if (!socketResult.ok) {
+      this.scheduleReconnect(socketResult.error);
+      return;
+    }
+
+    const active = this.createActiveConnection(socketResult.value);
+    this.activeConnection = active;
+
+    const helloResult = await this.sendRequest<DaemonHelloResult>(
+      "daemon.hello",
+      { protocolVersion: DAEMON_PROTOCOL_VERSION },
+      this.requestTimeoutMs,
+    );
+
+    if (!helloResult.ok) {
+      this.closeConnection(active, { reason: helloResult.error, shouldReconnect: true });
+      return;
+    }
+
+    if (!isHelloResult(helloResult.value)) {
+      this.closeConnection(active, {
+        reason: {
+          code: "BAD_RESPONSE",
+          message: "Daemon hello response is missing expected protocol metadata",
+        },
+        shouldReconnect: true,
+      });
+      return;
+    }
+
+    this.hasConnectedOnce = true;
+    this.reconnectAttempt = 0;
+    this.setSnapshot({
+      state: "connected",
+      hello: helloResult.value,
+      error: null,
+      reconnectAttempt: 0,
+      reconnectDelayMs: null,
+    });
+  }
+
+  private createActiveConnection(socket: DaemonSocket): ActiveConnection {
+    const connection: ActiveConnection = {
+      socket,
+      pending: new Map<string, PendingRequest>(),
+      buffer: "",
+      closed: false,
+      dispose: () => {
+        socket.off("data", onData);
+        socket.off("error", onError);
+        socket.off("close", onClose);
+      },
+    };
+
+    const onData = (chunk: string) => {
+      if (connection.closed) {
+        return;
+      }
+
+      connection.buffer += chunk;
+      const lines = connection.buffer.split("\n");
+      connection.buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) {
+          continue;
+        }
+
+        const parsed = parseJsonFrame(trimmed);
+        if (!parsed.ok) {
+          this.closeConnection(connection, { reason: parsed.error, shouldReconnect: true });
+          return;
+        }
+
+        this.handleFrame(connection, parsed.value);
+      }
+    };
+
+    const onError = (error: Error) => {
+      this.closeConnection(connection, { reason: error, shouldReconnect: true });
+    };
+
+    const onClose = () => {
+      this.closeConnection(connection, {
+        reason: { code: "DAEMON_UNAVAILABLE", message: "Daemon connection closed" },
+        shouldReconnect: true,
+      });
+    };
+
+    socket.setEncoding("utf8");
+    socket.on("data", onData);
+    socket.on("error", onError);
+    socket.on("close", onClose);
+
+    return connection;
+  }
+
+  private handleFrame(connection: ActiveConnection, frame: unknown): void {
+    const parsed = parseIncomingFrame(frame);
+    if (!parsed.ok) {
+      this.closeConnection(connection, { reason: parsed.error, shouldReconnect: true });
+      return;
+    }
+
+    if (parsed.kind === "event") {
+      return;
+    }
+
+    const responseId = parsed.value.id;
+    if (responseId === null) {
+      return;
+    }
+
+    const pending = connection.pending.get(responseId);
+    if (!pending) {
+      return;
+    }
+
+    connection.pending.delete(responseId);
+    clearTimeout(pending.timeout);
+
+    if (parsed.kind === "error") {
+      pending.resolve({ ok: false, error: parsed.value.error });
+      return;
+    }
+
+    pending.resolve({ ok: true, value: parsed.value.result });
+  }
+
+  private closeConnection(
+    connection: ActiveConnection,
+    options: { reason: unknown; shouldReconnect: boolean },
+  ): void {
+    if (connection.closed) {
+      return;
+    }
+
+    connection.closed = true;
+    connection.dispose();
+
+    if (this.activeConnection === connection) {
+      this.activeConnection = null;
+    }
+
+    for (const pending of connection.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.resolve({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: "Daemon connection closed before response was received",
+          details: { method: pending.method },
+        },
+      });
+    }
+    connection.pending.clear();
+
+    try {
+      connection.socket.end();
+      connection.socket.destroy();
+    } catch {
+      // Ignore socket teardown failures.
+    }
+
+    this.setSnapshot({
+      state: "disconnected",
+      hello: null,
+      error: toConnectionError(options.reason),
+      reconnectDelayMs: null,
+    });
+
+    if (options.shouldReconnect) {
+      this.scheduleReconnect(options.reason);
+    }
+  }
+
+  private scheduleReconnect(reason: unknown): void {
+    if (!this.running || this.reconnectTimer) {
+      return;
+    }
+
+    const delayMs =
+      this.reconnectBackoffMs[
+        Math.min(this.reconnectAttempt, this.reconnectBackoffMs.length - 1)
+      ] ?? 250;
+    this.reconnectAttempt += 1;
+
+    this.setSnapshot({
+      state: this.hasConnectedOnce ? "reconnecting" : "failed",
+      hello: null,
+      error: toConnectionError(reason),
+      reconnectAttempt: this.reconnectAttempt,
+      reconnectDelayMs: delayMs,
+    });
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.attemptConnect();
+    }, delayMs);
+  }
+
+  private sendRequest<T>(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+  ): Promise<DaemonConnectionResult<T>> {
+    const connection = this.activeConnection;
+    if (!this.running || !connection || connection.closed) {
+      return Promise.resolve({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: "Daemon connection is not available",
+          details: { method },
+        },
+      });
+    }
+
+    const id = this.requestIdFactory();
+    const request: ProtocolRequestFrame = { id, method, params };
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        connection.pending.delete(id);
+        resolve({
+          ok: false,
+          error: {
+            code: "TIMEOUT",
+            message: `Daemon request timed out after ${timeoutMs}ms`,
+            details: { method, timeoutMs },
+          },
+        });
+      }, timeoutMs);
+
+      connection.pending.set(id, {
+        id,
+        method,
+        resolve: resolve as (result: DaemonConnectionResult<unknown>) => void,
+        timeout,
+      });
+
+      try {
+        connection.socket.write(`${JSON.stringify(request)}\n`);
+      } catch (error) {
+        clearTimeout(timeout);
+        connection.pending.delete(id);
+        resolve({ ok: false, error: toConnectionError(error) });
+      }
+    });
+  }
+
+  private setSnapshot(update: Partial<DaemonConnectionSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...update };
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}
+
+async function connectSocket(
+  socketPath: string,
+  timeoutMs: number,
+  connect: (socketPath: string) => DaemonSocket,
+): Promise<DaemonConnectionResult<DaemonSocket>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = connect(socketPath);
+
+    const cleanup = () => {
+      socket.off("error", onError);
+      socket.off("connect", onConnect);
+    };
+
+    const finish = (result: DaemonConnectionResult<DaemonSocket>) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      cleanup();
+      resolve(result);
+    };
+
+    const onConnect = () => {
+      finish({ ok: true, value: socket });
+    };
+
+    const onError = (error: Error) => {
+      socket.destroy();
+      finish({ ok: false, error: mapConnectError(socketPath, error) });
+    };
+
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      finish({
+        ok: false,
+        error: {
+          code: "DAEMON_UNAVAILABLE",
+          message: `Timed out connecting to daemon socket after ${Math.floor(timeoutMs)}ms`,
+          details: { socketPath, timeoutMs: Math.floor(timeoutMs) },
+        },
+      });
+    }, timeoutMs);
+
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+  });
+}
+
+function mapConnectError(socketPath: string, source: unknown): DaemonConnectionError {
+  const code = errorCode(source);
+  if (code === "ENOENT" || code === "ECONNREFUSED" || code === "EACCES" || code === "EPERM") {
+    return {
+      code: "DAEMON_UNAVAILABLE",
+      message: `Daemon unavailable at socket: ${socketPath}`,
+      details: { socketPath, reason: code },
+    };
+  }
+
+  return {
+    code: "INTERNAL_ERROR",
+    message: getErrorMessage(source),
+    details: { socketPath, reason: code },
+  };
+}
+
+function parseJsonFrame(payload: string): DaemonConnectionResult<unknown> {
+  try {
+    return { ok: true, value: JSON.parse(payload) as unknown };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "BAD_RESPONSE",
+        message: "Daemon returned invalid JSON frame",
+        details: { parseError: getErrorMessage(error) },
+      },
+    };
+  }
+}
+
+function parseIncomingFrame(
+  frame: unknown,
+):
+  | { ok: true; kind: "success"; value: ProtocolSuccessFrame }
+  | { ok: true; kind: "error"; value: ProtocolErrorFrame }
+  | { ok: true; kind: "event" }
+  | { ok: false; error: DaemonConnectionError } {
+  if (!isRecord(frame)) {
+    return {
+      ok: false,
+      error: { code: "BAD_RESPONSE", message: "Daemon response frame must be an object" },
+    };
+  }
+
+  if (typeof frame.event === "string") {
+    return { ok: true, kind: "event" };
+  }
+
+  if (isRecord(frame.error)) {
+    const id = frame.id;
+    const error = frame.error;
+    if (
+      (typeof id === "string" || id === null) &&
+      typeof error.code === "string" &&
+      typeof error.message === "string"
+    ) {
+      return {
+        ok: true,
+        kind: "error",
+        value: {
+          id,
+          error: {
+            code: error.code,
+            message: error.message,
+            details: isRecord(error.details) ? error.details : undefined,
+          },
+        },
+      };
+    }
+  }
+
+  if (typeof frame.id === "string" && "result" in frame) {
+    return { ok: true, kind: "success", value: { id: frame.id, result: frame.result } };
+  }
+
+  return {
+    ok: false,
+    error: { code: "BAD_RESPONSE", message: "Daemon response frame shape is invalid" },
+  };
+}
+
+function isHelloResult(value: unknown): value is DaemonHelloResult {
+  return isRecord(value) && value.protocolVersion === DAEMON_PROTOCOL_VERSION;
+}
+
+function toConnectionError(source: unknown): DaemonConnectionError {
+  if (isConnectionError(source)) {
+    return source;
+  }
+
+  return {
+    code: errorCode(source) ?? "INTERNAL_ERROR",
+    message: getErrorMessage(source),
+  };
+}
+
+function isConnectionError(value: unknown): value is DaemonConnectionError {
+  return isRecord(value) && typeof value.code === "string" && typeof value.message === "string";
+}
+
+function normalizeTimeout(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unexpected daemon connection error";
+}
+
+let requestCounter = 0;
+
+function createRequestId(): string {
+  requestCounter += 1;
+  return `tui-${Date.now()}-${requestCounter}`;
+}


### PR DESCRIPTION
## Summary
- add TUI daemon connection manager with daemon.hello handshake
- render lifecycle state and daemon start guidance in the Ink app
- share CLI/daemon config resolution for data dir/socket lookup
- add connection lifecycle tests and an @todu/tui patch changeset

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- npm run check:ci
- make pre-pr
- stopped-daemon TTY smoke check with TODU_DAEMON_SOCKET=/tmp/todu-missing-daemon.sock

Task: #task-d466aed5