### PR TITLE
Fix npm release workflow bot push

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -44,4 +44,5 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HUSKY: "0"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- disable Husky git hooks for the Changesets action push
- prevents the release bot branch push from running local pre-push tests inside GitHub Actions

## Why
After PR #482 merged, the NPM Release workflow generated the version commit correctly but failed pushing `changeset-release/main` because Husky ran `npm test` during the workflow's git push and Electron binary install was unavailable in that context.

## Verification
- pre-commit check/typecheck passed
- push hook full test suite passed
