### PR TITLE
Make TUI frame fill terminal viewport

### DIFF
--- a/.changeset/tui-full-viewport.md
+++ b/.changeset/tui-full-viewport.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Make the TUI frame use the full terminal viewport height and width.

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -1,0 +1,50 @@
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { allProjectsFilter } from "../state/project-filter.js";
+import { AppFrame, resolveTerminalSize } from "./AppFrame.js";
+
+describe("AppFrame", () => {
+  it("uses provided terminal dimensions", () => {
+    expect(resolveTerminalSize({ width: 120, height: 40 })).toEqual({ width: 120, height: 40 });
+  });
+
+  it("falls back when terminal dimensions are unavailable", () => {
+    expect(resolveTerminalSize({ width: undefined, height: undefined })).toEqual({
+      width: 80,
+      height: 24,
+    });
+    expect(resolveTerminalSize({ width: 0, height: -1 })).toEqual({ width: 80, height: 24 });
+  });
+
+  it("renders header, body, and footer in a fixed-height frame", () => {
+    const { lastFrame } = render(
+      <AppFrame
+        route="tasks"
+        connection={{
+          state: "connected",
+          socketPath: "/tmp/todu.sock",
+          hello: {
+            protocolVersion: 1,
+            daemonVersion: "dev",
+            pid: 123,
+            capabilities: [],
+          },
+          error: null,
+          reconnectAttempt: 0,
+          reconnectDelayMs: null,
+        }}
+        projectFilter={allProjectsFilter}
+        terminalWidth={60}
+        terminalHeight={12}
+      >
+        <Text>body content</Text>
+      </AppFrame>,
+    );
+
+    expect(lastFrame()).toContain("Todu • Tasks");
+    expect(lastFrame()).toContain("View: Tasks");
+    expect(lastFrame()).toContain("body content");
+    expect(lastFrame()).toContain("1 Tasks");
+  });
+});

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -14,6 +14,7 @@ export interface AppFrameProps {
   syncStatus?: TuiSyncStatus;
   children: ReactNode;
   terminalWidth?: number;
+  terminalHeight?: number;
 }
 
 export function AppFrame({
@@ -23,13 +24,17 @@ export function AppFrame({
   syncStatus,
   children,
   terminalWidth,
+  terminalHeight,
 }: AppFrameProps): JSX.Element {
   const { stdout } = useStdout();
-  const width = resolveTerminalWidth(terminalWidth ?? stdout.columns);
+  const size = resolveTerminalSize({
+    width: terminalWidth ?? stdout.columns,
+    height: terminalHeight ?? stdout.rows,
+  });
 
   return (
-    <Box flexDirection="column" paddingX={1} paddingY={1} width={width}>
-      <Box flexDirection="row">
+    <Box flexDirection="column" paddingX={1} paddingY={1} width={size.width} height={size.height}>
+      <Box flexDirection="row" height={1} flexShrink={0}>
         <Text color="cyan" bold wrap="truncate-end">
           Todu
         </Text>
@@ -38,20 +43,37 @@ export function AppFrame({
           • {routeLabels[route]}
         </Text>
       </Box>
-      <StatusLine
-        route={route}
-        connection={connection}
-        projectFilter={projectFilter}
-        syncStatus={syncStatus}
-      />
-      <Box flexDirection="column" marginY={1}>
+      <Box height={1} flexShrink={0}>
+        <StatusLine
+          route={route}
+          connection={connection}
+          projectFilter={projectFilter}
+          syncStatus={syncStatus}
+        />
+      </Box>
+      <Box flexDirection="column" flexGrow={1} marginY={1}>
         {children}
       </Box>
-      <HelpBar />
+      <Box height={1} flexShrink={0}>
+        <HelpBar />
+      </Box>
     </Box>
   );
 }
 
-function resolveTerminalWidth(width: number | undefined): number {
-  return width && width > 0 ? width : 80;
+export interface TerminalSizeInput {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+export interface TerminalSize {
+  width: number;
+  height: number;
+}
+
+export function resolveTerminalSize({ width, height }: TerminalSizeInput): TerminalSize {
+  return {
+    width: width && width > 0 ? width : 80,
+    height: height && height > 0 ? height : 24,
+  };
 }


### PR DESCRIPTION
## Summary
- make AppFrame resolve terminal width and height from Ink stdout
- give the existing frame fixed header/status/footer rows and a flexing body region
- add sizing fallback tests without changing route content or visual style
- add pending @todu/tui patch changeset

## Verification
- npm test -- packages/tui/src/components/AppFrame.test.tsx packages/tui/src/app/App.test.tsx
- npm run --workspace=@todu/tui typecheck
- npm run --workspace=@todu/tui build
- make pre-pr
- npm run check:ci

Task: task-72475c75