### PR TITLE
Add TUI shell navigation

### DIFF
--- a/.changeset/tui-shell-navigation.md
+++ b/.changeset/tui-shell-navigation.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add TUI app shell navigation.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -244,13 +244,24 @@ The TUI should be optimized for fast keyboard workflows.
 ### Navigation Principles
 
 - Default screen: active tasks.
-- `j/k` and arrow keys move selection.
-- `enter` opens focused detail or toggles pane focus.
-- `/` starts search/filter input.
-- `:` opens command palette.
+- `j/k` and arrow keys move selection once a focused list is implemented.
+- `enter` opens focused detail or toggles pane focus once split-pane task browsing is implemented.
+- `/` starts search/filter input once filtering is implemented.
+- `:` opens command palette once command execution is implemented.
 - `?` opens help.
 - `q` backs out or quits from the root screen.
 - Mutating shortcuts should show confirmation only for destructive actions.
+
+### Current Shell Keymap
+
+The initial shell implements only global navigation keys:
+
+- `1`: Tasks.
+- `2`: Projects.
+- `3`: Data Status.
+- `?`: Help.
+- `q`: Back from Help or quit from a root route.
+- `Ctrl+C`: Quit immediately.
 
 ### MVP Task Actions
 

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -1,11 +1,15 @@
+import { Text } from "ink";
 import { render } from "ink-testing-library";
 import { describe, expect, it, vi } from "vitest";
+import { AppFrame } from "../components/AppFrame.js";
 import type {
   DaemonConnection,
   DaemonConnectionListener,
   DaemonConnectionSnapshot,
 } from "../daemon/connection.js";
+import type { TuiToduClient } from "../daemon/todu-client.js";
 import { App } from "./App.js";
+import { applyNavigationAction, createInitialRouteState } from "./keymap.js";
 
 function createFakeConnection(snapshot: DaemonConnectionSnapshot): DaemonConnection {
   return {
@@ -20,25 +24,168 @@ function createFakeConnection(snapshot: DaemonConnectionSnapshot): DaemonConnect
   };
 }
 
+function createConnectedSnapshot(): DaemonConnectionSnapshot {
+  return {
+    state: "connected",
+    socketPath: "/tmp/todu.sock",
+    hello: {
+      protocolVersion: 1,
+      daemonVersion: "dev",
+      pid: 123,
+      capabilities: [],
+    },
+    error: null,
+    reconnectAttempt: 0,
+    reconnectDelayMs: null,
+  };
+}
+
+function createFailedSnapshot(): DaemonConnectionSnapshot {
+  return {
+    state: "failed",
+    socketPath: "/tmp/todu.sock",
+    hello: null,
+    error: {
+      code: "DAEMON_UNAVAILABLE",
+      message: "Daemon unavailable at socket: /tmp/todu.sock",
+    },
+    reconnectAttempt: 1,
+    reconnectDelayMs: 250,
+  };
+}
+
+function createFakeClient(): TuiToduClient {
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: {
+      list: vi.fn().mockResolvedValue([{ id: "project-1", name: "Inbox" }]),
+      get: vi.fn(),
+    },
+    task: {
+      list: vi.fn().mockResolvedValue([{ id: "task-1", title: "Ship" }]),
+      get: vi.fn(),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (lastFrame()?.includes(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
 describe("App", () => {
   it("renders the initial TUI shell with daemon connection guidance", () => {
-    const connection = createFakeConnection({
-      state: "failed",
-      socketPath: "/tmp/todu.sock",
-      hello: null,
-      error: {
-        code: "DAEMON_UNAVAILABLE",
-        message: "Daemon unavailable at socket: /tmp/todu.sock",
-      },
-      reconnectAttempt: 1,
-      reconnectDelayMs: 250,
-    });
+    const connection = createFakeConnection(createFailedSnapshot());
 
     const { lastFrame } = render(<App connection={connection} />);
 
-    expect(lastFrame()).toContain("todu TUI");
+    expect(lastFrame()).toContain("Todu • Tasks");
+    expect(lastFrame()).toContain("View: Tasks");
     expect(lastFrame()).toContain("Daemon unavailable");
     expect(lastFrame()).toContain("todu daemon start");
-    expect(lastFrame()).toContain("Press q or Ctrl+C to quit.");
+    expect(lastFrame()).toContain("1 Tasks");
+    expect(lastFrame()).toContain("q Back/Quit");
+  });
+
+  it("switches between primary routes", async () => {
+    const { stdin, lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+      />,
+    );
+
+    expect(lastFrame()).toContain("Tasks");
+    expect(lastFrame()).toContain("Task list placeholder.");
+
+    stdin.write("2");
+    await waitForFrameText(lastFrame, "Projects placeholder.");
+    expect(lastFrame()).toContain("View: Projects");
+
+    stdin.write("3");
+    await waitForFrameText(lastFrame, "Data status ready");
+    expect(lastFrame()).toContain("Projects: 1");
+    expect(lastFrame()).toContain("Tasks: 1");
+  });
+
+  it("shows help with implemented keys", async () => {
+    const { stdin, lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+      />,
+    );
+
+    stdin.write("?");
+    await waitForFrameText(lastFrame, "Help");
+
+    expect(lastFrame()).toContain("1      Tasks");
+    expect(lastFrame()).toContain("2      Projects");
+    expect(lastFrame()).toContain("3      Data Status");
+    expect(lastFrame()).toContain("?      Help");
+    expect(lastFrame()).toContain("q      Back/Quit");
+    expect(lastFrame()).toContain("Ctrl+C Quit");
+  });
+
+  it("backs out of help before quitting from a root route", async () => {
+    const onExit = vi.fn();
+    const { stdin, lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+        onExit={onExit}
+      />,
+    );
+
+    stdin.write("2");
+    await waitForFrameText(lastFrame, "Projects placeholder.");
+    stdin.write("?");
+    await waitForFrameText(lastFrame, "Help");
+
+    stdin.write("q");
+    await waitForFrameText(lastFrame, "Projects placeholder.");
+    expect(onExit).not.toHaveBeenCalled();
+
+    stdin.write("q");
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps quit behavior deterministic in the route reducer", () => {
+    const state = createInitialRouteState();
+
+    expect(applyNavigationAction(state, { type: "back-or-quit" })).toBe("quit");
+    expect(
+      applyNavigationAction({ route: "help", previousRoute: "projects" }, { type: "back-or-quit" }),
+    ).toEqual({ route: "projects", previousRoute: "projects" });
+  });
+
+  it("renders the frame at narrow widths without wrapping route labels into exceptions", () => {
+    const { lastFrame } = render(
+      <AppFrame route="data-status" connection={createConnectedSnapshot()} terminalWidth={24}>
+        <TextFixture />
+      </AppFrame>,
+    );
+
+    expect(lastFrame()).toContain("Todu");
+    expect(lastFrame()).toContain("View: Data Status");
+    expect(lastFrame()).toContain("fixture");
   });
 });
+
+function TextFixture() {
+  return <Text>fixture</Text>;
+}

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -1,5 +1,6 @@
-import { Box, Text, useApp, useInput } from "ink";
+import { useApp, useInput } from "ink";
 import { type JSX, useEffect, useMemo, useState } from "react";
+import { AppFrame } from "../components/AppFrame.js";
 import { ConnectionState } from "../components/ConnectionState.js";
 import {
   createDaemonConnection,
@@ -8,22 +9,33 @@ import {
 } from "../daemon/connection.js";
 import { createTuiToduClient, type TuiToduClient } from "../daemon/todu-client.js";
 import { DataStatusScreen } from "../screens/DataStatusScreen.js";
+import { HelpScreen } from "../screens/HelpScreen.js";
+import { ProjectsScreen } from "../screens/ProjectsScreen.js";
+import { TasksScreen } from "../screens/TasksScreen.js";
 import { createTuiQueryClient, TuiQueryProvider } from "../state/query-client.js";
+import {
+  applyNavigationAction,
+  createInitialRouteState,
+  resolveGlobalKeyAction,
+} from "./keymap.js";
+import type { AppRoute } from "./routes.js";
 
 export interface AppProps {
   connection?: DaemonConnection;
   toduClient?: TuiToduClient;
+  onExit?: () => void;
 }
 
 export function App({
   connection: providedConnection,
   toduClient: providedToduClient,
+  onExit,
 }: AppProps = {}): JSX.Element {
   const queryClient = useMemo(() => createTuiQueryClient(), []);
 
   return (
     <TuiQueryProvider client={queryClient}>
-      <AppContent connection={providedConnection} toduClient={providedToduClient} />
+      <AppContent connection={providedConnection} toduClient={providedToduClient} onExit={onExit} />
     </TuiQueryProvider>
   );
 }
@@ -31,6 +43,7 @@ export function App({
 function AppContent({
   connection: providedConnection,
   toduClient: providedToduClient,
+  onExit,
 }: AppProps): JSX.Element {
   const { exit } = useApp();
   const connection = useMemo(
@@ -41,14 +54,26 @@ function AppContent({
     () => providedToduClient ?? createTuiToduClient(connection),
     [connection, providedToduClient],
   );
+  const [routeState, setRouteState] = useState(createInitialRouteState);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
   );
 
+  const requestExit = (): void => {
+    onExit?.();
+    exit();
+  };
+
   useInput((input, key) => {
-    if (input === "q" || (key.ctrl && input === "c")) {
-      exit();
+    const action = resolveGlobalKeyAction(input, key);
+    const nextState = applyNavigationAction(routeState, action);
+
+    if (nextState === "quit") {
+      requestExit();
+      return;
     }
+
+    setRouteState(nextState);
   });
 
   useEffect(() => {
@@ -62,13 +87,35 @@ function AppContent({
   }, [connection]);
 
   return (
-    <Box flexDirection="column" paddingX={1} paddingY={1}>
-      <Text color="cyan" bold>
-        todu TUI
-      </Text>
+    <AppFrame route={routeState.route} connection={connectionSnapshot}>
       <ConnectionState connection={connectionSnapshot} />
-      {connectionSnapshot.state === "connected" ? <DataStatusScreen client={toduClient} /> : null}
-      <Text color="gray">Press q or Ctrl+C to quit.</Text>
-    </Box>
+      <RouteScreen
+        route={routeState.route}
+        connection={connectionSnapshot}
+        toduClient={toduClient}
+      />
+    </AppFrame>
   );
+}
+
+interface RouteScreenProps {
+  route: AppRoute;
+  connection: DaemonConnectionSnapshot;
+  toduClient: TuiToduClient;
+}
+
+function RouteScreen({ route, connection, toduClient }: RouteScreenProps): JSX.Element | null {
+  if (route === "projects") {
+    return <ProjectsScreen />;
+  }
+
+  if (route === "data-status") {
+    return connection.state === "connected" ? <DataStatusScreen client={toduClient} /> : null;
+  }
+
+  if (route === "help") {
+    return <HelpScreen />;
+  }
+
+  return <TasksScreen />;
 }

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -1,0 +1,102 @@
+import { type AppRoute, defaultRoute, type PrimaryAppRoute } from "./routes.js";
+
+export interface TuiKeyBinding {
+  keys: string;
+  description: string;
+}
+
+export const globalKeyBindings: readonly TuiKeyBinding[] = [
+  { keys: "1", description: "Tasks" },
+  { keys: "2", description: "Projects" },
+  { keys: "3", description: "Data Status" },
+  { keys: "?", description: "Help" },
+  { keys: "q", description: "Back/Quit" },
+  { keys: "Ctrl+C", description: "Quit" },
+] as const;
+
+export type AppKeyAction =
+  | { type: "navigate"; route: PrimaryAppRoute }
+  | { type: "help" }
+  | { type: "back-or-quit" }
+  | { type: "quit" }
+  | { type: "none" };
+
+export interface AppKeyboardKey {
+  ctrl?: boolean;
+}
+
+export interface RouteState {
+  route: AppRoute;
+  previousRoute: PrimaryAppRoute;
+}
+
+export function resolveGlobalKeyAction(input: string, key: AppKeyboardKey): AppKeyAction {
+  if (key.ctrl && input === "c") {
+    return { type: "quit" };
+  }
+
+  if (input === "1") {
+    return { type: "navigate", route: "tasks" };
+  }
+
+  if (input === "2") {
+    return { type: "navigate", route: "projects" };
+  }
+
+  if (input === "3") {
+    return { type: "navigate", route: "data-status" };
+  }
+
+  if (input === "?") {
+    return { type: "help" };
+  }
+
+  if (input === "q") {
+    return { type: "back-or-quit" };
+  }
+
+  return { type: "none" };
+}
+
+export function applyNavigationAction(
+  state: RouteState,
+  action: AppKeyAction,
+): RouteState | "quit" {
+  if (action.type === "quit") {
+    return "quit";
+  }
+
+  if (action.type === "navigate") {
+    return {
+      route: action.route,
+      previousRoute: action.route,
+    };
+  }
+
+  if (action.type === "help") {
+    return {
+      route: "help",
+      previousRoute: state.route === "help" ? state.previousRoute : state.route,
+    };
+  }
+
+  if (action.type === "back-or-quit") {
+    if (state.route === "help") {
+      return {
+        route: state.previousRoute,
+        previousRoute: state.previousRoute,
+      };
+    }
+
+    return "quit";
+  }
+
+  return state;
+}
+
+export function createInitialRouteState(): RouteState {
+  return {
+    route: defaultRoute,
+    previousRoute: defaultRoute,
+  };
+}

--- a/packages/tui/src/app/routes.ts
+++ b/packages/tui/src/app/routes.ts
@@ -1,0 +1,17 @@
+export const appRoutes = ["tasks", "projects", "data-status", "help"] as const;
+
+export type AppRoute = (typeof appRoutes)[number];
+export type PrimaryAppRoute = Exclude<AppRoute, "help">;
+
+export const defaultRoute: PrimaryAppRoute = "tasks";
+
+export const routeLabels: Record<AppRoute, string> = {
+  tasks: "Tasks",
+  projects: "Projects",
+  "data-status": "Data Status",
+  help: "Help",
+};
+
+export function isPrimaryRoute(route: AppRoute): route is PrimaryAppRoute {
+  return route !== "help";
+}

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -1,0 +1,46 @@
+import { Box, Text, useStdout } from "ink";
+import type { JSX, ReactNode } from "react";
+import { type AppRoute, routeLabels } from "../app/routes.js";
+import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+import { HelpBar } from "./HelpBar.js";
+import { StatusLine } from "./StatusLine.js";
+
+export interface AppFrameProps {
+  route: AppRoute;
+  connection: DaemonConnectionSnapshot;
+  children: ReactNode;
+  terminalWidth?: number;
+}
+
+export function AppFrame({
+  route,
+  connection,
+  children,
+  terminalWidth,
+}: AppFrameProps): JSX.Element {
+  const { stdout } = useStdout();
+  const width = resolveTerminalWidth(terminalWidth ?? stdout.columns);
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1} width={width}>
+      <Box flexDirection="row">
+        <Text color="cyan" bold wrap="truncate-end">
+          Todu
+        </Text>
+        <Text color="gray" wrap="truncate-end">
+          {" "}
+          • {routeLabels[route]}
+        </Text>
+      </Box>
+      <StatusLine route={route} connection={connection} />
+      <Box flexDirection="column" marginY={1}>
+        {children}
+      </Box>
+      <HelpBar />
+    </Box>
+  );
+}
+
+function resolveTerminalWidth(width: number | undefined): number {
+  return width && width > 0 ? width : 80;
+}

--- a/packages/tui/src/components/HelpBar.tsx
+++ b/packages/tui/src/components/HelpBar.tsx
@@ -1,0 +1,13 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import { globalKeyBindings } from "../app/keymap.js";
+
+export function HelpBar(): JSX.Element {
+  return (
+    <Box flexDirection="row">
+      <Text color="gray" wrap="truncate-end">
+        {globalKeyBindings.map((binding) => `${binding.keys} ${binding.description}`).join("  •  ")}
+      </Text>
+    </Box>
+  );
+}

--- a/packages/tui/src/components/StatusLine.tsx
+++ b/packages/tui/src/components/StatusLine.tsx
@@ -1,0 +1,31 @@
+import { Text } from "ink";
+import type { JSX } from "react";
+import { type AppRoute, routeLabels } from "../app/routes.js";
+import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+
+export interface StatusLineProps {
+  route: AppRoute;
+  connection: DaemonConnectionSnapshot;
+}
+
+export function StatusLine({ route, connection }: StatusLineProps): JSX.Element {
+  return (
+    <Text color="gray" wrap="truncate-end">
+      View: {routeLabels[route]} • Daemon: {formatConnectionState(connection)}
+    </Text>
+  );
+}
+
+function formatConnectionState(connection: DaemonConnectionSnapshot): string {
+  if (connection.state === "connected") {
+    return connection.hello?.daemonVersion
+      ? `connected (${connection.hello.daemonVersion})`
+      : "connected";
+  }
+
+  if (connection.state === "failed") {
+    return "unavailable";
+  }
+
+  return connection.state;
+}

--- a/packages/tui/src/screens/HelpScreen.tsx
+++ b/packages/tui/src/screens/HelpScreen.tsx
@@ -1,0 +1,16 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import { globalKeyBindings } from "../app/keymap.js";
+
+export function HelpScreen(): JSX.Element {
+  return (
+    <Box flexDirection="column">
+      <Text color="cyan">Help</Text>
+      {globalKeyBindings.map((binding) => (
+        <Text key={binding.keys} color="gray">
+          {binding.keys.padEnd(6)} {binding.description}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -1,0 +1,12 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+
+export function ProjectsScreen(): JSX.Element {
+  return (
+    <Box flexDirection="column">
+      <Text color="cyan">Projects</Text>
+      <Text color="gray">Projects placeholder.</Text>
+      <Text color="gray">Project filtering lands after the task read model.</Text>
+    </Box>
+  );
+}

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,0 +1,12 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+
+export function TasksScreen(): JSX.Element {
+  return (
+    <Box flexDirection="column">
+      <Text color="cyan">Tasks</Text>
+      <Text color="gray">Task list placeholder.</Text>
+      <Text color="gray">The next TUI task will add active task browsing and details.</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add TUI routes and global keymap for Tasks, Projects, Data Status, and Help
- add app frame, status line, help bar, and placeholder Tasks/Projects/Help screens
- wire deterministic help back/quit behavior and Data Status routing
- document the currently implemented shell keymap and add a TUI patch changeset

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr
- dev-daemon smoke check showed framed Tasks shell and connection status

Task: task-9159377a