### PR TITLE
Add TUI task comment input

### DIFF
--- a/.changeset/tui-task-comments.md
+++ b/.changeset/tui-task-comments.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add TUI task comment input.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -270,6 +270,7 @@ The current TUI implements these global navigation and task-list movement keys:
 - `w`: Mark the selected task waiting.
 - `d`: Complete the selected task.
 - `x`: Cancel the selected task after confirmation.
+- `c`: Open a focused input to add a comment to the selected task.
 
 ### MVP Task Actions
 

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -61,6 +61,7 @@ function AppContent({
   );
   const [routeState, setRouteState] = useState(createInitialRouteState);
   const [projectFilter, setProjectFilter] = useState<ProjectFilterState>(allProjectsFilter);
+  const [globalInputEnabled, setGlobalInputEnabled] = useState(true);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
   );
@@ -70,17 +71,20 @@ function AppContent({
     exit();
   };
 
-  useInput((input, key) => {
-    const action = resolveGlobalKeyAction(input, key);
-    const nextState = applyNavigationAction(routeState, action);
+  useInput(
+    (input, key) => {
+      const action = resolveGlobalKeyAction(input, key);
+      const nextState = applyNavigationAction(routeState, action);
 
-    if (nextState === "quit") {
-      requestExit();
-      return;
-    }
+      if (nextState === "quit") {
+        requestExit();
+        return;
+      }
 
-    setRouteState(nextState);
-  });
+      setRouteState(nextState);
+    },
+    { isActive: globalInputEnabled },
+  );
 
   useEffect(() => {
     const unsubscribe = connection.subscribe(setConnectionSnapshot);
@@ -112,6 +116,7 @@ function AppContent({
           setProjectFilter(allProjectsFilter);
           setRouteState({ route: "tasks", previousRoute: "tasks" });
         }}
+        onGlobalInputEnabledChange={setGlobalInputEnabled}
       />
     </AppFrame>
   );
@@ -124,6 +129,7 @@ interface RouteScreenProps {
   projectFilter: ProjectFilterState;
   onSelectProject: (project: import("@todu/core").Project) => void;
   onSelectAllProjects: () => void;
+  onGlobalInputEnabledChange: (enabled: boolean) => void;
 }
 
 function RouteScreen({
@@ -133,6 +139,7 @@ function RouteScreen({
   projectFilter,
   onSelectProject,
   onSelectAllProjects,
+  onGlobalInputEnabledChange,
 }: RouteScreenProps): JSX.Element | null {
   if (route === "projects") {
     return connection.state === "connected" ? (
@@ -158,6 +165,7 @@ function RouteScreen({
       client={toduClient}
       projectFilter={projectFilter}
       statusActionsEnabled={connection.state === "connected"}
+      onGlobalInputEnabledChange={onGlobalInputEnabledChange}
     />
   ) : null;
 }

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -18,6 +18,7 @@ export const globalKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "w", description: "Wait" },
   { keys: "d", description: "Done" },
   { keys: "x", description: "Cancel" },
+  { keys: "c", description: "Comment" },
   { keys: "a", description: "All Projects" },
   { keys: "Ctrl+C", description: "Quit" },
 ] as const;

--- a/packages/tui/src/components/TextInputModal.tsx
+++ b/packages/tui/src/components/TextInputModal.tsx
@@ -1,0 +1,29 @@
+import { Box, Text } from "ink";
+import type { JSX } from "react";
+
+export interface TextInputModalProps {
+  title: string;
+  value: string;
+  placeholder?: string;
+  hint?: string;
+  error?: string | null;
+}
+
+export function TextInputModal({
+  title,
+  value,
+  placeholder = "Type here…",
+  hint = "Enter submits • Escape cancels",
+  error = null,
+}: TextInputModalProps): JSX.Element {
+  const displayValue = value.length > 0 ? value : placeholder;
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text color="cyan">{title}</Text>
+      <Text color={value.length > 0 ? "white" : "gray"}>{`> ${displayValue}_`}</Text>
+      {error ? <Text color="red">{error}</Text> : null}
+      <Text color="gray">{hint}</Text>
+    </Box>
+  );
+}

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -1,4 +1,4 @@
-import type { Project, Task, TaskWithDetail } from "@todu/core";
+import type { Note, Project, Task, TaskWithDetail } from "@todu/core";
 import { Box, Text } from "ink";
 import type { JSX } from "react";
 import { formatToduClientError } from "../../daemon/todu-client.js";
@@ -9,6 +9,8 @@ export interface TaskDetailPaneProps {
   detail?: TaskWithDetail;
   projects?: readonly Project[];
   isLoadingDetail: boolean;
+  comments?: readonly Note[];
+  isLoadingComments?: boolean;
   error: unknown;
 }
 
@@ -17,6 +19,8 @@ export function TaskDetailPane({
   detail,
   projects,
   isLoadingDetail,
+  comments = [],
+  isLoadingComments = false,
   error,
 }: TaskDetailPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
@@ -40,6 +44,17 @@ export function TaskDetailPane({
           )
         : null}
       {isLoadingDetail ? <Text color="yellow">Loading detail…</Text> : null}
+      {isLoadingComments ? <Text color="yellow">Loading comments…</Text> : null}
+      {comments.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="cyan">Comments</Text>
+          {comments.slice(0, 5).map((comment) => (
+            <Text key={comment.id} color="gray" wrap="truncate-end">
+              {comment.content}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
       {error ? <Text color="red">{formatToduClientError(error)}</Text> : null}
     </Box>
   );

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -37,6 +37,17 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
     createTask(),
     createTask({ id: "task-2", title: "Second task", status: "waiting", priority: "medium" }),
   ];
+  const comments = [
+    {
+      id: "note-1",
+      content: "Existing comment",
+      author: "Erik",
+      entityType: "task",
+      entityId: "task-1",
+      tags: [],
+      createdAt: "2026-06-30T00:01:00.000Z",
+    },
+  ];
 
   return {
     actor: { list: vi.fn().mockResolvedValue([]) },
@@ -54,9 +65,28 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
         const task = tasks.find((entry) => entry.id === id) ?? tasks[0];
         return Promise.resolve({ ...task, status: input.status });
       }),
-      createComment: vi.fn(),
+      createComment: vi.fn().mockImplementation((taskId: string, content: string) => {
+        const note = {
+          id: `note-${comments.length + 1}`,
+          content,
+          author: "Erik",
+          entityType: "task",
+          entityId: taskId,
+          tags: [],
+          createdAt: "2026-06-30T00:02:00.000Z",
+        };
+        comments.push(note);
+        return Promise.resolve(note);
+      }),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: {
+      list: vi
+        .fn()
+        .mockImplementation((filter: { entityId?: string } = {}) =>
+          Promise.resolve(comments.filter((comment) => comment.entityId === filter.entityId)),
+        ),
+      create: vi.fn(),
+    },
     sync: {
       status: vi
         .fn()
@@ -92,6 +122,7 @@ describe("TasksScreen", () => {
     expect(lastFrame()).toContain("Second task");
     expect(lastFrame()).toContain("Detail");
     expect(lastFrame()).toContain("Status: active");
+    expect(lastFrame()).toContain("Existing comment");
   });
 
   it("moves selection with j/k and arrow keys and updates detail", async () => {
@@ -212,6 +243,101 @@ describe("TasksScreen", () => {
     await waitForFrameText(lastFrame, "Description for First task");
     stdin.write("w");
     await waitForFrameText(lastFrame, "Cannot update task status");
+  });
+
+  it("opens comment input and submits a non-empty selected-task comment", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("c");
+    await waitForFrameText(lastFrame, "Comment on First task");
+    stdin.write("New task context");
+    await waitForFrameText(lastFrame, "New task context_");
+    stdin.write("\r");
+
+    await waitForFrameText(lastFrame, "Comment added: First task");
+    await waitForFrameText(lastFrame, "New task context");
+    expect(client.task.createComment).toHaveBeenCalledWith("task-1", "New task context");
+  });
+
+  it("rejects empty comments without sending a mutation", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("c");
+    await waitForFrameText(lastFrame, "Comment on First task");
+    stdin.write("   ");
+    stdin.write("\r");
+
+    await waitForFrameText(lastFrame, "Comment cannot be empty.");
+    expect(client.task.createComment).not.toHaveBeenCalled();
+  });
+
+  it("cancels comment input without sending a mutation", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("c");
+    await waitForFrameText(lastFrame, "Comment on First task");
+    stdin.write("Draft comment");
+    stdin.write("\u001B");
+
+    await waitForFrameText(lastFrame, "Cancelled comment.");
+    expect(lastFrame()).not.toContain("Comment on First task");
+    expect(client.task.createComment).not.toHaveBeenCalled();
+  });
+
+  it("reports comment action unavailable when no task is selected", async () => {
+    const client = createClient({
+      task: {
+        list: vi.fn().mockResolvedValue([]),
+        get: vi.fn(),
+        update: vi.fn(),
+        createComment: vi.fn(),
+      },
+    });
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks for All projects.");
+    stdin.write("c");
+
+    await waitForFrameText(lastFrame, "No task selected for comment.");
+    expect(client.task.createComment).not.toHaveBeenCalled();
+  });
+
+  it("renders readable comment mutation errors", async () => {
+    const client = createClient();
+    vi.mocked(client.task.createComment).mockRejectedValueOnce(
+      new TuiToduClientError({
+        method: "note.create",
+        code: "VALIDATION_ERROR",
+        message: "Cannot add comment",
+        userMessage: "Cannot add comment",
+      }),
+    );
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("c");
+    await waitForFrameText(lastFrame, "Comment on First task");
+    stdin.write("New task context");
+    await waitForFrameText(lastFrame, "New task context_");
+    stdin.write("\r");
+
+    await waitForFrameText(lastFrame, "Cannot add comment");
   });
 
   it("renders empty state", async () => {

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -4,10 +4,12 @@ import { Box, Text, useInput } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { TextInputModal } from "../components/TextInputModal.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { normalizeCommentContent } from "../state/comment-actions.js";
 import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
@@ -17,6 +19,7 @@ export interface TasksScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
   statusActionsEnabled?: boolean;
+  onGlobalInputEnabledChange?: (enabled: boolean) => void;
 }
 
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
@@ -25,10 +28,14 @@ export function TasksScreen({
   client,
   projectFilter,
   statusActionsEnabled = true,
+  onGlobalInputEnabledChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [confirmCancel, setConfirmCancel] = useState(false);
+  const [commentModalOpen, setCommentModalOpen] = useState(false);
+  const [commentText, setCommentText] = useState("");
+  const [commentError, setCommentError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
   const taskFilter = {
     status: [...visibleTaskStatuses],
@@ -49,9 +56,18 @@ export function TasksScreen({
     queryFn: () => client.task.get(selectedTaskId ?? ""),
     enabled: selectedTaskId !== null,
   });
+  const commentsQuery = useQuery({
+    queryKey: queryKeys.taskComments(selectedTaskId ?? "none"),
+    queryFn: () => client.note.list({ entityType: "task", entityId: selectedTaskId ?? "" }),
+    enabled: selectedTaskId !== null,
+  });
   const statusMutation = useMutation({
     mutationFn: ({ taskId, status }: { taskId: string; status: TaskStatus }) =>
       client.task.update(taskId, { status }),
+  });
+  const commentMutation = useMutation({
+    mutationFn: ({ taskId, content }: { taskId: string; content: string }) =>
+      client.task.createComment(taskId, content),
   });
 
   useEffect(() => {
@@ -61,6 +77,11 @@ export function TasksScreen({
 
     setSelectedTaskId((current) => resolveSelectedId(tasksQuery.data ?? [], current));
   }, [tasksQuery.data]);
+
+  useEffect(() => {
+    onGlobalInputEnabledChange?.(!commentModalOpen);
+    return () => onGlobalInputEnabledChange?.(true);
+  }, [commentModalOpen, onGlobalInputEnabledChange]);
 
   const performStatusAction = async (
     taskId: string,
@@ -77,7 +98,66 @@ export function TasksScreen({
     }
   };
 
+  const submitComment = async (): Promise<void> => {
+    if (!selectedTask) {
+      setCommentModalOpen(false);
+      setFeedback({ message: "No task selected for comment.", tone: "error" });
+      return;
+    }
+
+    const content = normalizeCommentContent(commentText);
+    if (!content) {
+      setCommentError("Comment cannot be empty.");
+      return;
+    }
+
+    try {
+      await commentMutation.mutateAsync({ taskId: selectedTask.id, content });
+      setCommentModalOpen(false);
+      setCommentText("");
+      setCommentError(null);
+      setFeedback({ message: `Comment added: ${selectedTask.title}`, tone: "success" });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.task(selectedTask.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.taskComments(selectedTask.id) }),
+      ]);
+    } catch (error) {
+      setCommentError(formatToduClientError(error));
+    }
+  };
+
+  const closeCommentModal = (): void => {
+    setCommentModalOpen(false);
+    setCommentText("");
+    setCommentError(null);
+    setFeedback({ message: "Cancelled comment.", tone: "info" });
+  };
+
   useInput((input, key) => {
+    if (commentModalOpen) {
+      if (key.escape) {
+        closeCommentModal();
+        return;
+      }
+
+      if (key.return) {
+        void submitComment();
+        return;
+      }
+
+      if (key.backspace || key.delete) {
+        setCommentText((current) => current.slice(0, -1));
+        setCommentError(null);
+        return;
+      }
+
+      if (!key.ctrl && !key.meta && input.length > 0) {
+        setCommentText((current) => `${current}${input}`);
+        setCommentError(null);
+      }
+      return;
+    }
+
     if (confirmCancel) {
       if (input === "y" && selectedTask) {
         void performStatusAction(
@@ -95,7 +175,20 @@ export function TasksScreen({
       return;
     }
 
+    if (input === "c" && !selectedTask) {
+      setFeedback({ message: "No task selected for comment.", tone: "error" });
+      return;
+    }
+
     if (tasks.length === 0) {
+      return;
+    }
+
+    if (input === "c" && selectedTask) {
+      setCommentModalOpen(true);
+      setCommentText("");
+      setCommentError(null);
+      setFeedback(null);
       return;
     }
 
@@ -152,6 +245,7 @@ export function TasksScreen({
         <Text color="gray">
           No active, in-progress, or waiting tasks for {describeProjectFilter(projectFilter)}.
         </Text>
+        <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
       </Box>
     );
   }
@@ -165,9 +259,19 @@ export function TasksScreen({
           detail={selectedDetailQuery.data}
           projects={projectsQuery.data}
           isLoadingDetail={selectedDetailQuery.isLoading}
-          error={selectedDetailQuery.error}
+          comments={commentsQuery.data}
+          isLoadingComments={commentsQuery.isLoading}
+          error={selectedDetailQuery.error ?? commentsQuery.error}
         />
       </Box>
+      {commentModalOpen ? (
+        <TextInputModal
+          title={selectedTask ? `Comment on ${selectedTask.title}` : "Comment"}
+          value={commentText}
+          placeholder="Write a task comment…"
+          error={commentError}
+        />
+      ) : null}
       {confirmCancel ? <ConfirmDialog message="Cancel selected task?" /> : null}
       <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
     </Box>

--- a/packages/tui/src/state/comment-actions.test.ts
+++ b/packages/tui/src/state/comment-actions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCommentContent } from "./comment-actions.js";
+
+describe("comment actions", () => {
+  it("normalizes non-empty comments", () => {
+    expect(normalizeCommentContent("  Looks good  ")).toBe("Looks good");
+  });
+
+  it("rejects empty comments", () => {
+    expect(normalizeCommentContent("")).toBeNull();
+    expect(normalizeCommentContent("   \t  ")).toBeNull();
+  });
+});

--- a/packages/tui/src/state/comment-actions.ts
+++ b/packages/tui/src/state/comment-actions.ts
@@ -1,0 +1,4 @@
+export function normalizeCommentContent(content: string): string | null {
+  const trimmed = content.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}


### PR DESCRIPTION
## Summary
- add c shortcut and focused text input for selected-task comments
- submit comments through daemon client and refetch task detail/comment queries
- render recent comments in task detail pane
- reject empty comments and support Escape cancel without mutation
- disable global navigation input while comment input is focused
- add @todu/tui patch changeset

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr

Task: task-a03c3148