### PR TITLE
Add TUI daemon domain client

### DIFF
--- a/.changeset/inferred-mr06sqpf.md
+++ b/.changeset/inferred-mr06sqpf.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add TUI daemon domain client and data status panel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13347,6 +13347,7 @@
       "version": "0.23.3",
       "license": "MIT",
       "dependencies": {
+        "@tanstack/react-query": "^5.90.21",
         "@todu/core": "*",
         "ink": "^7.1.0",
         "react": "^19.2.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
     "@todu/core": "*",
     "ink": "^7.1.0",
     "react": "^19.2.0",

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -6,16 +6,40 @@ import {
   type DaemonConnection,
   type DaemonConnectionSnapshot,
 } from "../daemon/connection.js";
+import { createTuiToduClient, type TuiToduClient } from "../daemon/todu-client.js";
+import { DataStatusScreen } from "../screens/DataStatusScreen.js";
+import { createTuiQueryClient, TuiQueryProvider } from "../state/query-client.js";
 
 export interface AppProps {
   connection?: DaemonConnection;
+  toduClient?: TuiToduClient;
 }
 
-export function App({ connection: providedConnection }: AppProps = {}): JSX.Element {
+export function App({
+  connection: providedConnection,
+  toduClient: providedToduClient,
+}: AppProps = {}): JSX.Element {
+  const queryClient = useMemo(() => createTuiQueryClient(), []);
+
+  return (
+    <TuiQueryProvider client={queryClient}>
+      <AppContent connection={providedConnection} toduClient={providedToduClient} />
+    </TuiQueryProvider>
+  );
+}
+
+function AppContent({
+  connection: providedConnection,
+  toduClient: providedToduClient,
+}: AppProps): JSX.Element {
   const { exit } = useApp();
   const connection = useMemo(
     () => providedConnection ?? createDaemonConnection(),
     [providedConnection],
+  );
+  const toduClient = useMemo(
+    () => providedToduClient ?? createTuiToduClient(connection),
+    [connection, providedToduClient],
   );
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
@@ -43,6 +67,7 @@ export function App({ connection: providedConnection }: AppProps = {}): JSX.Elem
         todu TUI
       </Text>
       <ConnectionState connection={connectionSnapshot} />
+      {connectionSnapshot.state === "connected" ? <DataStatusScreen client={toduClient} /> : null}
       <Text color="gray">Press q or Ctrl+C to quit.</Text>
     </Box>
   );

--- a/packages/tui/src/daemon/todu-client.test.ts
+++ b/packages/tui/src/daemon/todu-client.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DaemonConnection } from "./connection.js";
+import {
+  createTuiToduClient,
+  formatToduClientError,
+  invokeDaemonValue,
+  TuiToduClientError,
+} from "./todu-client.js";
+
+function createMockDaemon(request: ReturnType<typeof vi.fn>): Pick<DaemonConnection, "request"> {
+  return { request };
+}
+
+describe("createTuiToduClient", () => {
+  it("maps project methods to daemon RPC params", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: [{ id: "project-1", name: "Inbox" }] })
+      .mockResolvedValueOnce({ ok: true, value: { id: "project-1", name: "Inbox" } });
+    const client = createTuiToduClient(createMockDaemon(request));
+
+    await expect(client.project.list({ status: "active" })).resolves.toEqual([
+      { id: "project-1", name: "Inbox" },
+    ]);
+    await expect(client.project.get("project-1")).resolves.toEqual({
+      id: "project-1",
+      name: "Inbox",
+    });
+
+    expect(request).toHaveBeenNthCalledWith(1, "project.list", { filter: { status: "active" } });
+    expect(request).toHaveBeenNthCalledWith(2, "project.get", { id: "project-1" });
+  });
+
+  it("maps task methods to daemon RPC params", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: [{ id: "task-1", title: "Ship" }] })
+      .mockResolvedValueOnce({ ok: true, value: { id: "task-1", title: "Ship" } })
+      .mockResolvedValueOnce({ ok: true, value: { id: "task-1", title: "Ship it" } });
+    const client = createTuiToduClient(createMockDaemon(request));
+
+    await client.task.list({ projectId: "project-1" }, { field: "title", direction: "asc" });
+    await client.task.get("task-1");
+    await client.task.update("task-1", { title: "Ship it" });
+
+    expect(request).toHaveBeenNthCalledWith(1, "task.list", {
+      filter: { projectId: "project-1" },
+      sort: { field: "title", direction: "asc" },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "task.get", { id: "task-1" });
+    expect(request).toHaveBeenNthCalledWith(3, "task.update", {
+      id: "task-1",
+      input: { title: "Ship it" },
+    });
+  });
+
+  it("maps task comments to note.create", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { id: "note-1", content: "Looks good", entityType: "task", entityId: "task-1" },
+    });
+    const client = createTuiToduClient(createMockDaemon(request));
+
+    await client.task.createComment("task-1", "Looks good");
+
+    expect(request).toHaveBeenCalledWith("note.create", {
+      input: {
+        content: "Looks good",
+        entityType: "task",
+        entityId: "task-1",
+      },
+    });
+  });
+
+  it("maps actor, note, and sync status methods", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: [] })
+      .mockResolvedValueOnce({ ok: true, value: [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { local: { mode: "standalone" }, remote: { state: "disconnected" } },
+      });
+    const client = createTuiToduClient(createMockDaemon(request));
+
+    await client.actor.list();
+    await client.note.list({ entityType: "task", entityId: "task-1" });
+    await client.sync.status();
+
+    expect(request).toHaveBeenNthCalledWith(1, "actor.list", {});
+    expect(request).toHaveBeenNthCalledWith(2, "note.list", {
+      filter: { entityType: "task", entityId: "task-1" },
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "sync.status", {});
+  });
+
+  it("throws user-facing mapped errors instead of raw protocol frames", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "task not found",
+        details: { entity: "task", id: "task-9" },
+      },
+    });
+
+    await expect(
+      invokeDaemonValue(createMockDaemon(request), "task.get", { id: "task-9" }),
+    ).rejects.toMatchObject({
+      userMessage: "task not found: task-9",
+      method: "task.get",
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("formats daemon unavailable errors for users", () => {
+    const error = new TuiToduClientError({
+      method: "project.list",
+      code: "DAEMON_UNAVAILABLE",
+      message: "project.list failed (DAEMON_UNAVAILABLE): socket missing",
+      userMessage: "Daemon unavailable. Start it with: todu daemon start.",
+    });
+
+    expect(formatToduClientError(error)).toBe(
+      "Daemon unavailable. Start it with: todu daemon start.",
+    );
+  });
+});

--- a/packages/tui/src/daemon/todu-client.ts
+++ b/packages/tui/src/daemon/todu-client.ts
@@ -1,0 +1,172 @@
+import type {
+  Actor,
+  CreateNoteInput,
+  Note,
+  NoteFilter,
+  Project,
+  ProjectFilter,
+  ProjectId,
+  Task,
+  TaskFilter,
+  TaskId,
+  TaskSortOptions,
+  TaskWithDetail,
+  UpdateTaskInput,
+} from "@todu/core";
+import type { DaemonConnection, DaemonConnectionError } from "./connection.js";
+
+export interface TuiSyncStatus {
+  local: {
+    mode: string;
+  };
+  remote: {
+    state: string;
+    server?: string;
+    lastSync?: string;
+  };
+}
+
+export interface TuiToduClient {
+  actor: {
+    list(): Promise<Actor[]>;
+  };
+  project: {
+    list(filter?: ProjectFilter): Promise<Project[]>;
+    get(id: ProjectId | string): Promise<Project>;
+  };
+  task: {
+    list(filter?: TaskFilter, sort?: TaskSortOptions): Promise<Task[]>;
+    get(id: TaskId | string): Promise<TaskWithDetail>;
+    update(id: TaskId | string, input: UpdateTaskInput): Promise<Task>;
+    createComment(taskId: TaskId | string, content: string): Promise<Note>;
+  };
+  note: {
+    list(filter?: NoteFilter): Promise<Note[]>;
+    create(input: CreateNoteInput): Promise<Note>;
+  };
+  sync: {
+    status(): Promise<TuiSyncStatus>;
+  };
+}
+
+export class TuiToduClientError extends Error {
+  readonly method: string;
+  readonly code: string;
+  readonly userMessage: string;
+  readonly details?: Record<string, unknown>;
+
+  constructor(options: {
+    method: string;
+    code: string;
+    message: string;
+    userMessage: string;
+    details?: Record<string, unknown>;
+  }) {
+    super(options.message);
+    this.name = "TuiToduClientError";
+    this.method = options.method;
+    this.code = options.code;
+    this.userMessage = options.userMessage;
+    this.details = options.details;
+  }
+}
+
+export function createTuiToduClient(daemon: Pick<DaemonConnection, "request">): TuiToduClient {
+  const invoke = <T>(method: string, params: Record<string, unknown> = {}) =>
+    invokeDaemonValue<T>(daemon, method, params);
+
+  return {
+    actor: {
+      list: () => invoke<Actor[]>("actor.list", {}),
+    },
+    project: {
+      list: (filter) => invoke<Project[]>("project.list", { filter }),
+      get: (id) => invoke<Project>("project.get", { id }),
+    },
+    task: {
+      list: (filter, sort) => invoke<Task[]>("task.list", { filter, sort }),
+      get: (id) => invoke<TaskWithDetail>("task.get", { id }),
+      update: (id, input) => invoke<Task>("task.update", { id, input }),
+      createComment: (taskId, content) =>
+        invoke<Note>("note.create", {
+          input: {
+            content,
+            entityType: "task",
+            entityId: taskId,
+          } satisfies CreateNoteInput,
+        }),
+    },
+    note: {
+      list: (filter) => invoke<Note[]>("note.list", { filter }),
+      create: (input) => invoke<Note>("note.create", { input }),
+    },
+    sync: {
+      status: () => invoke<TuiSyncStatus>("sync.status", {}),
+    },
+  };
+}
+
+export async function invokeDaemonValue<T>(
+  daemon: Pick<DaemonConnection, "request">,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const response = await daemon.request<T>(method, params);
+  if (response.ok) {
+    return response.value;
+  }
+
+  throw mapDaemonErrorToClientError(method, response.error);
+}
+
+export function mapDaemonErrorToClientError(
+  method: string,
+  error: DaemonConnectionError,
+): TuiToduClientError {
+  return new TuiToduClientError({
+    method,
+    code: error.code,
+    message: `${method} failed (${error.code}): ${error.message}`,
+    userMessage: formatDaemonErrorForUser(error),
+    details: error.details,
+  });
+}
+
+export function formatToduClientError(error: unknown): string {
+  if (error instanceof TuiToduClientError) {
+    return error.userMessage;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "Unexpected TUI data error.";
+}
+
+function formatDaemonErrorForUser(error: DaemonConnectionError): string {
+  if (error.code === "DAEMON_UNAVAILABLE") {
+    return "Daemon unavailable. Start it with: todu daemon start.";
+  }
+
+  if (error.code === "TIMEOUT") {
+    return "Daemon request timed out. Try again.";
+  }
+
+  if (error.code === "NOT_FOUND") {
+    const entity = getStringDetail(error.details, "entity") ?? "item";
+    const id = getStringDetail(error.details, "id");
+    return id ? `${entity} not found: ${id}` : error.message;
+  }
+
+  if (error.code === "VALIDATION_ERROR" || error.code === "BAD_REQUEST") {
+    return error.message;
+  }
+
+  return error.message;
+}
+
+function getStringDetail(details: Record<string, unknown> | undefined, key: string): string | null {
+  const value = details?.[key];
+  return typeof value === "string" ? value : null;
+}

--- a/packages/tui/src/screens/DataStatusScreen.test.tsx
+++ b/packages/tui/src/screens/DataStatusScreen.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "ink-testing-library";
+import type { JSX, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { type TuiToduClient, TuiToduClientError } from "../daemon/todu-client.js";
+import { createTuiQueryClient } from "../state/query-client.js";
+import { DataStatusScreen } from "./DataStatusScreen.js";
+
+function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
+  const queryClient = createTuiQueryClient();
+  function Wrapper(): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return render(<Wrapper />);
+}
+
+function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: {
+      list: vi.fn().mockResolvedValue([{ id: "project-1", name: "Inbox" }]),
+      get: vi.fn(),
+    },
+    task: {
+      list: vi.fn().mockResolvedValue([
+        { id: "task-1", title: "One" },
+        { id: "task-2", title: "Two" },
+      ]),
+      get: vi.fn(),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+    ...overrides,
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (lastFrame()?.includes(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
+describe("DataStatusScreen", () => {
+  it("renders project and task counts from daemon data", async () => {
+    const { lastFrame } = renderWithQuery(<DataStatusScreen client={createClient()} />);
+
+    await waitForFrameText(lastFrame, "Data status ready");
+
+    expect(lastFrame()).toContain("Projects: 1");
+    expect(lastFrame()).toContain("Tasks: 2");
+  });
+
+  it("renders user-facing client errors", async () => {
+    const client = createClient({
+      project: {
+        list: vi.fn().mockRejectedValue(
+          new TuiToduClientError({
+            method: "project.list",
+            code: "DAEMON_UNAVAILABLE",
+            message: "project.list failed (DAEMON_UNAVAILABLE): socket missing",
+            userMessage: "Daemon unavailable. Start it with: todu daemon start.",
+          }),
+        ),
+        get: vi.fn(),
+      },
+    });
+    const { lastFrame } = renderWithQuery(<DataStatusScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "Data status unavailable");
+
+    expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");
+  });
+});

--- a/packages/tui/src/screens/DataStatusScreen.tsx
+++ b/packages/tui/src/screens/DataStatusScreen.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { queryKeys } from "../state/query-keys.js";
+
+export interface DataStatusScreenProps {
+  client: TuiToduClient;
+}
+
+export function DataStatusScreen({ client }: DataStatusScreenProps): JSX.Element {
+  const projects = useQuery({
+    queryKey: queryKeys.projects(),
+    queryFn: () => client.project.list(),
+  });
+  const tasks = useQuery({
+    queryKey: queryKeys.tasks(),
+    queryFn: () => client.task.list(),
+  });
+
+  const error = projects.error ?? tasks.error;
+
+  if (error) {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Data status unavailable</Text>
+        <Text color="gray">{formatToduClientError(error)}</Text>
+      </Box>
+    );
+  }
+
+  if (projects.isLoading || tasks.isLoading) {
+    return <Text color="yellow">Loading daemon data…</Text>;
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color="green">Data status ready</Text>
+      <Text color="gray">Projects: {projects.data?.length ?? 0}</Text>
+      <Text color="gray">Tasks: {tasks.data?.length ?? 0}</Text>
+    </Box>
+  );
+}

--- a/packages/tui/src/state/query-client.tsx
+++ b/packages/tui/src/state/query-client.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { JSX, ReactNode } from "react";
+
+export function createTuiQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 5_000,
+      },
+    },
+  });
+}
+
+export interface TuiQueryProviderProps {
+  client: QueryClient;
+  children: ReactNode;
+}
+
+export function TuiQueryProvider({ client, children }: TuiQueryProviderProps): JSX.Element {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/packages/tui/src/state/query-keys.ts
+++ b/packages/tui/src/state/query-keys.ts
@@ -1,0 +1,13 @@
+import type { NoteFilter, ProjectFilter, TaskFilter, TaskId, TaskSortOptions } from "@todu/core";
+
+export const queryKeys = {
+  actors: () => ["actors"] as const,
+  projects: (filter?: ProjectFilter) => ["projects", filter ?? null] as const,
+  project: (id: string) => ["projects", id] as const,
+  tasks: (filter?: TaskFilter, sort?: TaskSortOptions) =>
+    ["tasks", filter ?? null, sort ?? null] as const,
+  task: (id: TaskId | string) => ["tasks", id] as const,
+  notes: (filter?: NoteFilter) => ["notes", filter ?? null] as const,
+  taskComments: (taskId: TaskId | string) => ["tasks", taskId, "comments"] as const,
+  syncStatus: () => ["sync", "status"] as const,
+};


### PR DESCRIPTION
## Summary
- add a typed TUI daemon domain client for project, task, note/comment, actor, and sync status RPCs
- add React Query client/provider and shared query keys for TUI data access
- render connected data status with real project/task counts and user-facing error messages
- add an inferred @todu/tui patch changeset

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr
- dev-daemon smoke check showed connected data status with project/task counts

Task: task-95e4407d