### PR TITLE
Add TUI task read model

### DIFF
--- a/.changeset/tui-task-read-model.md
+++ b/.changeset/tui-task-read-model.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add TUI task list and detail read model.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -244,7 +244,7 @@ The TUI should be optimized for fast keyboard workflows.
 ### Navigation Principles
 
 - Default screen: active tasks.
-- `j/k` and arrow keys move selection once a focused list is implemented.
+- `j/k` and arrow keys move selection in the Tasks list.
 - `enter` opens focused detail or toggles pane focus once split-pane task browsing is implemented.
 - `/` starts search/filter input once filtering is implemented.
 - `:` opens command palette once command execution is implemented.
@@ -254,7 +254,7 @@ The TUI should be optimized for fast keyboard workflows.
 
 ### Current Shell Keymap
 
-The initial shell implements only global navigation keys:
+The current TUI implements these global navigation and task-list movement keys:
 
 - `1`: Tasks.
 - `2`: Projects.
@@ -262,6 +262,8 @@ The initial shell implements only global navigation keys:
 - `?`: Help.
 - `q`: Back from Help or quit from a root route.
 - `Ctrl+C`: Quit immediately.
+- `j` / `Down Arrow`: Move down in the Tasks list.
+- `k` / `Up Arrow`: Move up in the Tasks list.
 
 ### MVP Task Actions
 

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -54,7 +54,23 @@ function createFailedSnapshot(): DaemonConnectionSnapshot {
   };
 }
 
+function createFakeTask() {
+  return {
+    id: "task-1",
+    title: "Ship",
+    status: "active",
+    priority: "high",
+    projectId: "project-1",
+    labels: ["tui"],
+    assigneeActorIds: [],
+    assignees: [],
+    createdAt: "2026-06-30T00:00:00.000Z",
+    updatedAt: "2026-06-30T00:00:00.000Z",
+  };
+}
+
 function createFakeClient(): TuiToduClient {
+  const task = createFakeTask();
   return {
     actor: { list: vi.fn().mockResolvedValue([]) },
     project: {
@@ -62,8 +78,8 @@ function createFakeClient(): TuiToduClient {
       get: vi.fn(),
     },
     task: {
-      list: vi.fn().mockResolvedValue([{ id: "task-1", title: "Ship" }]),
-      get: vi.fn(),
+      list: vi.fn().mockResolvedValue([task]),
+      get: vi.fn().mockResolvedValue({ ...task, description: "Ship details" }),
       update: vi.fn(),
       createComment: vi.fn(),
     },
@@ -91,7 +107,7 @@ describe("App", () => {
   it("renders the initial TUI shell with daemon connection guidance", () => {
     const connection = createFakeConnection(createFailedSnapshot());
 
-    const { lastFrame } = render(<App connection={connection} />);
+    const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
 
     expect(lastFrame()).toContain("Todu • Tasks");
     expect(lastFrame()).toContain("View: Tasks");
@@ -109,8 +125,8 @@ describe("App", () => {
       />,
     );
 
+    await waitForFrameText(lastFrame, "Ship");
     expect(lastFrame()).toContain("Tasks");
-    expect(lastFrame()).toContain("Task list placeholder.");
 
     stdin.write("2");
     await waitForFrameText(lastFrame, "Projects placeholder.");

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -117,5 +117,5 @@ function RouteScreen({ route, connection, toduClient }: RouteScreenProps): JSX.E
     return <HelpScreen />;
   }
 
-  return <TasksScreen />;
+  return connection.state === "connected" ? <TasksScreen client={toduClient} /> : null;
 }

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -1,0 +1,46 @@
+import type { Project, Task, TaskWithDetail } from "@todu/core";
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import { formatToduClientError } from "../../daemon/todu-client.js";
+import { createProjectNameMap, formatTaskDetailLines } from "../../formatting/task.js";
+
+export interface TaskDetailPaneProps {
+  task: Task | null;
+  detail?: TaskWithDetail;
+  projects?: readonly Project[];
+  isLoadingDetail: boolean;
+  error: unknown;
+}
+
+export function TaskDetailPane({
+  task,
+  detail,
+  projects,
+  isLoadingDetail,
+  error,
+}: TaskDetailPaneProps): JSX.Element {
+  const projectNames = createProjectNameMap(projects);
+  const detailTask = detail ?? task;
+
+  return (
+    <Box flexDirection="column" width="50%" paddingLeft={1}>
+      <Text color="cyan">Detail</Text>
+      {!detailTask ? <Text color="gray">No task selected.</Text> : null}
+      {detailTask
+        ? formatTaskDetailLines(detailTask, projectNames.get(detailTask.projectId) ?? null).map(
+            (line, index) => (
+              <Text
+                key={`${detailTask.id}-${index}`}
+                color={index === 0 ? "white" : "gray"}
+                wrap="truncate-end"
+              >
+                {line}
+              </Text>
+            ),
+          )
+        : null}
+      {isLoadingDetail ? <Text color="yellow">Loading detail…</Text> : null}
+      {error ? <Text color="red">{formatToduClientError(error)}</Text> : null}
+    </Box>
+  );
+}

--- a/packages/tui/src/components/tasks/TaskListPane.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.tsx
@@ -1,0 +1,58 @@
+import type { Project, Task } from "@todu/core";
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+import { createProjectNameMap, formatTaskRow } from "../../formatting/task.js";
+
+const MAX_VISIBLE_TASKS = 12;
+
+export interface TaskListPaneProps {
+  tasks: readonly Task[];
+  projects?: readonly Project[];
+  selectedTaskId: string | null;
+}
+
+export function TaskListPane({ tasks, projects, selectedTaskId }: TaskListPaneProps): JSX.Element {
+  const projectNames = createProjectNameMap(projects);
+  const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, MAX_VISIBLE_TASKS);
+
+  return (
+    <Box flexDirection="column" width="50%" paddingRight={1}>
+      <Text color="cyan">Tasks ({tasks.length})</Text>
+      {visibleTasks.map((task) => {
+        const selected = task.id === selectedTaskId;
+        const prefix = selected ? ">" : " ";
+        return (
+          <Text
+            key={task.id}
+            color={selected ? "cyan" : undefined}
+            inverse={selected}
+            wrap="truncate-end"
+          >
+            {prefix} {formatTaskRow(task, projectNames.get(task.projectId) ?? null)}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function getVisibleTaskWindow<T extends { id: string }>(
+  tasks: readonly T[],
+  selectedTaskId: string | null,
+  maxVisible: number,
+): readonly T[] {
+  if (tasks.length <= maxVisible) {
+    return tasks;
+  }
+
+  const selectedIndex = selectedTaskId
+    ? Math.max(
+        0,
+        tasks.findIndex((task) => task.id === selectedTaskId),
+      )
+    : 0;
+  const halfWindow = Math.floor(maxVisible / 2);
+  const start = Math.min(Math.max(0, selectedIndex - halfWindow), tasks.length - maxVisible);
+
+  return tasks.slice(start, start + maxVisible);
+}

--- a/packages/tui/src/formatting/priority.ts
+++ b/packages/tui/src/formatting/priority.ts
@@ -1,0 +1,9 @@
+import type { TaskPriority } from "@todu/core";
+
+export function formatTaskPriority(priority: TaskPriority): string {
+  if (priority === "medium") {
+    return "med";
+  }
+
+  return priority;
+}

--- a/packages/tui/src/formatting/status.ts
+++ b/packages/tui/src/formatting/status.ts
@@ -1,0 +1,9 @@
+import type { TaskStatus } from "@todu/core";
+
+export function formatTaskStatus(status: TaskStatus): string {
+  if (status === "inprogress") {
+    return "doing";
+  }
+
+  return status;
+}

--- a/packages/tui/src/formatting/task.test.ts
+++ b/packages/tui/src/formatting/task.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatTaskDetailLines, formatTaskRow } from "./task.js";
+
+const task = {
+  id: "task-1",
+  title: "Ship the TUI task read model",
+  status: "inprogress",
+  priority: "medium",
+  projectId: "project-1",
+  labels: ["tui", "spec"],
+  assigneeActorIds: [],
+  assignees: [],
+  createdAt: "2026-06-30T00:00:00.000Z",
+  updatedAt: "2026-06-30T00:00:00.000Z",
+} as const;
+
+describe("task formatting", () => {
+  it("formats compact task rows", () => {
+    expect(formatTaskRow(task, "todu")).toBe(
+      "[med] [doing] Ship the TUI task read model (todu) #tui #spec",
+    );
+  });
+
+  it("formats selected task details", () => {
+    expect(formatTaskDetailLines({ ...task, description: "Read-only browsing." }, "todu")).toEqual([
+      "Ship the TUI task read model",
+      "Status: doing",
+      "Priority: med",
+      "Project: todu",
+      "Labels: #tui #spec",
+      "",
+      "Description",
+      "Read-only browsing.",
+    ]);
+  });
+});

--- a/packages/tui/src/formatting/task.ts
+++ b/packages/tui/src/formatting/task.ts
@@ -1,0 +1,50 @@
+import type { Project, Task, TaskWithDetail } from "@todu/core";
+import { formatTaskPriority } from "./priority.js";
+import { formatTaskStatus } from "./status.js";
+import { truncateText } from "./truncate.js";
+
+export function formatTaskRow(task: Task, projectName: string | null, maxTitleLength = 42): string {
+  const parts = [
+    `[${formatTaskPriority(task.priority)}]`,
+    `[${formatTaskStatus(task.status)}]`,
+    truncateText(task.title, maxTitleLength),
+  ];
+
+  if (projectName) {
+    parts.push(`(${projectName})`);
+  }
+
+  if (task.labels.length > 0) {
+    parts.push(task.labels.map((label) => `#${label}`).join(" "));
+  }
+
+  return parts.join(" ");
+}
+
+export function formatTaskDetailLines(
+  task: TaskWithDetail | Task,
+  projectName: string | null,
+): string[] {
+  const lines = [
+    task.title,
+    `Status: ${formatTaskStatus(task.status)}`,
+    `Priority: ${formatTaskPriority(task.priority)}`,
+    `Project: ${projectName ?? task.projectId}`,
+  ];
+
+  if (task.labels.length > 0) {
+    lines.push(`Labels: ${task.labels.map((label) => `#${label}`).join(" ")}`);
+  }
+
+  if ("description" in task && task.description?.trim()) {
+    lines.push("", "Description", task.description.trim());
+  }
+
+  return lines;
+}
+
+export function createProjectNameMap(
+  projects: readonly Project[] | undefined,
+): Map<string, string> {
+  return new Map((projects ?? []).map((project) => [project.id, project.name]));
+}

--- a/packages/tui/src/formatting/truncate.ts
+++ b/packages/tui/src/formatting/truncate.ts
@@ -1,0 +1,15 @@
+export function truncateText(value: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return "";
+  }
+
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  if (maxLength === 1) {
+    return "…";
+  }
+
+  return `${value.slice(0, maxLength - 1)}…`;
+}

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "ink-testing-library";
+import type { JSX, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { type TuiToduClient, TuiToduClientError } from "../daemon/todu-client.js";
+import { createTuiQueryClient } from "../state/query-client.js";
+import { TasksScreen } from "./TasksScreen.js";
+
+function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
+  const queryClient = createTuiQueryClient();
+  function Wrapper(): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return render(<Wrapper />);
+}
+
+function createTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "task-1",
+    title: "First task",
+    status: "active",
+    priority: "high",
+    projectId: "project-1",
+    labels: ["tui"],
+    assigneeActorIds: [],
+    assignees: [],
+    createdAt: "2026-06-30T00:00:00.000Z",
+    updatedAt: "2026-06-30T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
+  const tasks = [
+    createTask(),
+    createTask({ id: "task-2", title: "Second task", status: "waiting", priority: "medium" }),
+  ];
+
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: {
+      list: vi.fn().mockResolvedValue([{ id: "project-1", name: "todu" }]),
+      get: vi.fn(),
+    },
+    task: {
+      list: vi.fn().mockResolvedValue(tasks),
+      get: vi.fn().mockImplementation((id: string) => {
+        const task = tasks.find((entry) => entry.id === id) ?? tasks[0];
+        return Promise.resolve({ ...task, description: `Description for ${task.title}` });
+      }),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+    ...overrides,
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (lastFrame()?.includes(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
+describe("TasksScreen", () => {
+  it("renders fetched tasks and selected task details", async () => {
+    const client = createClient();
+    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "First task");
+    await waitForFrameText(lastFrame, "Description for First task");
+
+    expect(lastFrame()).toContain("Tasks (2)");
+    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+    expect(lastFrame()).toContain("Second task");
+    expect(lastFrame()).toContain("Detail");
+    expect(lastFrame()).toContain("Status: active");
+  });
+
+  it("moves selection with j/k and arrow keys and updates detail", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "Description for First task");
+
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "Description for Second task");
+    expect(lastFrame()).toContain("> [med] [waiting] Second task (todu) #tui");
+
+    stdin.write("k");
+    await waitForFrameText(lastFrame, "Description for First task");
+    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+
+    stdin.write("\u001B[B");
+    await waitForFrameText(lastFrame, "Description for Second task");
+    expect(lastFrame()).toContain("> [med] [waiting] Second task (todu) #tui");
+
+    stdin.write("\u001B[A");
+    await waitForFrameText(lastFrame, "Description for First task");
+    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+  });
+
+  it("renders empty state", async () => {
+    const client = createClient({
+      task: {
+        list: vi.fn().mockResolvedValue([]),
+        get: vi.fn(),
+        update: vi.fn(),
+        createComment: vi.fn(),
+      },
+    });
+    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks.");
+  });
+
+  it("renders user-facing errors", async () => {
+    const client = createClient({
+      task: {
+        list: vi.fn().mockRejectedValue(
+          new TuiToduClientError({
+            method: "task.list",
+            code: "DAEMON_UNAVAILABLE",
+            message: "task.list failed (DAEMON_UNAVAILABLE): socket missing",
+            userMessage: "Daemon unavailable. Start it with: todu daemon start.",
+          }),
+        ),
+        get: vi.fn(),
+        update: vi.fn(),
+        createComment: vi.fn(),
+      },
+    });
+    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "Tasks unavailable");
+    expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");
+  });
+});

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,12 +1,93 @@
-import { Box, Text } from "ink";
+import { useQuery } from "@tanstack/react-query";
+import { Box, Text, useInput } from "ink";
 import type { JSX } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
+import { TaskListPane } from "../components/tasks/TaskListPane.js";
+import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { queryKeys } from "../state/query-keys.js";
+import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
 
-export function TasksScreen(): JSX.Element {
+export interface TasksScreenProps {
+  client: TuiToduClient;
+}
+
+const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
+
+export function TasksScreen({ client }: TasksScreenProps): JSX.Element {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const tasksQuery = useQuery({
+    queryKey: queryKeys.tasks({ status: [...visibleTaskStatuses] }),
+    queryFn: () => client.task.list({ status: [...visibleTaskStatuses] }),
+  });
+  const projectsQuery = useQuery({
+    queryKey: queryKeys.projects(),
+    queryFn: () => client.project.list(),
+  });
+  const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
+  const selectedTask = getSelectedItem(tasks, selectedTaskId);
+  const selectedDetailQuery = useQuery({
+    queryKey: queryKeys.task(selectedTaskId ?? "none"),
+    queryFn: () => client.task.get(selectedTaskId ?? ""),
+    enabled: selectedTaskId !== null,
+  });
+
+  useEffect(() => {
+    if (!tasksQuery.data) {
+      return;
+    }
+
+    setSelectedTaskId((current) => resolveSelectedId(tasksQuery.data ?? [], current));
+  }, [tasksQuery.data]);
+
+  useInput((input, key) => {
+    if (tasks.length === 0) {
+      return;
+    }
+
+    if (input === "j" || key.downArrow) {
+      setSelectedTaskId((current) => moveSelection(tasks, current, "next"));
+      return;
+    }
+
+    if (input === "k" || key.upArrow) {
+      setSelectedTaskId((current) => moveSelection(tasks, current, "previous"));
+    }
+  });
+
+  const error = tasksQuery.error ?? projectsQuery.error;
+  if (error) {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Tasks unavailable</Text>
+        <Text color="gray">{formatToduClientError(error)}</Text>
+      </Box>
+    );
+  }
+
+  if (tasksQuery.isLoading) {
+    return <Text color="yellow">Loading tasks…</Text>;
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text color="cyan">Tasks</Text>
+        <Text color="gray">No active, in-progress, or waiting tasks.</Text>
+      </Box>
+    );
+  }
+
   return (
-    <Box flexDirection="column">
-      <Text color="cyan">Tasks</Text>
-      <Text color="gray">Task list placeholder.</Text>
-      <Text color="gray">The next TUI task will add active task browsing and details.</Text>
+    <Box flexDirection="row">
+      <TaskListPane tasks={tasks} projects={projectsQuery.data} selectedTaskId={selectedTaskId} />
+      <TaskDetailPane
+        task={selectedTask}
+        detail={selectedDetailQuery.data}
+        projects={projectsQuery.data}
+        isLoadingDetail={selectedDetailQuery.isLoading}
+        error={selectedDetailQuery.error}
+      />
     </Box>
   );
 }

--- a/packages/tui/src/state/selection.test.ts
+++ b/packages/tui/src/state/selection.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getSelectedItem, moveSelection, resolveSelectedId } from "./selection.js";
+
+const items = [{ id: "task-1" }, { id: "task-2" }, { id: "task-3" }];
+
+describe("selection helpers", () => {
+  it("preserves the current selected ID when it still exists", () => {
+    expect(resolveSelectedId(items, "task-2")).toBe("task-2");
+  });
+
+  it("falls back to the first item when the selected ID disappears", () => {
+    expect(resolveSelectedId(items, "missing")).toBe("task-1");
+  });
+
+  it("returns null for empty lists", () => {
+    expect(resolveSelectedId([], "task-1")).toBeNull();
+  });
+
+  it("moves selection within bounds", () => {
+    expect(moveSelection(items, "task-1", "next")).toBe("task-2");
+    expect(moveSelection(items, "task-2", "previous")).toBe("task-1");
+    expect(moveSelection(items, "task-3", "next")).toBe("task-3");
+    expect(moveSelection(items, "task-1", "previous")).toBe("task-1");
+  });
+
+  it("returns the selected item", () => {
+    expect(getSelectedItem(items, "task-2")).toEqual({ id: "task-2" });
+  });
+});

--- a/packages/tui/src/state/selection.ts
+++ b/packages/tui/src/state/selection.ts
@@ -1,0 +1,40 @@
+export function resolveSelectedId<T extends { id: string }>(
+  items: readonly T[],
+  currentSelectedId: string | null,
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  if (currentSelectedId && items.some((item) => item.id === currentSelectedId)) {
+    return currentSelectedId;
+  }
+
+  return items[0]?.id ?? null;
+}
+
+export function moveSelection<T extends { id: string }>(
+  items: readonly T[],
+  currentSelectedId: string | null,
+  direction: "next" | "previous",
+): string | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const currentIndex = currentSelectedId
+    ? items.findIndex((item) => item.id === currentSelectedId)
+    : -1;
+  const safeIndex = currentIndex >= 0 ? currentIndex : 0;
+  const delta = direction === "next" ? 1 : -1;
+  const nextIndex = Math.max(0, Math.min(items.length - 1, safeIndex + delta));
+
+  return items[nextIndex]?.id ?? null;
+}
+
+export function getSelectedItem<T extends { id: string }>(
+  items: readonly T[],
+  selectedId: string | null,
+): T | null {
+  return items.find((item) => item.id === selectedId) ?? null;
+}


### PR DESCRIPTION
## Summary
- replace the Tasks placeholder with a daemon-backed task list/detail browser
- fetch active/in-progress/waiting tasks, projects for labels, and selected task details
- add j/k and arrow-key selection movement with selection preservation helpers
- add loading, empty, and user-facing error states
- update TUI keymap docs and add a TUI patch changeset

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr
- dev-daemon smoke check showed real task list/detail rendering with project label and description

Task: task-b8fa8878