### PR TITLE
Wire TUI daemon events and reconnect recovery

### DIFF
--- a/.changeset/tui-events-reconnect.md
+++ b/.changeset/tui-events-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Wire daemon events and reconnect recovery into the TUI.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -380,7 +380,7 @@ On `data.changed`:
 On `sync.statusChanged`:
 
 - update sync status query/cache.
-- refresh status line.
+- refresh status line, which shows the current remote sync state.
 
 On reconnect:
 

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -6,23 +6,61 @@ import type {
   DaemonConnection,
   DaemonConnectionListener,
   DaemonConnectionSnapshot,
+  DaemonEventFrame,
+  DaemonEventListener,
 } from "../daemon/connection.js";
 import type { TuiToduClient } from "../daemon/todu-client.js";
 import { allProjectsFilter } from "../state/project-filter.js";
 import { App } from "./App.js";
 import { applyNavigationAction, createInitialRouteState } from "./keymap.js";
 
-function createFakeConnection(snapshot: DaemonConnectionSnapshot): DaemonConnection {
-  return {
-    start: vi.fn(),
-    stop: vi.fn(),
-    getSnapshot: () => snapshot,
-    subscribe: (listener: DaemonConnectionListener) => {
+class FakeConnection implements DaemonConnection {
+  readonly start = vi.fn();
+  readonly stop = vi.fn();
+  readonly request = vi.fn().mockResolvedValue({ ok: true, value: { subscribed: [] } });
+  private snapshot: DaemonConnectionSnapshot;
+  private readonly listeners = new Set<DaemonConnectionListener>();
+  private readonly eventListeners = new Set<DaemonEventListener>();
+
+  constructor(snapshot: DaemonConnectionSnapshot) {
+    this.snapshot = snapshot;
+  }
+
+  getSnapshot(): DaemonConnectionSnapshot {
+    return this.snapshot;
+  }
+
+  subscribe(listener: DaemonConnectionListener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  subscribeEvents(listener: DaemonEventListener): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
+    };
+  }
+
+  emitSnapshot(snapshot: DaemonConnectionSnapshot): void {
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) {
       listener(snapshot);
-      return vi.fn();
-    },
-    request: vi.fn(),
-  };
+    }
+  }
+
+  emitEvent(event: DaemonEventFrame): void {
+    for (const listener of this.eventListeners) {
+      listener(event);
+    }
+  }
+}
+
+function createFakeConnection(snapshot: DaemonConnectionSnapshot): FakeConnection {
+  return new FakeConnection(snapshot);
 }
 
 function createConnectedSnapshot(): DaemonConnectionSnapshot {
@@ -213,6 +251,7 @@ describe("App", () => {
     expect(lastFrame()).toContain("j/↓    Down");
     expect(lastFrame()).toContain("Enter  Select Project");
     expect(lastFrame()).toContain("a      All Projects");
+    expect(lastFrame()).toContain("c      Comment");
     expect(lastFrame()).toContain("q      Back/Quit");
     expect(lastFrame()).toContain("Ctrl+C Quit");
   });
@@ -238,6 +277,63 @@ describe("App", () => {
 
     stdin.write("q");
     expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches active task data when data.changed is received", async () => {
+    const connection = createFakeConnection(createConnectedSnapshot());
+    const client = createFakeClient();
+    render(<App connection={connection} toduClient={client} />);
+
+    await vi.waitFor(() => {
+      expect(client.task.list).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(connection.request).toHaveBeenCalledWith("events.subscribe", {
+        events: ["data.changed", "sync.statusChanged"],
+      });
+    });
+
+    connection.emitEvent({ event: "data.changed", payload: { type: "catalog" } });
+
+    await vi.waitFor(() => {
+      expect(client.task.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("updates sync status line from sync.statusChanged without a full app refresh", async () => {
+    const connection = createFakeConnection(createConnectedSnapshot());
+    const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
+
+    await waitForFrameText(lastFrame, "Ship");
+    connection.emitEvent({
+      event: "sync.statusChanged",
+      payload: { local: { mode: "standalone" }, remote: { state: "connected" } },
+    });
+
+    await waitForFrameText(lastFrame, "Sync: connected");
+  });
+
+  it("resubscribes and keeps task data visible across reconnect", async () => {
+    const connection = createFakeConnection(createConnectedSnapshot());
+    const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
+
+    await waitForFrameText(lastFrame, "Ship");
+    await vi.waitFor(() => {
+      expect(connection.request).toHaveBeenCalledTimes(1);
+    });
+
+    connection.emitSnapshot({ ...createConnectedSnapshot(), state: "reconnecting", hello: null });
+    await waitForFrameText(lastFrame, "Daemon disconnected; reconnecting");
+    expect(lastFrame()).toContain("Ship");
+
+    connection.emitSnapshot(createConnectedSnapshot());
+
+    await vi.waitFor(() => {
+      expect(connection.request).toHaveBeenCalledTimes(2);
+    });
+    expect(connection.request).toHaveBeenLastCalledWith("events.subscribe", {
+      events: ["data.changed", "sync.statusChanged"],
+    });
   });
 
   it("keeps quit behavior deterministic in the route reducer", () => {

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -1,5 +1,6 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApp, useInput } from "ink";
-import { type JSX, useEffect, useMemo, useState } from "react";
+import { type JSX, useEffect, useMemo, useRef, useState } from "react";
 import { AppFrame } from "../components/AppFrame.js";
 import { ConnectionState } from "../components/ConnectionState.js";
 import {
@@ -13,11 +14,18 @@ import { HelpScreen } from "../screens/HelpScreen.js";
 import { ProjectsScreen } from "../screens/ProjectsScreen.js";
 import { TasksScreen } from "../screens/TasksScreen.js";
 import {
+  applySyncStatusEvent,
+  invalidateDataChangedQueries,
+  invalidateReconnectQueries,
+  reactiveDaemonEvents,
+} from "../state/event-invalidation.js";
+import {
   allProjectsFilter,
   createProjectFilter,
   type ProjectFilterState,
 } from "../state/project-filter.js";
 import { createTuiQueryClient, TuiQueryProvider } from "../state/query-client.js";
+import { queryKeys } from "../state/query-keys.js";
 import {
   applyNavigationAction,
   createInitialRouteState,
@@ -51,6 +59,7 @@ function AppContent({
   onExit,
 }: AppProps): JSX.Element {
   const { exit } = useApp();
+  const queryClient = useQueryClient();
   const connection = useMemo(
     () => providedConnection ?? createDaemonConnection(),
     [providedConnection],
@@ -65,6 +74,13 @@ function AppContent({
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
   );
+  const [hasConnected, setHasConnected] = useState(connectionSnapshot.state === "connected");
+  const previousConnectionState = useRef(connectionSnapshot.state);
+  const syncStatus = useQuery({
+    queryKey: queryKeys.syncStatus(),
+    queryFn: () => toduClient.sync.status(),
+    enabled: connectionSnapshot.state === "connected",
+  });
 
   const requestExit = (): void => {
     onExit?.();
@@ -96,16 +112,62 @@ function AppContent({
     };
   }, [connection]);
 
+  useEffect(() => {
+    if (connectionSnapshot.state === "connected") {
+      setHasConnected(true);
+    }
+  }, [connectionSnapshot.state]);
+
+  useEffect(() => {
+    const previousState = previousConnectionState.current;
+    previousConnectionState.current = connectionSnapshot.state;
+
+    if (connectionSnapshot.state !== "connected") {
+      return;
+    }
+
+    let active = true;
+    const unsubscribeEvents = connection.subscribeEvents((event) => {
+      if (event.event === "data.changed") {
+        void invalidateDataChangedQueries(queryClient);
+        return;
+      }
+
+      if (event.event === "sync.statusChanged") {
+        applySyncStatusEvent(queryClient, event.payload);
+      }
+    });
+
+    void connection
+      .request<{ subscribed: string[] }>("events.subscribe", { events: [...reactiveDaemonEvents] })
+      .then((result) => {
+        if (!active || !result.ok) {
+          return;
+        }
+
+        if (previousState !== "connected") {
+          void invalidateReconnectQueries(queryClient);
+        }
+      });
+
+    return () => {
+      active = false;
+      unsubscribeEvents();
+    };
+  }, [connection, connectionSnapshot.state, queryClient]);
+
   return (
     <AppFrame
       route={routeState.route}
       connection={connectionSnapshot}
       projectFilter={projectFilter}
+      syncStatus={syncStatus.data}
     >
       <ConnectionState connection={connectionSnapshot} />
       <RouteScreen
         route={routeState.route}
         connection={connectionSnapshot}
+        hasConnected={hasConnected}
         toduClient={toduClient}
         projectFilter={projectFilter}
         onSelectProject={(project) => {
@@ -125,6 +187,7 @@ function AppContent({
 interface RouteScreenProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
+  hasConnected: boolean;
   toduClient: TuiToduClient;
   projectFilter: ProjectFilterState;
   onSelectProject: (project: import("@todu/core").Project) => void;
@@ -135,19 +198,24 @@ interface RouteScreenProps {
 function RouteScreen({
   route,
   connection,
+  hasConnected,
   toduClient,
   projectFilter,
   onSelectProject,
   onSelectAllProjects,
   onGlobalInputEnabledChange,
 }: RouteScreenProps): JSX.Element | null {
+  const dataQueriesEnabled = connection.state === "connected";
+  const canShowDataScreens = dataQueriesEnabled || hasConnected;
+
   if (route === "projects") {
-    return connection.state === "connected" ? (
+    return canShowDataScreens ? (
       <ProjectsScreen
         client={toduClient}
         projectFilter={projectFilter}
         onSelectProject={onSelectProject}
         onSelectAllProjects={onSelectAllProjects}
+        dataQueriesEnabled={dataQueriesEnabled}
       />
     ) : null;
   }
@@ -160,11 +228,12 @@ function RouteScreen({
     return <HelpScreen />;
   }
 
-  return connection.state === "connected" ? (
+  return canShowDataScreens ? (
     <TasksScreen
       client={toduClient}
       projectFilter={projectFilter}
-      statusActionsEnabled={connection.state === "connected"}
+      statusActionsEnabled={dataQueriesEnabled}
+      dataQueriesEnabled={dataQueriesEnabled}
       onGlobalInputEnabledChange={onGlobalInputEnabledChange}
     />
   ) : null;

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useStdout } from "ink";
 import type { JSX, ReactNode } from "react";
 import { type AppRoute, routeLabels } from "../app/routes.js";
 import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+import type { TuiSyncStatus } from "../daemon/todu-client.js";
 import type { ProjectFilterState } from "../state/project-filter.js";
 import { HelpBar } from "./HelpBar.js";
 import { StatusLine } from "./StatusLine.js";
@@ -10,6 +11,7 @@ export interface AppFrameProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
   projectFilter: ProjectFilterState;
+  syncStatus?: TuiSyncStatus;
   children: ReactNode;
   terminalWidth?: number;
 }
@@ -18,6 +20,7 @@ export function AppFrame({
   route,
   connection,
   projectFilter,
+  syncStatus,
   children,
   terminalWidth,
 }: AppFrameProps): JSX.Element {
@@ -35,7 +38,12 @@ export function AppFrame({
           • {routeLabels[route]}
         </Text>
       </Box>
-      <StatusLine route={route} connection={connection} projectFilter={projectFilter} />
+      <StatusLine
+        route={route}
+        connection={connection}
+        projectFilter={projectFilter}
+        syncStatus={syncStatus}
+      />
       <Box flexDirection="column" marginY={1}>
         {children}
       </Box>

--- a/packages/tui/src/components/StatusLine.tsx
+++ b/packages/tui/src/components/StatusLine.tsx
@@ -2,21 +2,32 @@ import { Text } from "ink";
 import type { JSX } from "react";
 import { type AppRoute, routeLabels } from "../app/routes.js";
 import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
+import type { TuiSyncStatus } from "../daemon/todu-client.js";
 import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
 
 export interface StatusLineProps {
   route: AppRoute;
   connection: DaemonConnectionSnapshot;
   projectFilter: ProjectFilterState;
+  syncStatus?: TuiSyncStatus;
 }
 
-export function StatusLine({ route, connection, projectFilter }: StatusLineProps): JSX.Element {
+export function StatusLine({
+  route,
+  connection,
+  projectFilter,
+  syncStatus,
+}: StatusLineProps): JSX.Element {
   return (
     <Text color="gray" wrap="truncate-end">
       View: {routeLabels[route]} • Project: {describeProjectFilter(projectFilter)} • Daemon:{" "}
-      {formatConnectionState(connection)}
+      {formatConnectionState(connection)} • Sync: {formatSyncStatus(syncStatus)}
     </Text>
   );
+}
+
+function formatSyncStatus(syncStatus: TuiSyncStatus | undefined): string {
+  return syncStatus?.remote.state ?? "unknown";
 }
 
 function formatConnectionState(connection: DaemonConnectionSnapshot): string {

--- a/packages/tui/src/daemon/connection.test.ts
+++ b/packages/tui/src/daemon/connection.test.ts
@@ -162,6 +162,33 @@ describe("TUI daemon connection", () => {
     vi.useRealTimers();
   });
 
+  it("dispatches daemon event frames to event subscribers", async () => {
+    const socket = new FakeSocket();
+    const events: unknown[] = [];
+    const connection = createDaemonConnection({
+      socketPath: "/tmp/todu.sock",
+      connect: () => socket,
+      requestIdFactory: () => "hello-event",
+    });
+
+    connection.subscribeEvents((event) => events.push(event));
+    connection.start();
+    socket.emit("connect");
+    await flushPromises();
+    sendSuccess(socket, readLastRequest(socket).id, { protocolVersion: DAEMON_PROTOCOL_VERSION });
+    await flushPromises();
+
+    socket.emit(
+      "data",
+      `${JSON.stringify({ event: "data.changed", payload: { type: "catalog" }, ts: "now" })}\n`,
+    );
+    await flushPromises();
+
+    expect(events).toEqual([{ event: "data.changed", payload: { type: "catalog" }, ts: "now" }]);
+
+    connection.stop();
+  });
+
   it("transitions through disconnected to reconnecting when a connected socket closes", async () => {
     vi.useFakeTimers();
     const socket = new FakeSocket();

--- a/packages/tui/src/daemon/connection.ts
+++ b/packages/tui/src/daemon/connection.ts
@@ -50,11 +50,20 @@ export interface DaemonConnectionSnapshot {
 
 export type DaemonConnectionListener = (snapshot: DaemonConnectionSnapshot) => void;
 
+export interface DaemonEventFrame {
+  event: string;
+  payload: unknown;
+  ts?: string;
+}
+
+export type DaemonEventListener = (event: DaemonEventFrame) => void;
+
 export interface DaemonConnection {
   start(): void;
   stop(): void;
   getSnapshot(): DaemonConnectionSnapshot;
   subscribe(listener: DaemonConnectionListener): () => void;
+  subscribeEvents(listener: DaemonEventListener): () => void;
   request<T>(
     method: string,
     params?: Record<string, unknown>,
@@ -119,6 +128,12 @@ interface ProtocolErrorFrame {
   error: DaemonConnectionError;
 }
 
+interface ProtocolEventFrame {
+  event: string;
+  payload: unknown;
+  ts?: string;
+}
+
 export function createDaemonConnection(options: DaemonConnectionOptions = {}): DaemonConnection {
   return new TuiDaemonConnection(options);
 }
@@ -156,6 +171,7 @@ class TuiDaemonConnection implements DaemonConnection {
   private readonly connect: (socketPath: string) => DaemonSocket;
   private readonly requestIdFactory: () => string;
   private readonly listeners = new Set<DaemonConnectionListener>();
+  private readonly eventListeners = new Set<DaemonEventListener>();
 
   private running = false;
   private connecting = false;
@@ -237,6 +253,13 @@ class TuiDaemonConnection implements DaemonConnection {
     listener(this.snapshot);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  subscribeEvents(listener: DaemonEventListener): () => void {
+    this.eventListeners.add(listener);
+    return () => {
+      this.eventListeners.delete(listener);
     };
   }
 
@@ -380,6 +403,7 @@ class TuiDaemonConnection implements DaemonConnection {
     }
 
     if (parsed.kind === "event") {
+      this.dispatchEvent(parsed.value);
       return;
     }
 
@@ -402,6 +426,12 @@ class TuiDaemonConnection implements DaemonConnection {
     }
 
     pending.resolve({ ok: true, value: parsed.value.result });
+  }
+
+  private dispatchEvent(event: DaemonEventFrame): void {
+    for (const listener of this.eventListeners) {
+      listener(event);
+    }
   }
 
   private closeConnection(
@@ -622,7 +652,7 @@ function parseIncomingFrame(
 ):
   | { ok: true; kind: "success"; value: ProtocolSuccessFrame }
   | { ok: true; kind: "error"; value: ProtocolErrorFrame }
-  | { ok: true; kind: "event" }
+  | { ok: true; kind: "event"; value: ProtocolEventFrame }
   | { ok: false; error: DaemonConnectionError } {
   if (!isRecord(frame)) {
     return {
@@ -632,7 +662,15 @@ function parseIncomingFrame(
   }
 
   if (typeof frame.event === "string") {
-    return { ok: true, kind: "event" };
+    return {
+      ok: true,
+      kind: "event",
+      value: {
+        event: frame.event,
+        payload: frame.payload,
+        ts: typeof frame.ts === "string" ? frame.ts : undefined,
+      },
+    };
   }
 
   if (isRecord(frame.error)) {

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -20,6 +20,7 @@ export interface ProjectsScreenProps {
   projectFilter: ProjectFilterState;
   onSelectProject: (project: Project) => void;
   onSelectAllProjects: () => void;
+  dataQueriesEnabled?: boolean;
 }
 
 export function ProjectsScreen({
@@ -27,6 +28,7 @@ export function ProjectsScreen({
   projectFilter,
   onSelectProject,
   onSelectAllProjects,
+  dataQueriesEnabled = true,
 }: ProjectsScreenProps): JSX.Element {
   const [selectedOptionId, setSelectedOptionId] = useState<string>(
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
@@ -34,6 +36,7 @@ export function ProjectsScreen({
   const projectsQuery = useQuery({
     queryKey: queryKeys.projects(),
     queryFn: () => client.project.list(),
+    enabled: dataQueriesEnabled,
   });
   const projectOptions = useMemo(
     () => createProjectOptions(projectsQuery.data ?? []),

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -316,6 +316,24 @@ describe("TasksScreen", () => {
     expect(client.task.createComment).not.toHaveBeenCalled();
   });
 
+  it("disables comment action while disconnected", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        statusActionsEnabled={false}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for First task");
+    stdin.write("c");
+
+    await waitForFrameText(lastFrame, "Task actions unavailable while daemon is disconnected.");
+    expect(lastFrame()).not.toContain("Comment on First task");
+    expect(client.task.createComment).not.toHaveBeenCalled();
+  });
+
   it("renders readable comment mutation errors", async () => {
     const client = createClient();
     vi.mocked(client.task.createComment).mockRejectedValueOnce(

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -19,6 +19,7 @@ export interface TasksScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
   statusActionsEnabled?: boolean;
+  dataQueriesEnabled?: boolean;
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
 }
 
@@ -28,6 +29,7 @@ export function TasksScreen({
   client,
   projectFilter,
   statusActionsEnabled = true,
+  dataQueriesEnabled = true,
   onGlobalInputEnabledChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
@@ -44,22 +46,24 @@ export function TasksScreen({
   const tasksQuery = useQuery({
     queryKey: queryKeys.tasks(taskFilter),
     queryFn: () => client.task.list(taskFilter),
+    enabled: dataQueriesEnabled,
   });
   const projectsQuery = useQuery({
     queryKey: queryKeys.projects(),
     queryFn: () => client.project.list(),
+    enabled: dataQueriesEnabled,
   });
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
   const selectedTask = getSelectedItem(tasks, selectedTaskId);
   const selectedDetailQuery = useQuery({
     queryKey: queryKeys.task(selectedTaskId ?? "none"),
     queryFn: () => client.task.get(selectedTaskId ?? ""),
-    enabled: selectedTaskId !== null,
+    enabled: dataQueriesEnabled && selectedTaskId !== null,
   });
   const commentsQuery = useQuery({
     queryKey: queryKeys.taskComments(selectedTaskId ?? "none"),
     queryFn: () => client.note.list({ entityType: "task", entityId: selectedTaskId ?? "" }),
-    enabled: selectedTaskId !== null,
+    enabled: dataQueriesEnabled && selectedTaskId !== null,
   });
   const statusMutation = useMutation({
     mutationFn: ({ taskId, status }: { taskId: string; status: TaskStatus }) =>
@@ -102,6 +106,11 @@ export function TasksScreen({
     if (!selectedTask) {
       setCommentModalOpen(false);
       setFeedback({ message: "No task selected for comment.", tone: "error" });
+      return;
+    }
+
+    if (!statusActionsEnabled) {
+      setCommentError("Task actions unavailable while daemon is disconnected.");
       return;
     }
 
@@ -185,6 +194,14 @@ export function TasksScreen({
     }
 
     if (input === "c" && selectedTask) {
+      if (!statusActionsEnabled) {
+        setFeedback({
+          message: "Task actions unavailable while daemon is disconnected.",
+          tone: "error",
+        });
+        return;
+      }
+
       setCommentModalOpen(true);
       setCommentText("");
       setCommentError(null);

--- a/packages/tui/src/state/event-invalidation.test.ts
+++ b/packages/tui/src/state/event-invalidation.test.ts
@@ -1,0 +1,48 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  applySyncStatusEvent,
+  invalidateDataChangedQueries,
+  invalidateReconnectQueries,
+  isReactiveDaemonEvent,
+} from "./event-invalidation.js";
+import { queryKeys } from "./query-keys.js";
+
+describe("event invalidation", () => {
+  it("recognizes daemon events used by the TUI", () => {
+    expect(isReactiveDaemonEvent("data.changed")).toBe(true);
+    expect(isReactiveDaemonEvent("sync.statusChanged")).toBe(true);
+    expect(isReactiveDaemonEvent("other.event")).toBe(false);
+  });
+
+  it("invalidates domain queries on data.changed", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    await invalidateDataChangedQueries(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["actors"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["projects"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["notes"] });
+  });
+
+  it("invalidates domain and sync queries on reconnect", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    await invalidateReconnectQueries(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["tasks"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.syncStatus() });
+  });
+
+  it("applies sync.statusChanged payloads to the sync query cache", () => {
+    const queryClient = new QueryClient();
+    const status = { local: { mode: "standalone" }, remote: { state: "connected" } };
+
+    applySyncStatusEvent(queryClient, status);
+
+    expect(queryClient.getQueryData(queryKeys.syncStatus())).toEqual(status);
+  });
+});

--- a/packages/tui/src/state/event-invalidation.ts
+++ b/packages/tui/src/state/event-invalidation.ts
@@ -1,0 +1,48 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { TuiSyncStatus } from "../daemon/todu-client.js";
+import { queryKeys } from "./query-keys.js";
+
+export const reactiveDaemonEvents = ["data.changed", "sync.statusChanged"] as const;
+
+export type ReactiveDaemonEvent = (typeof reactiveDaemonEvents)[number];
+
+export function isReactiveDaemonEvent(event: string): event is ReactiveDaemonEvent {
+  return (reactiveDaemonEvents as readonly string[]).includes(event);
+}
+
+export async function invalidateDataChangedQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["actors"] }),
+    queryClient.invalidateQueries({ queryKey: ["projects"] }),
+    queryClient.invalidateQueries({ queryKey: ["tasks"] }),
+    queryClient.invalidateQueries({ queryKey: ["notes"] }),
+  ]);
+}
+
+export async function invalidateReconnectQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    invalidateDataChangedQueries(queryClient),
+    queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() }),
+  ]);
+}
+
+export function applySyncStatusEvent(queryClient: QueryClient, payload: unknown): void {
+  if (isTuiSyncStatus(payload)) {
+    queryClient.setQueryData(queryKeys.syncStatus(), payload);
+    return;
+  }
+
+  void queryClient.invalidateQueries({ queryKey: queryKeys.syncStatus() });
+}
+
+function isTuiSyncStatus(value: unknown): value is TuiSyncStatus {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return isRecord(value.local) && isRecord(value.remote) && typeof value.remote.state === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- dispatch daemon event frames through the TUI connection
- subscribe to data.changed and sync.statusChanged after connected hello state
- invalidate task/project/note/actor queries on data.changed and reconnect
- update sync status cache/status line from sync.statusChanged
- keep cached task/project screens visible while reconnecting and keep mutations disabled
- add tests for event dispatch, invalidation, sync status update, and reconnect resubscribe
- add @todu/tui patch changeset metadata only; no release/version branch created

## Verification
- npm run --workspace=@todu/tui test
- npm run --workspace=@todu/tui build
- make pre-pr

Task: task-a92b30f6