### PR TITLE
Fix npm release auth environment

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -45,4 +45,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: "0"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- pass GitHub secret `NPM_TOKEN` as `NODE_AUTH_TOKEN` during the Changesets publish step
- keep `NPM_TOKEN` for Changesets action compatibility

## Why
`actions/setup-node` writes npm auth config that reads `NODE_AUTH_TOKEN`. The publish step was only explicitly receiving `NPM_TOKEN`, so npm publish could use the wrong auth env path.

## Verification
- pre-commit check/typecheck passed
- push hook full test suite passed
