### PR TITLE
Add TUI project filtering

### DIFF
--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -262,8 +262,10 @@ The current TUI implements these global navigation and task-list movement keys:
 - `?`: Help.
 - `q`: Back from Help or quit from a root route.
 - `Ctrl+C`: Quit immediately.
-- `j` / `Down Arrow`: Move down in the Tasks list.
-- `k` / `Up Arrow`: Move up in the Tasks list.
+- `j` / `Down Arrow`: Move down in the Tasks or Projects list.
+- `k` / `Up Arrow`: Move up in the Tasks or Projects list.
+- `Enter`: Select the focused project and open Tasks filtered by that project.
+- `a`: Clear the project filter and open Tasks for all projects.
 
 ### MVP Task Actions
 
@@ -285,17 +287,18 @@ The current TUI implements these global navigation and task-list movement keys:
    - Sort by priority or updated/due date once due dates exist.
    - Selected task detail pane.
 
-2. **Task detail**
+2. **Projects**
+   - Project list with an `All projects` option.
+   - Selected project summary.
+   - `Enter` opens Tasks filtered by the focused project.
+   - `a` clears the filter and returns to all-project Tasks.
+   - The active project filter is shown in the shell status line.
+
+3. **Task detail**
    - Full title, status, priority, project, labels, assignees.
    - Description rendered as terminal markdown where practical.
    - Recent comments/notes.
    - Status/comment actions.
-
-3. **Projects**
-   - Project list.
-   - Project detail summary.
-   - Filter tasks by selected project.
-   - Create/update can be deferred unless they fall out naturally from shared mutation patterns.
 
 4. **Help / command palette**
    - Discoverable shortcuts.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -8,6 +8,7 @@ import type {
   DaemonConnectionSnapshot,
 } from "../daemon/connection.js";
 import type { TuiToduClient } from "../daemon/todu-client.js";
+import { allProjectsFilter } from "../state/project-filter.js";
 import { App } from "./App.js";
 import { applyNavigationAction, createInitialRouteState } from "./keymap.js";
 
@@ -74,7 +75,18 @@ function createFakeClient(): TuiToduClient {
   return {
     actor: { list: vi.fn().mockResolvedValue([]) },
     project: {
-      list: vi.fn().mockResolvedValue([{ id: "project-1", name: "Inbox" }]),
+      list: vi.fn().mockResolvedValue([
+        {
+          id: "project-1",
+          name: "Inbox",
+          description: "Default project",
+          status: "active",
+          priority: "medium",
+          authorizedAssigneeActorIds: [],
+          createdAt: "2026-06-30T00:00:00.000Z",
+          updatedAt: "2026-06-30T00:00:00.000Z",
+        },
+      ]),
       get: vi.fn(),
     },
     task: {
@@ -115,6 +127,7 @@ describe("App", () => {
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Tasks");
     expect(lastFrame()).toContain("q Back/Quit");
+    expect(lastFrame()).toContain("Project: All projects");
   });
 
   it("switches between primary routes", async () => {
@@ -129,13 +142,57 @@ describe("App", () => {
     expect(lastFrame()).toContain("Tasks");
 
     stdin.write("2");
-    await waitForFrameText(lastFrame, "Projects placeholder.");
+    await waitForFrameText(lastFrame, "Project detail");
     expect(lastFrame()).toContain("View: Projects");
 
     stdin.write("3");
     await waitForFrameText(lastFrame, "Data status ready");
     expect(lastFrame()).toContain("Projects: 1");
     expect(lastFrame()).toContain("Tasks: 1");
+  });
+
+  it("selects a project and filters Tasks", async () => {
+    const client = createFakeClient();
+    const { stdin, lastFrame } = render(
+      <App connection={createFakeConnection(createConnectedSnapshot())} toduClient={client} />,
+    );
+
+    await waitForFrameText(lastFrame, "Ship");
+    stdin.write("2");
+    await waitForFrameText(lastFrame, "Project detail");
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "Default project");
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "Project: Inbox");
+
+    await vi.waitFor(() => {
+      expect(client.task.list).toHaveBeenCalledWith({
+        status: ["active", "inprogress", "waiting"],
+        projectId: "project-1",
+      });
+    });
+  });
+
+  it("clears project filter from Projects with a", async () => {
+    const { stdin, lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Ship");
+    stdin.write("2");
+    await waitForFrameText(lastFrame, "Project detail");
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "Default project");
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "Project: Inbox");
+
+    stdin.write("2");
+    await waitForFrameText(lastFrame, "Project detail");
+    stdin.write("a");
+    await waitForFrameText(lastFrame, "Project: All projects");
   });
 
   it("shows help with implemented keys", async () => {
@@ -153,6 +210,9 @@ describe("App", () => {
     expect(lastFrame()).toContain("2      Projects");
     expect(lastFrame()).toContain("3      Data Status");
     expect(lastFrame()).toContain("?      Help");
+    expect(lastFrame()).toContain("j/↓    Down");
+    expect(lastFrame()).toContain("Enter  Select Project");
+    expect(lastFrame()).toContain("a      All Projects");
     expect(lastFrame()).toContain("q      Back/Quit");
     expect(lastFrame()).toContain("Ctrl+C Quit");
   });
@@ -168,12 +228,12 @@ describe("App", () => {
     );
 
     stdin.write("2");
-    await waitForFrameText(lastFrame, "Projects placeholder.");
+    await waitForFrameText(lastFrame, "Project detail");
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
 
     stdin.write("q");
-    await waitForFrameText(lastFrame, "Projects placeholder.");
+    await waitForFrameText(lastFrame, "Project detail");
     expect(onExit).not.toHaveBeenCalled();
 
     stdin.write("q");
@@ -191,7 +251,12 @@ describe("App", () => {
 
   it("renders the frame at narrow widths without wrapping route labels into exceptions", () => {
     const { lastFrame } = render(
-      <AppFrame route="data-status" connection={createConnectedSnapshot()} terminalWidth={24}>
+      <AppFrame
+        route="data-status"
+        connection={createConnectedSnapshot()}
+        projectFilter={allProjectsFilter}
+        terminalWidth={24}
+      >
         <TextFixture />
       </AppFrame>,
     );

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -12,6 +12,11 @@ import { DataStatusScreen } from "../screens/DataStatusScreen.js";
 import { HelpScreen } from "../screens/HelpScreen.js";
 import { ProjectsScreen } from "../screens/ProjectsScreen.js";
 import { TasksScreen } from "../screens/TasksScreen.js";
+import {
+  allProjectsFilter,
+  createProjectFilter,
+  type ProjectFilterState,
+} from "../state/project-filter.js";
 import { createTuiQueryClient, TuiQueryProvider } from "../state/query-client.js";
 import {
   applyNavigationAction,
@@ -55,6 +60,7 @@ function AppContent({
     [connection, providedToduClient],
   );
   const [routeState, setRouteState] = useState(createInitialRouteState);
+  const [projectFilter, setProjectFilter] = useState<ProjectFilterState>(allProjectsFilter);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
   );
@@ -87,12 +93,25 @@ function AppContent({
   }, [connection]);
 
   return (
-    <AppFrame route={routeState.route} connection={connectionSnapshot}>
+    <AppFrame
+      route={routeState.route}
+      connection={connectionSnapshot}
+      projectFilter={projectFilter}
+    >
       <ConnectionState connection={connectionSnapshot} />
       <RouteScreen
         route={routeState.route}
         connection={connectionSnapshot}
         toduClient={toduClient}
+        projectFilter={projectFilter}
+        onSelectProject={(project) => {
+          setProjectFilter(createProjectFilter(project));
+          setRouteState({ route: "tasks", previousRoute: "tasks" });
+        }}
+        onSelectAllProjects={() => {
+          setProjectFilter(allProjectsFilter);
+          setRouteState({ route: "tasks", previousRoute: "tasks" });
+        }}
       />
     </AppFrame>
   );
@@ -102,11 +121,28 @@ interface RouteScreenProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
   toduClient: TuiToduClient;
+  projectFilter: ProjectFilterState;
+  onSelectProject: (project: import("@todu/core").Project) => void;
+  onSelectAllProjects: () => void;
 }
 
-function RouteScreen({ route, connection, toduClient }: RouteScreenProps): JSX.Element | null {
+function RouteScreen({
+  route,
+  connection,
+  toduClient,
+  projectFilter,
+  onSelectProject,
+  onSelectAllProjects,
+}: RouteScreenProps): JSX.Element | null {
   if (route === "projects") {
-    return <ProjectsScreen />;
+    return connection.state === "connected" ? (
+      <ProjectsScreen
+        client={toduClient}
+        projectFilter={projectFilter}
+        onSelectProject={onSelectProject}
+        onSelectAllProjects={onSelectAllProjects}
+      />
+    ) : null;
   }
 
   if (route === "data-status") {
@@ -117,5 +153,7 @@ function RouteScreen({ route, connection, toduClient }: RouteScreenProps): JSX.E
     return <HelpScreen />;
   }
 
-  return connection.state === "connected" ? <TasksScreen client={toduClient} /> : null;
+  return connection.state === "connected" ? (
+    <TasksScreen client={toduClient} projectFilter={projectFilter} />
+  ) : null;
 }

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -11,6 +11,10 @@ export const globalKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "3", description: "Data Status" },
   { keys: "?", description: "Help" },
   { keys: "q", description: "Back/Quit" },
+  { keys: "j/↓", description: "Down" },
+  { keys: "k/↑", description: "Up" },
+  { keys: "Enter", description: "Select Project" },
+  { keys: "a", description: "All Projects" },
   { keys: "Ctrl+C", description: "Quit" },
 ] as const;
 

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -2,12 +2,14 @@ import { Box, Text, useStdout } from "ink";
 import type { JSX, ReactNode } from "react";
 import { type AppRoute, routeLabels } from "../app/routes.js";
 import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+import type { ProjectFilterState } from "../state/project-filter.js";
 import { HelpBar } from "./HelpBar.js";
 import { StatusLine } from "./StatusLine.js";
 
 export interface AppFrameProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
+  projectFilter: ProjectFilterState;
   children: ReactNode;
   terminalWidth?: number;
 }
@@ -15,6 +17,7 @@ export interface AppFrameProps {
 export function AppFrame({
   route,
   connection,
+  projectFilter,
   children,
   terminalWidth,
 }: AppFrameProps): JSX.Element {
@@ -32,7 +35,7 @@ export function AppFrame({
           • {routeLabels[route]}
         </Text>
       </Box>
-      <StatusLine route={route} connection={connection} />
+      <StatusLine route={route} connection={connection} projectFilter={projectFilter} />
       <Box flexDirection="column" marginY={1}>
         {children}
       </Box>

--- a/packages/tui/src/components/StatusLine.tsx
+++ b/packages/tui/src/components/StatusLine.tsx
@@ -2,16 +2,19 @@ import { Text } from "ink";
 import type { JSX } from "react";
 import { type AppRoute, routeLabels } from "../app/routes.js";
 import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
 
 export interface StatusLineProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
+  projectFilter: ProjectFilterState;
 }
 
-export function StatusLine({ route, connection }: StatusLineProps): JSX.Element {
+export function StatusLine({ route, connection, projectFilter }: StatusLineProps): JSX.Element {
   return (
     <Text color="gray" wrap="truncate-end">
-      View: {routeLabels[route]} • Daemon: {formatConnectionState(connection)}
+      View: {routeLabels[route]} • Project: {describeProjectFilter(projectFilter)} • Daemon:{" "}
+      {formatConnectionState(connection)}
     </Text>
   );
 }

--- a/packages/tui/src/screens/ProjectsScreen.test.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.test.tsx
@@ -1,0 +1,201 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "ink-testing-library";
+import type { JSX, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { type TuiToduClient, TuiToduClientError } from "../daemon/todu-client.js";
+import { allProjectsFilter } from "../state/project-filter.js";
+import { createTuiQueryClient } from "../state/query-client.js";
+import {
+  createProjectOptions,
+  moveProjectOption,
+  ProjectsScreen,
+  resolveProjectOptionId,
+} from "./ProjectsScreen.js";
+
+function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
+  const queryClient = createTuiQueryClient();
+  function Wrapper(): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return render(<Wrapper />);
+}
+
+function createProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "project-1",
+    name: "Inbox",
+    description: "Default project",
+    status: "active",
+    priority: "medium",
+    authorizedAssigneeActorIds: [],
+    createdAt: "2026-06-30T00:00:00.000Z",
+    updatedAt: "2026-06-30T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: {
+      list: vi
+        .fn()
+        .mockResolvedValue([
+          createProject(),
+          createProject({ id: "project-2", name: "Work", description: "Work project" }),
+        ]),
+      get: vi.fn(),
+    },
+    task: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn(),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+    ...overrides,
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (lastFrame()?.includes(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
+describe("ProjectsScreen", () => {
+  it("renders projects and selected project details", async () => {
+    const { lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={createClient()}
+        projectFilter={allProjectsFilter}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Projects (2)");
+
+    expect(lastFrame()).toContain("> All projects");
+    expect(lastFrame()).toContain("Inbox");
+    expect(lastFrame()).toContain("Work");
+    expect(lastFrame()).toContain("Project detail");
+    expect(lastFrame()).toContain("Press Enter or a to show tasks from every");
+    expect(lastFrame()).toContain("project.");
+  });
+
+  it("moves selection and selects a project with enter", async () => {
+    const onSelectProject = vi.fn();
+    const { stdin, lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={createClient()}
+        projectFilter={allProjectsFilter}
+        onSelectProject={onSelectProject}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Projects (2)");
+
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "Default project");
+    stdin.write("\r");
+
+    expect(onSelectProject).toHaveBeenCalledWith(expect.objectContaining({ id: "project-1" }));
+  });
+
+  it("clears to all projects with a", async () => {
+    const onSelectAllProjects = vi.fn();
+    const { stdin, lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={createClient()}
+        projectFilter={{ projectId: "project-1", projectName: "Inbox" }}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={onSelectAllProjects}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Projects (2)");
+    stdin.write("a");
+
+    expect(onSelectAllProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders empty state", async () => {
+    const client = createClient({
+      project: { list: vi.fn().mockResolvedValue([]), get: vi.fn() },
+    });
+    const { lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "No projects available.");
+  });
+
+  it("renders user-facing errors", async () => {
+    const client = createClient({
+      project: {
+        list: vi.fn().mockRejectedValue(
+          new TuiToduClientError({
+            method: "project.list",
+            code: "DAEMON_UNAVAILABLE",
+            message: "project.list failed (DAEMON_UNAVAILABLE): socket missing",
+            userMessage: "Daemon unavailable. Start it with: todu daemon start.",
+          }),
+        ),
+        get: vi.fn(),
+      },
+    });
+    const { lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Projects unavailable");
+    expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");
+  });
+});
+
+describe("project option helpers", () => {
+  it("adds all projects before fetched projects", () => {
+    expect(createProjectOptions([createProject()])).toEqual([
+      { id: "__all__", label: "All projects", project: null },
+      { id: "project-1", label: "Inbox", project: createProject() },
+    ]);
+  });
+
+  it("preserves or falls back selected option IDs", () => {
+    const options = createProjectOptions([createProject()]);
+
+    expect(resolveProjectOptionId(options, "project-1")).toBe("project-1");
+    expect(resolveProjectOptionId(options, "missing")).toBe("__all__");
+  });
+
+  it("moves project option selection within bounds", () => {
+    const options = createProjectOptions([createProject()]);
+
+    expect(moveProjectOption(options, "__all__", "next")).toBe("project-1");
+    expect(moveProjectOption(options, "project-1", "previous")).toBe("__all__");
+    expect(moveProjectOption(options, "project-1", "next")).toBe("project-1");
+  });
+});

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -1,12 +1,197 @@
-import { Box, Text } from "ink";
+import { useQuery } from "@tanstack/react-query";
+import type { Project } from "@todu/core";
+import { Box, Text, useInput } from "ink";
 import type { JSX } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import type { ProjectFilterState } from "../state/project-filter.js";
+import { queryKeys } from "../state/query-keys.js";
 
-export function ProjectsScreen(): JSX.Element {
+const ALL_PROJECTS_OPTION_ID = "__all__";
+
+interface ProjectOption {
+  id: string;
+  label: string;
+  project: Project | null;
+}
+
+export interface ProjectsScreenProps {
+  client: TuiToduClient;
+  projectFilter: ProjectFilterState;
+  onSelectProject: (project: Project) => void;
+  onSelectAllProjects: () => void;
+}
+
+export function ProjectsScreen({
+  client,
+  projectFilter,
+  onSelectProject,
+  onSelectAllProjects,
+}: ProjectsScreenProps): JSX.Element {
+  const [selectedOptionId, setSelectedOptionId] = useState<string>(
+    projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
+  );
+  const projectsQuery = useQuery({
+    queryKey: queryKeys.projects(),
+    queryFn: () => client.project.list(),
+  });
+  const projectOptions = useMemo(
+    () => createProjectOptions(projectsQuery.data ?? []),
+    [projectsQuery.data],
+  );
+  const selectedOption =
+    projectOptions.find((option) => option.id === selectedOptionId) ?? projectOptions[0];
+
+  useEffect(() => {
+    if (!projectsQuery.data) {
+      return;
+    }
+
+    setSelectedOptionId((current) => resolveProjectOptionId(projectOptions, current));
+  }, [projectOptions, projectsQuery.data]);
+
+  useInput((input, key) => {
+    if (input === "a") {
+      onSelectAllProjects();
+      return;
+    }
+
+    if (input === "\r") {
+      if (selectedOption?.project) {
+        onSelectProject(selectedOption.project);
+        return;
+      }
+
+      onSelectAllProjects();
+      return;
+    }
+
+    if (input === "j" || key.downArrow) {
+      setSelectedOptionId((current) => moveProjectOption(projectOptions, current, "next"));
+      return;
+    }
+
+    if (input === "k" || key.upArrow) {
+      setSelectedOptionId((current) => moveProjectOption(projectOptions, current, "previous"));
+    }
+  });
+
+  if (projectsQuery.error) {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">Projects unavailable</Text>
+        <Text color="gray">{formatToduClientError(projectsQuery.error)}</Text>
+      </Box>
+    );
+  }
+
+  if (projectsQuery.isLoading) {
+    return <Text color="yellow">Loading projects…</Text>;
+  }
+
+  if ((projectsQuery.data ?? []).length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text color="cyan">Projects</Text>
+        <Text color="gray">No projects available.</Text>
+        <Text color="gray">Press a to show tasks from all projects.</Text>
+      </Box>
+    );
+  }
+
   return (
-    <Box flexDirection="column">
-      <Text color="cyan">Projects</Text>
-      <Text color="gray">Projects placeholder.</Text>
-      <Text color="gray">Project filtering lands after the task read model.</Text>
+    <Box flexDirection="row">
+      <Box flexDirection="column" width="50%" paddingRight={1}>
+        <Text color="cyan">Projects ({projectsQuery.data?.length ?? 0})</Text>
+        {projectOptions.map((option) => {
+          const selected = option.id === selectedOption?.id;
+          return (
+            <Text
+              key={option.id}
+              color={selected ? "cyan" : undefined}
+              inverse={selected}
+              wrap="truncate-end"
+            >
+              {selected ? ">" : " "} {option.label}
+            </Text>
+          );
+        })}
+      </Box>
+      <ProjectDetail option={selectedOption} activeFilter={projectFilter} />
     </Box>
   );
+}
+
+function ProjectDetail({
+  option,
+  activeFilter,
+}: {
+  option: ProjectOption | undefined;
+  activeFilter: ProjectFilterState;
+}): JSX.Element {
+  if (!option?.project) {
+    return (
+      <Box flexDirection="column" width="50%" paddingLeft={1}>
+        <Text color="cyan">Project detail</Text>
+        <Text color="gray">All projects</Text>
+        <Text color="gray">Press Enter or a to show tasks from every project.</Text>
+        <Text color="gray">Current filter: {activeFilter.projectName ?? "All projects"}</Text>
+      </Box>
+    );
+  }
+
+  const project = option.project;
+  return (
+    <Box flexDirection="column" width="50%" paddingLeft={1}>
+      <Text color="cyan">Project detail</Text>
+      <Text color="white" wrap="truncate-end">
+        {project.name}
+      </Text>
+      <Text color="gray">Status: {project.status}</Text>
+      <Text color="gray">Priority: {project.priority}</Text>
+      {project.description ? (
+        <Text color="gray" wrap="truncate-end">
+          {project.description}
+        </Text>
+      ) : null}
+      <Text color="gray">Press Enter to filter Tasks by this project.</Text>
+      <Text color="gray">Press a for all projects.</Text>
+    </Box>
+  );
+}
+
+export function createProjectOptions(projects: readonly Project[]): ProjectOption[] {
+  return [
+    { id: ALL_PROJECTS_OPTION_ID, label: "All projects", project: null },
+    ...projects.map((project) => ({ id: project.id, label: project.name, project })),
+  ];
+}
+
+export function resolveProjectOptionId(
+  options: readonly ProjectOption[],
+  currentOptionId: string,
+): string {
+  if (options.some((option) => option.id === currentOptionId)) {
+    return currentOptionId;
+  }
+
+  return options[0]?.id ?? ALL_PROJECTS_OPTION_ID;
+}
+
+export function moveProjectOption(
+  options: readonly ProjectOption[],
+  currentOptionId: string,
+  direction: "next" | "previous",
+): string {
+  if (options.length === 0) {
+    return ALL_PROJECTS_OPTION_ID;
+  }
+
+  const currentIndex = Math.max(
+    0,
+    options.findIndex((option) => option.id === currentOptionId),
+  );
+  const delta = direction === "next" ? 1 : -1;
+  const nextIndex = Math.max(0, Math.min(options.length - 1, currentIndex + delta));
+  return options[nextIndex]?.id ?? ALL_PROJECTS_OPTION_ID;
 }

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -3,6 +3,7 @@ import { render } from "ink-testing-library";
 import type { JSX, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { type TuiToduClient, TuiToduClientError } from "../daemon/todu-client.js";
+import { allProjectsFilter } from "../state/project-filter.js";
 import { createTuiQueryClient } from "../state/query-client.js";
 import { TasksScreen } from "./TasksScreen.js";
 
@@ -76,7 +77,9 @@ async function waitForFrameText(lastFrame: () => string | undefined, text: strin
 describe("TasksScreen", () => {
   it("renders fetched tasks and selected task details", async () => {
     const client = createClient();
-    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+    const { lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
 
     await waitForFrameText(lastFrame, "First task");
     await waitForFrameText(lastFrame, "Description for First task");
@@ -90,7 +93,9 @@ describe("TasksScreen", () => {
 
   it("moves selection with j/k and arrow keys and updates detail", async () => {
     const client = createClient();
-    const { stdin, lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
 
     await waitForFrameText(lastFrame, "Description for First task");
 
@@ -111,6 +116,23 @@ describe("TasksScreen", () => {
     expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
   });
 
+  it("passes selected project ID to task list filter", async () => {
+    const client = createClient();
+    renderWithQuery(
+      <TasksScreen
+        client={client}
+        projectFilter={{ projectId: "project-1", projectName: "todu" }}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(client.task.list).toHaveBeenCalledWith({
+        status: ["active", "inprogress", "waiting"],
+        projectId: "project-1",
+      });
+    });
+  });
+
   it("renders empty state", async () => {
     const client = createClient({
       task: {
@@ -120,9 +142,11 @@ describe("TasksScreen", () => {
         createComment: vi.fn(),
       },
     });
-    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+    const { lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
 
-    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks.");
+    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks for All projects.");
   });
 
   it("renders user-facing errors", async () => {
@@ -141,7 +165,9 @@ describe("TasksScreen", () => {
         createComment: vi.fn(),
       },
     });
-    const { lastFrame } = renderWithQuery(<TasksScreen client={client} />);
+    const { lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
 
     await waitForFrameText(lastFrame, "Tasks unavailable");
     expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -5,20 +5,26 @@ import { useEffect, useMemo, useState } from "react";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
 
 export interface TasksScreenProps {
   client: TuiToduClient;
+  projectFilter: ProjectFilterState;
 }
 
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
 
-export function TasksScreen({ client }: TasksScreenProps): JSX.Element {
+export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.Element {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const taskFilter = {
+    status: [...visibleTaskStatuses],
+    ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
+  };
   const tasksQuery = useQuery({
-    queryKey: queryKeys.tasks({ status: [...visibleTaskStatuses] }),
-    queryFn: () => client.task.list({ status: [...visibleTaskStatuses] }),
+    queryKey: queryKeys.tasks(taskFilter),
+    queryFn: () => client.task.list(taskFilter),
   });
   const projectsQuery = useQuery({
     queryKey: queryKeys.projects(),
@@ -73,7 +79,9 @@ export function TasksScreen({ client }: TasksScreenProps): JSX.Element {
     return (
       <Box flexDirection="column">
         <Text color="cyan">Tasks</Text>
-        <Text color="gray">No active, in-progress, or waiting tasks.</Text>
+        <Text color="gray">
+          No active, in-progress, or waiting tasks for {describeProjectFilter(projectFilter)}.
+        </Text>
       </Box>
     );
   }

--- a/packages/tui/src/state/project-filter.test.ts
+++ b/packages/tui/src/state/project-filter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { allProjectsFilter, createProjectFilter, describeProjectFilter } from "./project-filter.js";
+
+const project = {
+  id: "project-1",
+  name: "Inbox",
+  status: "active",
+  priority: "medium",
+  authorizedAssigneeActorIds: [],
+  createdAt: "2026-06-30T00:00:00.000Z",
+  updatedAt: "2026-06-30T00:00:00.000Z",
+} as const;
+
+describe("project filter helpers", () => {
+  it("describes all projects", () => {
+    expect(describeProjectFilter(allProjectsFilter)).toBe("All projects");
+  });
+
+  it("creates and describes selected project filters", () => {
+    const filter = createProjectFilter(project);
+
+    expect(filter).toEqual({ projectId: "project-1", projectName: "Inbox" });
+    expect(describeProjectFilter(filter)).toBe("Inbox");
+  });
+});

--- a/packages/tui/src/state/project-filter.ts
+++ b/packages/tui/src/state/project-filter.ts
@@ -1,0 +1,22 @@
+import type { Project, ProjectId } from "@todu/core";
+
+export interface ProjectFilterState {
+  projectId: ProjectId | null;
+  projectName: string | null;
+}
+
+export const allProjectsFilter: ProjectFilterState = {
+  projectId: null,
+  projectName: null,
+};
+
+export function createProjectFilter(project: Project): ProjectFilterState {
+  return {
+    projectId: project.id,
+    projectName: project.name,
+  };
+}
+
+export function describeProjectFilter(filter: ProjectFilterState): string {
+  return filter.projectName ?? "All projects";
+}


### PR DESCRIPTION
## Summary
- replace Projects placeholder with daemon-backed project list and detail summary
- add All projects/project filter state in the app shell and status line
- wire Enter/a from Projects to Tasks filtered by selected project or all projects
- pass selected project ID into task.list query params
- add tests for project rendering, filter state, route switching, and task query params

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr
- dev-daemon smoke check showed Tasks with Project: All projects and real task list/detail rendering

Task: task-5f6acdd5