### PR TITLE
Add TUI task status actions

### DIFF
--- a/.changeset/tui-task-status-actions.md
+++ b/.changeset/tui-task-status-actions.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add TUI task status actions.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -266,6 +266,10 @@ The current TUI implements these global navigation and task-list movement keys:
 - `k` / `Up Arrow`: Move up in the Tasks or Projects list.
 - `Enter`: Select the focused project and open Tasks filtered by that project.
 - `a`: Clear the project filter and open Tasks for all projects.
+- `s`: Start the selected task (`inprogress`).
+- `w`: Mark the selected task waiting.
+- `d`: Complete the selected task.
+- `x`: Cancel the selected task after confirmation.
 
 ### MVP Task Actions
 

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -154,6 +154,10 @@ function RouteScreen({
   }
 
   return connection.state === "connected" ? (
-    <TasksScreen client={toduClient} projectFilter={projectFilter} />
+    <TasksScreen
+      client={toduClient}
+      projectFilter={projectFilter}
+      statusActionsEnabled={connection.state === "connected"}
+    />
   ) : null;
 }

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -14,6 +14,10 @@ export const globalKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "j/↓", description: "Down" },
   { keys: "k/↑", description: "Up" },
   { keys: "Enter", description: "Select Project" },
+  { keys: "s", description: "Start" },
+  { keys: "w", description: "Wait" },
+  { keys: "d", description: "Done" },
+  { keys: "x", description: "Cancel" },
   { keys: "a", description: "All Projects" },
   { keys: "Ctrl+C", description: "Quit" },
 ] as const;

--- a/packages/tui/src/components/ConfirmDialog.tsx
+++ b/packages/tui/src/components/ConfirmDialog.tsx
@@ -1,0 +1,15 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+
+export interface ConfirmDialogProps {
+  message: string;
+}
+
+export function ConfirmDialog({ message }: ConfirmDialogProps): JSX.Element {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color="yellow">{message}</Text>
+      <Text color="gray">Press y to confirm or n to cancel.</Text>
+    </Box>
+  );
+}

--- a/packages/tui/src/components/ToastLine.tsx
+++ b/packages/tui/src/components/ToastLine.tsx
@@ -1,0 +1,18 @@
+import { Text } from "ink";
+import type { JSX } from "react";
+
+export type ToastTone = "info" | "success" | "error";
+
+export interface ToastLineProps {
+  message: string | null;
+  tone: ToastTone;
+}
+
+export function ToastLine({ message, tone }: ToastLineProps): JSX.Element | null {
+  if (!message) {
+    return null;
+  }
+
+  const color = tone === "error" ? "red" : tone === "success" ? "green" : "gray";
+  return <Text color={color}>{message}</Text>;
+}

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -50,7 +50,10 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
         const task = tasks.find((entry) => entry.id === id) ?? tasks[0];
         return Promise.resolve({ ...task, description: `Description for ${task.title}` });
       }),
-      update: vi.fn(),
+      update: vi.fn().mockImplementation((id: string, input: { status: string }) => {
+        const task = tasks.find((entry) => entry.id === id) ?? tasks[0];
+        return Promise.resolve({ ...task, status: input.status });
+      }),
       createComment: vi.fn(),
     },
     note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
@@ -131,6 +134,84 @@ describe("TasksScreen", () => {
         projectId: "project-1",
       });
     });
+  });
+
+  it("updates selected task status without confirmation for non-destructive actions", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("s");
+
+    await waitForFrameText(lastFrame, "Task started: First task");
+    expect(client.task.update).toHaveBeenCalledWith("task-1", { status: "inprogress" });
+  });
+
+  it("requires confirmation before cancelling a task", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("x");
+    await waitForFrameText(lastFrame, "Cancel selected task?");
+    expect(client.task.update).not.toHaveBeenCalled();
+
+    stdin.write("y");
+    await waitForFrameText(lastFrame, "Task cancelled: First task");
+    expect(client.task.update).toHaveBeenCalledWith("task-1", { status: "canceled" });
+  });
+
+  it("can dismiss cancellation confirmation", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("x");
+    await waitForFrameText(lastFrame, "Cancel selected task?");
+    stdin.write("n");
+    await waitForFrameText(lastFrame, "Cancelled task action.");
+    expect(client.task.update).not.toHaveBeenCalled();
+  });
+
+  it("disables status actions while disconnected", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        statusActionsEnabled={false}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("s");
+    await waitForFrameText(lastFrame, "Task actions unavailable while daemon is disconnected.");
+    expect(client.task.update).not.toHaveBeenCalled();
+  });
+
+  it("renders readable mutation errors", async () => {
+    const client = createClient();
+    vi.mocked(client.task.update).mockRejectedValueOnce(
+      new TuiToduClientError({
+        method: "task.update",
+        code: "VALIDATION_ERROR",
+        message: "Cannot update task status",
+        userMessage: "Cannot update task status",
+      }),
+    );
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("w");
+    await waitForFrameText(lastFrame, "Cannot update task status");
   });
 
   it("renders empty state", async () => {

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,23 +1,35 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { TaskStatus } from "@todu/core";
 import { Box, Text, useInput } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { ToastLine, type ToastTone } from "../components/ToastLine.js";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
+import { resolveTaskStatusAction, taskStatusActions } from "../state/task-actions.js";
 
 export interface TasksScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
+  statusActionsEnabled?: boolean;
 }
 
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
 
-export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.Element {
+export function TasksScreen({
+  client,
+  projectFilter,
+  statusActionsEnabled = true,
+}: TasksScreenProps): JSX.Element {
+  const queryClient = useQueryClient();
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [confirmCancel, setConfirmCancel] = useState(false);
+  const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
   const taskFilter = {
     status: [...visibleTaskStatuses],
     ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
@@ -37,6 +49,10 @@ export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.El
     queryFn: () => client.task.get(selectedTaskId ?? ""),
     enabled: selectedTaskId !== null,
   });
+  const statusMutation = useMutation({
+    mutationFn: ({ taskId, status }: { taskId: string; status: TaskStatus }) =>
+      client.task.update(taskId, { status }),
+  });
 
   useEffect(() => {
     if (!tasksQuery.data) {
@@ -46,7 +62,39 @@ export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.El
     setSelectedTaskId((current) => resolveSelectedId(tasksQuery.data ?? [], current));
   }, [tasksQuery.data]);
 
+  const performStatusAction = async (
+    taskId: string,
+    status: TaskStatus,
+    successLabel: string,
+  ): Promise<void> => {
+    try {
+      const updatedTask = await statusMutation.mutateAsync({ taskId, status });
+      setConfirmCancel(false);
+      setFeedback({ message: `Task ${successLabel}: ${updatedTask.title}`, tone: "success" });
+      await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    } catch (error) {
+      setFeedback({ message: formatToduClientError(error), tone: "error" });
+    }
+  };
+
   useInput((input, key) => {
+    if (confirmCancel) {
+      if (input === "y" && selectedTask) {
+        void performStatusAction(
+          selectedTask.id,
+          taskStatusActions.cancel.status,
+          taskStatusActions.cancel.successLabel,
+        );
+        return;
+      }
+
+      if (input === "n" || input === "\u001B") {
+        setConfirmCancel(false);
+        setFeedback({ message: "Cancelled task action.", tone: "info" });
+      }
+      return;
+    }
+
     if (tasks.length === 0) {
       return;
     }
@@ -58,7 +106,29 @@ export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.El
 
     if (input === "k" || key.upArrow) {
       setSelectedTaskId((current) => moveSelection(tasks, current, "previous"));
+      return;
     }
+
+    const action = resolveTaskStatusAction(input);
+    if (!action || !selectedTask || statusMutation.isPending) {
+      return;
+    }
+
+    if (!statusActionsEnabled) {
+      setFeedback({
+        message: "Task actions unavailable while daemon is disconnected.",
+        tone: "error",
+      });
+      return;
+    }
+
+    if (action.requiresConfirmation) {
+      setConfirmCancel(true);
+      setFeedback(null);
+      return;
+    }
+
+    void performStatusAction(selectedTask.id, action.status, action.successLabel);
   });
 
   const error = tasksQuery.error ?? projectsQuery.error;
@@ -87,15 +157,19 @@ export function TasksScreen({ client, projectFilter }: TasksScreenProps): JSX.El
   }
 
   return (
-    <Box flexDirection="row">
-      <TaskListPane tasks={tasks} projects={projectsQuery.data} selectedTaskId={selectedTaskId} />
-      <TaskDetailPane
-        task={selectedTask}
-        detail={selectedDetailQuery.data}
-        projects={projectsQuery.data}
-        isLoadingDetail={selectedDetailQuery.isLoading}
-        error={selectedDetailQuery.error}
-      />
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <TaskListPane tasks={tasks} projects={projectsQuery.data} selectedTaskId={selectedTaskId} />
+        <TaskDetailPane
+          task={selectedTask}
+          detail={selectedDetailQuery.data}
+          projects={projectsQuery.data}
+          isLoadingDetail={selectedDetailQuery.isLoading}
+          error={selectedDetailQuery.error}
+        />
+      </Box>
+      {confirmCancel ? <ConfirmDialog message="Cancel selected task?" /> : null}
+      <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
     </Box>
   );
 }

--- a/packages/tui/src/state/task-actions.test.ts
+++ b/packages/tui/src/state/task-actions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveTaskStatusAction } from "./task-actions.js";
+
+describe("task status actions", () => {
+  it("maps keyboard shortcuts to status updates", () => {
+    expect(resolveTaskStatusAction("s")).toMatchObject({
+      status: "inprogress",
+      requiresConfirmation: false,
+    });
+    expect(resolveTaskStatusAction("w")).toMatchObject({
+      status: "waiting",
+      requiresConfirmation: false,
+    });
+    expect(resolveTaskStatusAction("d")).toMatchObject({
+      status: "done",
+      requiresConfirmation: false,
+    });
+    expect(resolveTaskStatusAction("x")).toMatchObject({
+      status: "canceled",
+      requiresConfirmation: true,
+    });
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(resolveTaskStatusAction("?")).toBeNull();
+  });
+});

--- a/packages/tui/src/state/task-actions.ts
+++ b/packages/tui/src/state/task-actions.ts
@@ -1,0 +1,57 @@
+import type { TaskStatus } from "@todu/core";
+
+export type TaskStatusAction = "start" | "wait" | "done" | "cancel";
+
+export interface TaskStatusActionConfig {
+  action: TaskStatusAction;
+  status: TaskStatus;
+  successLabel: string;
+  requiresConfirmation: boolean;
+}
+
+export const taskStatusActions: Record<TaskStatusAction, TaskStatusActionConfig> = {
+  start: {
+    action: "start",
+    status: "inprogress",
+    successLabel: "started",
+    requiresConfirmation: false,
+  },
+  wait: {
+    action: "wait",
+    status: "waiting",
+    successLabel: "marked waiting",
+    requiresConfirmation: false,
+  },
+  done: {
+    action: "done",
+    status: "done",
+    successLabel: "completed",
+    requiresConfirmation: false,
+  },
+  cancel: {
+    action: "cancel",
+    status: "canceled",
+    successLabel: "cancelled",
+    requiresConfirmation: true,
+  },
+};
+
+export function resolveTaskStatusAction(input: string): TaskStatusActionConfig | null {
+  if (input === "s") {
+    return taskStatusActions.start;
+  }
+
+  if (input === "w") {
+    return taskStatusActions.wait;
+  }
+
+  if (input === "d") {
+    return taskStatusActions.done;
+  }
+
+  if (input === "x") {
+    return taskStatusActions.cancel;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add keyboard-driven task status actions for selected tasks
- wire s/w/d to non-confirmed status updates and x to confirmed cancel
- invalidate task queries after successful mutations and show inline success/error feedback
- add status action disabled handling and tests for mutation routing/params/errors
- add @todu/tui patch changeset for follow-up local versioning

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr
- dev-daemon smoke launch showed task list/detail still renders

Task: task-f7786263