### PR TITLE
Add permanent TUI project pane

### DIFF
--- a/.changeset/tui-permanent-project-pane.md
+++ b/.changeset/tui-permanent-project-pane.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add a permanent project pane to the TUI tasks view.

--- a/packages/tui/src/components/ConnectionState.tsx
+++ b/packages/tui/src/components/ConnectionState.tsx
@@ -6,17 +6,9 @@ export interface ConnectionStateProps {
   connection: DaemonConnectionSnapshot;
 }
 
-export function ConnectionState({ connection }: ConnectionStateProps): JSX.Element {
+export function ConnectionState({ connection }: ConnectionStateProps): JSX.Element | null {
   if (connection.state === "connected") {
-    return (
-      <Box flexDirection="column">
-        <Text color="green">Daemon connected</Text>
-        <Text color="gray">Handshake: daemon.hello OK</Text>
-        {connection.hello?.daemonVersion ? (
-          <Text color="gray">Daemon version: {connection.hello.daemonVersion}</Text>
-        ) : null}
-      </Box>
-    );
+    return null;
   }
 
   if (connection.state === "connecting") {

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -28,9 +28,11 @@ export function TaskDetailPane({
   const projectNames = createProjectNameMap(projects);
   const detailTask = detail ?? task;
 
+  const loadingLabel = formatDetailLoadingLabel({ isLoadingDetail, isLoadingComments });
+
   return (
     <Box flexDirection="column" width={width} paddingLeft={1}>
-      <Text color="cyan">Detail</Text>
+      <Text color="cyan">Detail{loadingLabel ? ` • ${loadingLabel}` : ""}</Text>
       {!detailTask ? <Text color="gray">No task selected.</Text> : null}
       {detailTask
         ? formatTaskDetailLines(detailTask, projectNames.get(detailTask.projectId) ?? null).map(
@@ -45,8 +47,6 @@ export function TaskDetailPane({
             ),
           )
         : null}
-      {isLoadingDetail ? <Text color="yellow">Loading detail…</Text> : null}
-      {isLoadingComments ? <Text color="yellow">Loading comments…</Text> : null}
       {comments.length > 0 ? (
         <Box flexDirection="column" marginTop={1}>
           <Text color="cyan">Comments</Text>
@@ -60,4 +60,26 @@ export function TaskDetailPane({
       {error ? <Text color="red">{formatToduClientError(error)}</Text> : null}
     </Box>
   );
+}
+
+function formatDetailLoadingLabel({
+  isLoadingDetail,
+  isLoadingComments,
+}: {
+  isLoadingDetail: boolean;
+  isLoadingComments: boolean;
+}): string | null {
+  if (isLoadingDetail && isLoadingComments) {
+    return "loading detail + comments…";
+  }
+
+  if (isLoadingDetail) {
+    return "loading detail…";
+  }
+
+  if (isLoadingComments) {
+    return "loading comments…";
+  }
+
+  return null;
 }

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -12,6 +12,7 @@ export interface TaskDetailPaneProps {
   comments?: readonly Note[];
   isLoadingComments?: boolean;
   error: unknown;
+  width?: string;
 }
 
 export function TaskDetailPane({
@@ -22,12 +23,13 @@ export function TaskDetailPane({
   comments = [],
   isLoadingComments = false,
   error,
+  width = "50%",
 }: TaskDetailPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
   const detailTask = detail ?? task;
 
   return (
-    <Box flexDirection="column" width="50%" paddingLeft={1}>
+    <Box flexDirection="column" width={width} paddingLeft={1}>
       <Text color="cyan">Detail</Text>
       {!detailTask ? <Text color="gray">No task selected.</Text> : null}
       {detailTask

--- a/packages/tui/src/components/tasks/TaskListPane.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.tsx
@@ -9,15 +9,23 @@ export interface TaskListPaneProps {
   tasks: readonly Task[];
   projects?: readonly Project[];
   selectedTaskId: string | null;
+  width?: string;
+  focused?: boolean;
 }
 
-export function TaskListPane({ tasks, projects, selectedTaskId }: TaskListPaneProps): JSX.Element {
+export function TaskListPane({
+  tasks,
+  projects,
+  selectedTaskId,
+  width = "50%",
+  focused = true,
+}: TaskListPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
   const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, MAX_VISIBLE_TASKS);
 
   return (
-    <Box flexDirection="column" width="50%" paddingRight={1}>
-      <Text color="cyan">Tasks ({tasks.length})</Text>
+    <Box flexDirection="column" width={width} paddingRight={1}>
+      <Text color={focused ? "cyan" : "gray"}>Tasks ({tasks.length})</Text>
       {visibleTasks.map((task) => {
         const selected = task.id === selectedTaskId;
         const prefix = selected ? ">" : " ";
@@ -25,7 +33,7 @@ export function TaskListPane({ tasks, projects, selectedTaskId }: TaskListPanePr
           <Text
             key={task.id}
             color={selected ? "cyan" : undefined}
-            inverse={selected}
+            inverse={selected && focused}
             wrap="truncate-end"
           >
             {prefix} {formatTaskRow(task, projectNames.get(task.projectId) ?? null)}

--- a/packages/tui/src/components/tasks/TaskListPane.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "ink";
 import type { JSX } from "react";
 import { createProjectNameMap, formatTaskRow } from "../../formatting/task.js";
 
-const MAX_VISIBLE_TASKS = 12;
+const DEFAULT_MAX_VISIBLE_TASKS = 12;
 
 export interface TaskListPaneProps {
   tasks: readonly Task[];
@@ -11,6 +11,7 @@ export interface TaskListPaneProps {
   selectedTaskId: string | null;
   width?: string;
   focused?: boolean;
+  maxVisibleTasks?: number;
 }
 
 export function TaskListPane({
@@ -19,9 +20,10 @@ export function TaskListPane({
   selectedTaskId,
   width = "50%",
   focused = true,
+  maxVisibleTasks = DEFAULT_MAX_VISIBLE_TASKS,
 }: TaskListPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
-  const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, MAX_VISIBLE_TASKS);
+  const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, maxVisibleTasks);
 
   return (
     <Box flexDirection="column" width={width} paddingRight={1}>

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -117,8 +117,10 @@ describe("TasksScreen", () => {
     await waitForFrameText(lastFrame, "First task");
     await waitForFrameText(lastFrame, "Description for First task");
 
+    expect(lastFrame()).toContain("Projects");
+    expect(lastFrame()).toContain("> All Projects");
     expect(lastFrame()).toContain("Tasks (2)");
-    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+    expect(lastFrame()).toContain("First task");
     expect(lastFrame()).toContain("Second task");
     expect(lastFrame()).toContain("Detail");
     expect(lastFrame()).toContain("Status: active");
@@ -135,19 +137,67 @@ describe("TasksScreen", () => {
 
     stdin.write("j");
     await waitForFrameText(lastFrame, "Description for Second task");
-    expect(lastFrame()).toContain("> [med] [waiting] Second task (todu) #tui");
+    expect(lastFrame()).toContain("Second task");
 
     stdin.write("k");
     await waitForFrameText(lastFrame, "Description for First task");
-    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+    expect(lastFrame()).toContain("First task");
 
     stdin.write("\u001B[B");
     await waitForFrameText(lastFrame, "Description for Second task");
-    expect(lastFrame()).toContain("> [med] [waiting] Second task (todu) #tui");
+    expect(lastFrame()).toContain("Second task");
 
     stdin.write("\u001B[A");
     await waitForFrameText(lastFrame, "Description for First task");
-    expect(lastFrame()).toContain("> [high] [active] First task (todu) #tui");
+    expect(lastFrame()).toContain("First task");
+  });
+
+  it("filters tasks from the permanent project pane", async () => {
+    const inboxTask = createTask({ id: "task-inbox", title: "Inbox task", projectId: "project-1" });
+    const workTask = createTask({ id: "task-work", title: "Work task", projectId: "project-2" });
+    const client = createClient({
+      project: {
+        list: vi.fn().mockResolvedValue([
+          { id: "project-1", name: "todu" },
+          { id: "project-2", name: "Work" },
+        ]),
+        get: vi.fn(),
+      },
+      task: {
+        list: vi.fn().mockImplementation((filter: { projectId?: string } = {}) => {
+          const tasks = [inboxTask, workTask];
+          return Promise.resolve(
+            filter.projectId ? tasks.filter((task) => task.projectId === filter.projectId) : tasks,
+          );
+        }),
+        get: vi.fn().mockImplementation((id: string) => {
+          const task = [inboxTask, workTask].find((entry) => entry.id === id) ?? inboxTask;
+          return Promise.resolve({ ...task, description: `Description for ${task.title}` });
+        }),
+        update: vi.fn(),
+        createComment: vi.fn(),
+      },
+    });
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Inbox task");
+    expect(lastFrame()).toContain("Work task");
+
+    stdin.write("p");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stdin.write("j");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stdin.write("j");
+
+    await waitForFrameText(lastFrame, "Description for Work task");
+    expect(lastFrame()).toContain("Work task");
+    expect(lastFrame()).not.toContain("Inbox task");
+    expect(client.task.list).toHaveBeenCalledWith({
+      status: ["active", "inprogress", "waiting"],
+      projectId: "project-2",
+    });
   });
 
   it("passes selected project ID to task list filter", async () => {
@@ -309,7 +359,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks for All projects.");
+    await waitForFrameText(lastFrame, "No active, in-progress, or waiting");
     stdin.write("c");
 
     await waitForFrameText(lastFrame, "No task selected for comment.");
@@ -371,7 +421,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "No active, in-progress, or waiting tasks for All projects.");
+    await waitForFrameText(lastFrame, "No active, in-progress, or waiting");
   });
 
   it("renders user-facing errors", async () => {

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -108,47 +108,56 @@ async function waitForFrameText(lastFrame: () => string | undefined, text: strin
 }
 
 describe("TasksScreen", () => {
-  it("renders fetched tasks and selected task details", async () => {
+  it("renders fetched tasks without task details until enter opens detail mode", async () => {
     const client = createClient();
-    const { lastFrame } = renderWithQuery(
+    const { stdin, lastFrame } = renderWithQuery(
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
     await waitForFrameText(lastFrame, "First task");
-    await waitForFrameText(lastFrame, "Description for First task");
 
     expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("> All Projects");
     expect(lastFrame()).toContain("Tasks (2)");
     expect(lastFrame()).toContain("First task");
     expect(lastFrame()).toContain("Second task");
+    expect(lastFrame()).not.toContain("Detail");
+
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "Existing comment");
+
     expect(lastFrame()).toContain("Detail");
     expect(lastFrame()).toContain("Status: active");
     expect(lastFrame()).toContain("Existing comment");
+    expect(lastFrame()).not.toContain("Second task");
+
+    stdin.write("\u001B");
+    await waitForFrameText(lastFrame, "Second task");
+    expect(lastFrame()).not.toContain("Detail");
   });
 
-  it("moves selection with j/k and arrow keys and updates detail", async () => {
+  it("moves task selection with j/k and arrow keys", async () => {
     const client = createClient();
     const { stdin, lastFrame } = renderWithQuery(
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
 
     stdin.write("j");
-    await waitForFrameText(lastFrame, "Description for Second task");
+    await waitForFrameText(lastFrame, "Second task");
     expect(lastFrame()).toContain("Second task");
 
     stdin.write("k");
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     expect(lastFrame()).toContain("First task");
 
     stdin.write("\u001B[B");
-    await waitForFrameText(lastFrame, "Description for Second task");
+    await waitForFrameText(lastFrame, "Second task");
     expect(lastFrame()).toContain("Second task");
 
     stdin.write("\u001B[A");
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     expect(lastFrame()).toContain("First task");
   });
 
@@ -185,19 +194,29 @@ describe("TasksScreen", () => {
     await waitForFrameText(lastFrame, "Inbox task");
     expect(lastFrame()).toContain("Work task");
 
-    stdin.write("p");
+    stdin.write("h");
     await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
     await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
 
-    await waitForFrameText(lastFrame, "Description for Work task");
+    await waitForFrameText(lastFrame, "Work task");
     expect(lastFrame()).toContain("Work task");
     expect(lastFrame()).not.toContain("Inbox task");
     expect(client.task.list).toHaveBeenCalledWith({
       status: ["active", "inprogress", "waiting"],
       projectId: "project-2",
     });
+
+    stdin.write("\r");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "Work task");
+
+    stdin.write("l");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stdin.write("k");
+    await waitForFrameText(lastFrame, "Work task");
   });
 
   it("passes selected project ID to task list filter", async () => {
@@ -223,7 +242,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("s");
 
     await waitForFrameText(lastFrame, "Task started: First task");
@@ -236,7 +255,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("x");
     await waitForFrameText(lastFrame, "Cancel selected task?");
     expect(client.task.update).not.toHaveBeenCalled();
@@ -252,7 +271,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("x");
     await waitForFrameText(lastFrame, "Cancel selected task?");
     stdin.write("n");
@@ -270,7 +289,7 @@ describe("TasksScreen", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("s");
     await waitForFrameText(lastFrame, "Task actions unavailable while daemon is disconnected.");
     expect(client.task.update).not.toHaveBeenCalled();
@@ -290,7 +309,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("w");
     await waitForFrameText(lastFrame, "Cannot update task status");
   });
@@ -301,7 +320,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
     await waitForFrameText(lastFrame, "Comment on First task");
     stdin.write("New task context");
@@ -309,7 +328,6 @@ describe("TasksScreen", () => {
     stdin.write("\r");
 
     await waitForFrameText(lastFrame, "Comment added: First task");
-    await waitForFrameText(lastFrame, "New task context");
     expect(client.task.createComment).toHaveBeenCalledWith("task-1", "New task context");
   });
 
@@ -319,7 +337,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
     await waitForFrameText(lastFrame, "Comment on First task");
     stdin.write("   ");
@@ -335,7 +353,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
     await waitForFrameText(lastFrame, "Comment on First task");
     stdin.write("Draft comment");
@@ -376,7 +394,7 @@ describe("TasksScreen", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
 
     await waitForFrameText(lastFrame, "Task actions unavailable while daemon is disconnected.");
@@ -398,7 +416,7 @@ describe("TasksScreen", () => {
       <TasksScreen client={client} projectFilter={allProjectsFilter} />,
     );
 
-    await waitForFrameText(lastFrame, "Description for First task");
+    await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
     await waitForFrameText(lastFrame, "Comment on First task");
     stdin.write("New task context");

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { TaskStatus } from "@todu/core";
+import type { Project, TaskStatus } from "@todu/core";
 import { Box, Text, useInput } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
@@ -10,7 +10,11 @@ import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { normalizeCommentContent } from "../state/comment-actions.js";
-import { describeProjectFilter, type ProjectFilterState } from "../state/project-filter.js";
+import {
+  allProjectsFilter,
+  describeProjectFilter,
+  type ProjectFilterState,
+} from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
 import { resolveTaskStatusAction, taskStatusActions } from "../state/task-actions.js";
@@ -24,6 +28,15 @@ export interface TasksScreenProps {
 }
 
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
+const ALL_PROJECTS_OPTION_ID = "__all__";
+
+type PaneFocus = "projects" | "tasks";
+
+interface ProjectOption {
+  id: string;
+  label: string;
+  project: Project | null;
+}
 
 export function TasksScreen({
   client,
@@ -33,24 +46,40 @@ export function TasksScreen({
   onGlobalInputEnabledChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
+  const [selectedProjectOptionId, setSelectedProjectOptionId] = useState<string>(
+    projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
+  );
+  const [focusedPane, setFocusedPane] = useState<PaneFocus>("tasks");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [commentModalOpen, setCommentModalOpen] = useState(false);
   const [commentText, setCommentText] = useState("");
   const [commentError, setCommentError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
+  const projectsQuery = useQuery({
+    queryKey: queryKeys.projects(),
+    queryFn: () => client.project.list(),
+    enabled: dataQueriesEnabled,
+  });
+  const projectOptions = useMemo(
+    () => createTaskProjectOptions(projectsQuery.data ?? []),
+    [projectsQuery.data],
+  );
+  const selectedProjectOption =
+    projectOptions.find((option) => option.id === selectedProjectOptionId) ?? projectOptions[0];
+  const selectedProjectFilter: ProjectFilterState = selectedProjectOption?.project
+    ? {
+        projectId: selectedProjectOption.project.id,
+        projectName: selectedProjectOption.project.name,
+      }
+    : allProjectsFilter;
   const taskFilter = {
     status: [...visibleTaskStatuses],
-    ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
+    ...(selectedProjectFilter.projectId ? { projectId: selectedProjectFilter.projectId } : {}),
   };
   const tasksQuery = useQuery({
     queryKey: queryKeys.tasks(taskFilter),
     queryFn: () => client.task.list(taskFilter),
-    enabled: dataQueriesEnabled,
-  });
-  const projectsQuery = useQuery({
-    queryKey: queryKeys.projects(),
-    queryFn: () => client.project.list(),
     enabled: dataQueriesEnabled,
   });
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
@@ -73,6 +102,18 @@ export function TasksScreen({
     mutationFn: ({ taskId, content }: { taskId: string; content: string }) =>
       client.task.createComment(taskId, content),
   });
+
+  useEffect(() => {
+    setSelectedProjectOptionId(projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID);
+  }, [projectFilter.projectId]);
+
+  useEffect(() => {
+    if (!projectsQuery.data) {
+      return;
+    }
+
+    setSelectedProjectOptionId((current) => resolveTaskProjectOptionId(projectOptions, current));
+  }, [projectOptions, projectsQuery.data]);
 
   useEffect(() => {
     if (!tasksQuery.data) {
@@ -184,6 +225,39 @@ export function TasksScreen({
       return;
     }
 
+    if (input === "\t") {
+      setFocusedPane((current) => (current === "projects" ? "tasks" : "projects"));
+      return;
+    }
+
+    if (input === "p" || key.leftArrow) {
+      setFocusedPane("projects");
+      return;
+    }
+
+    if (key.rightArrow) {
+      setFocusedPane("tasks");
+      return;
+    }
+
+    if (focusedPane === "projects") {
+      if (input === "j" || key.downArrow) {
+        setSelectedProjectOptionId((current) =>
+          moveTaskProjectOption(projectOptions, current, "next"),
+        );
+        setFeedback(null);
+        return;
+      }
+
+      if (input === "k" || key.upArrow) {
+        setSelectedProjectOptionId((current) =>
+          moveTaskProjectOption(projectOptions, current, "previous"),
+        );
+        setFeedback(null);
+        return;
+      }
+    }
+
     if (input === "c" && !selectedTask) {
       setFeedback({ message: "No task selected for comment.", tone: "error" });
       return;
@@ -209,12 +283,12 @@ export function TasksScreen({
       return;
     }
 
-    if (input === "j" || key.downArrow) {
+    if (focusedPane === "tasks" && (input === "j" || key.downArrow)) {
       setSelectedTaskId((current) => moveSelection(tasks, current, "next"));
       return;
     }
 
-    if (input === "k" || key.upArrow) {
+    if (focusedPane === "tasks" && (input === "k" || key.upArrow)) {
       setSelectedTaskId((current) => moveSelection(tasks, current, "previous"));
       return;
     }
@@ -258,10 +332,29 @@ export function TasksScreen({
   if (tasks.length === 0) {
     return (
       <Box flexDirection="column">
-        <Text color="cyan">Tasks</Text>
-        <Text color="gray">
-          No active, in-progress, or waiting tasks for {describeProjectFilter(projectFilter)}.
-        </Text>
+        <Box flexDirection="row">
+          <ProjectListPane
+            projects={projectOptions}
+            selectedProjectOptionId={selectedProjectOptionId}
+            focused={focusedPane === "projects"}
+          />
+          <Box flexDirection="column" width="35%" paddingRight={1}>
+            <Text color={focusedPane === "tasks" ? "cyan" : "gray"}>Tasks (0)</Text>
+            <Text color="gray">
+              No active, in-progress, or waiting tasks for{" "}
+              {describeProjectFilter(selectedProjectFilter)}.
+            </Text>
+          </Box>
+          <TaskDetailPane
+            task={null}
+            projects={projectsQuery.data}
+            width="40%"
+            isLoadingDetail={false}
+            comments={[]}
+            isLoadingComments={false}
+            error={null}
+          />
+        </Box>
         <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
       </Box>
     );
@@ -270,11 +363,23 @@ export function TasksScreen({
   return (
     <Box flexDirection="column">
       <Box flexDirection="row">
-        <TaskListPane tasks={tasks} projects={projectsQuery.data} selectedTaskId={selectedTaskId} />
+        <ProjectListPane
+          projects={projectOptions}
+          selectedProjectOptionId={selectedProjectOptionId}
+          focused={focusedPane === "projects"}
+        />
+        <TaskListPane
+          tasks={tasks}
+          projects={projectsQuery.data}
+          selectedTaskId={selectedTaskId}
+          width="35%"
+          focused={focusedPane === "tasks"}
+        />
         <TaskDetailPane
           task={selectedTask}
           detail={selectedDetailQuery.data}
           projects={projectsQuery.data}
+          width="40%"
           isLoadingDetail={selectedDetailQuery.isLoading}
           comments={commentsQuery.data}
           isLoadingComments={commentsQuery.isLoading}
@@ -293,4 +398,71 @@ export function TasksScreen({
       <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
     </Box>
   );
+}
+
+interface ProjectListPaneProps {
+  projects: readonly ProjectOption[];
+  selectedProjectOptionId: string;
+  focused: boolean;
+}
+
+function ProjectListPane({
+  projects,
+  selectedProjectOptionId,
+  focused,
+}: ProjectListPaneProps): JSX.Element {
+  return (
+    <Box flexDirection="column" width="25%" paddingRight={1}>
+      <Text color={focused ? "cyan" : "gray"}>Projects</Text>
+      {projects.map((option) => {
+        const selected = option.id === selectedProjectOptionId;
+        return (
+          <Text
+            key={option.id}
+            color={selected ? "cyan" : undefined}
+            inverse={selected && focused}
+            wrap="truncate-end"
+          >
+            {selected ? ">" : " "} {option.label}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}
+
+function createTaskProjectOptions(projects: readonly Project[]): ProjectOption[] {
+  return [
+    { id: ALL_PROJECTS_OPTION_ID, label: "All Projects", project: null },
+    ...projects.map((project) => ({ id: project.id, label: project.name, project })),
+  ];
+}
+
+function resolveTaskProjectOptionId(
+  options: readonly ProjectOption[],
+  currentOptionId: string,
+): string {
+  if (options.some((option) => option.id === currentOptionId)) {
+    return currentOptionId;
+  }
+
+  return options[0]?.id ?? ALL_PROJECTS_OPTION_ID;
+}
+
+function moveTaskProjectOption(
+  options: readonly ProjectOption[],
+  currentOptionId: string,
+  direction: "next" | "previous",
+): string {
+  if (options.length === 0) {
+    return ALL_PROJECTS_OPTION_ID;
+  }
+
+  const currentIndex = Math.max(
+    0,
+    options.findIndex((option) => option.id === currentOptionId),
+  );
+  const delta = direction === "next" ? 1 : -1;
+  const nextIndex = Math.max(0, Math.min(options.length - 1, currentIndex + delta));
+  return options[nextIndex]?.id ?? ALL_PROJECTS_OPTION_ID;
 }

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,13 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Project, TaskStatus } from "@todu/core";
-import { Box, Text, useInput } from "ink";
+import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { TextInputModal } from "../components/TextInputModal.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
-import { TaskListPane } from "../components/tasks/TaskListPane.js";
+import { getVisibleTaskWindow, TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { normalizeCommentContent } from "../state/comment-actions.js";
 import {
@@ -29,6 +29,11 @@ export interface TasksScreenProps {
 
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
 const ALL_PROJECTS_OPTION_ID = "__all__";
+const PROJECT_PANE_WIDTH_PERCENT = 0.36;
+const PROJECT_PANE_WIDTH = "36%";
+const TASK_MAIN_PANE_WIDTH = "64%";
+const MIN_PROJECT_LABEL_LENGTH = 8;
+const MIN_VISIBLE_LIST_ITEMS = 6;
 
 type PaneFocus = "projects" | "tasks";
 
@@ -46,11 +51,13 @@ export function TasksScreen({
   onGlobalInputEnabledChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
+  const { stdout } = useStdout();
   const [selectedProjectOptionId, setSelectedProjectOptionId] = useState<string>(
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
   );
   const [focusedPane, setFocusedPane] = useState<PaneFocus>("tasks");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [taskDetailOpen, setTaskDetailOpen] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [commentModalOpen, setCommentModalOpen] = useState(false);
   const [commentText, setCommentText] = useState("");
@@ -83,16 +90,18 @@ export function TasksScreen({
     enabled: dataQueriesEnabled,
   });
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
-  const selectedTask = getSelectedItem(tasks, selectedTaskId);
+  const effectiveSelectedTaskId = resolveSelectedId(tasks, selectedTaskId);
+  const selectedTask = getSelectedItem(tasks, effectiveSelectedTaskId);
   const selectedDetailQuery = useQuery({
-    queryKey: queryKeys.task(selectedTaskId ?? "none"),
-    queryFn: () => client.task.get(selectedTaskId ?? ""),
-    enabled: dataQueriesEnabled && selectedTaskId !== null,
+    queryKey: queryKeys.task(effectiveSelectedTaskId ?? "none"),
+    queryFn: () => client.task.get(effectiveSelectedTaskId ?? ""),
+    enabled: dataQueriesEnabled && effectiveSelectedTaskId !== null,
   });
   const commentsQuery = useQuery({
-    queryKey: queryKeys.taskComments(selectedTaskId ?? "none"),
-    queryFn: () => client.note.list({ entityType: "task", entityId: selectedTaskId ?? "" }),
-    enabled: dataQueriesEnabled && selectedTaskId !== null,
+    queryKey: queryKeys.taskComments(effectiveSelectedTaskId ?? "none"),
+    queryFn: () =>
+      client.note.list({ entityType: "task", entityId: effectiveSelectedTaskId ?? "" }),
+    enabled: dataQueriesEnabled && effectiveSelectedTaskId !== null,
   });
   const statusMutation = useMutation({
     mutationFn: ({ taskId, status }: { taskId: string; status: TaskStatus }) =>
@@ -105,6 +114,7 @@ export function TasksScreen({
 
   useEffect(() => {
     setSelectedProjectOptionId(projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID);
+    setTaskDetailOpen(false);
   }, [projectFilter.projectId]);
 
   useEffect(() => {
@@ -225,17 +235,17 @@ export function TasksScreen({
       return;
     }
 
-    if (input === "\t") {
-      setFocusedPane((current) => (current === "projects" ? "tasks" : "projects"));
+    if (taskDetailOpen && (key.escape || input === "\u001B")) {
+      setTaskDetailOpen(false);
       return;
     }
 
-    if (input === "p" || key.leftArrow) {
+    if (input === "h" || key.leftArrow) {
       setFocusedPane("projects");
       return;
     }
 
-    if (key.rightArrow) {
+    if (input === "l" || key.rightArrow) {
       setFocusedPane("tasks");
       return;
     }
@@ -245,6 +255,7 @@ export function TasksScreen({
         setSelectedProjectOptionId((current) =>
           moveTaskProjectOption(projectOptions, current, "next"),
         );
+        setTaskDetailOpen(false);
         setFeedback(null);
         return;
       }
@@ -253,6 +264,13 @@ export function TasksScreen({
         setSelectedProjectOptionId((current) =>
           moveTaskProjectOption(projectOptions, current, "previous"),
         );
+        setTaskDetailOpen(false);
+        setFeedback(null);
+        return;
+      }
+
+      if (key.return || input === "\r") {
+        setFocusedPane("tasks");
         setFeedback(null);
         return;
       }
@@ -283,12 +301,17 @@ export function TasksScreen({
       return;
     }
 
-    if (focusedPane === "tasks" && (input === "j" || key.downArrow)) {
+    if (focusedPane === "tasks" && !taskDetailOpen && (key.return || input === "\r")) {
+      setTaskDetailOpen(true);
+      return;
+    }
+
+    if (focusedPane === "tasks" && !taskDetailOpen && (input === "j" || key.downArrow)) {
       setSelectedTaskId((current) => moveSelection(tasks, current, "next"));
       return;
     }
 
-    if (focusedPane === "tasks" && (input === "k" || key.upArrow)) {
+    if (focusedPane === "tasks" && !taskDetailOpen && (input === "k" || key.upArrow)) {
       setSelectedTaskId((current) => moveSelection(tasks, current, "previous"));
       return;
     }
@@ -315,6 +338,8 @@ export function TasksScreen({
     void performStatusAction(selectedTask.id, action.status, action.successLabel);
   });
 
+  const maxVisibleListItems = resolveMaxVisibleListItems(stdout.rows);
+  const maxProjectLabelLength = resolveProjectLabelLength(stdout.columns);
   const error = tasksQuery.error ?? projectsQuery.error;
   if (error) {
     return (
@@ -326,7 +351,25 @@ export function TasksScreen({
   }
 
   if (tasksQuery.isLoading) {
-    return <Text color="yellow">Loading tasks…</Text>;
+    return (
+      <Box flexDirection="column">
+        <Box flexDirection="row">
+          <ProjectListPane
+            projects={projectOptions}
+            selectedProjectOptionId={selectedProjectOptionId}
+            focused={focusedPane === "projects"}
+            isLoading={projectsQuery.isLoading}
+            maxVisibleProjects={maxVisibleListItems}
+            maxProjectLabelLength={maxProjectLabelLength}
+          />
+          <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH} paddingRight={1}>
+            <Text color={focusedPane === "tasks" ? "cyan" : "gray"}>Tasks • loading…</Text>
+            <Text color="gray">Loading active, in-progress, and waiting tasks…</Text>
+          </Box>
+        </Box>
+        <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
+      </Box>
+    );
   }
 
   if (tasks.length === 0) {
@@ -337,23 +380,17 @@ export function TasksScreen({
             projects={projectOptions}
             selectedProjectOptionId={selectedProjectOptionId}
             focused={focusedPane === "projects"}
+            isLoading={projectsQuery.isLoading}
+            maxVisibleProjects={maxVisibleListItems}
+            maxProjectLabelLength={maxProjectLabelLength}
           />
-          <Box flexDirection="column" width="35%" paddingRight={1}>
+          <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH} paddingRight={1}>
             <Text color={focusedPane === "tasks" ? "cyan" : "gray"}>Tasks (0)</Text>
             <Text color="gray">
               No active, in-progress, or waiting tasks for{" "}
               {describeProjectFilter(selectedProjectFilter)}.
             </Text>
           </Box>
-          <TaskDetailPane
-            task={null}
-            projects={projectsQuery.data}
-            width="40%"
-            isLoadingDetail={false}
-            comments={[]}
-            isLoadingComments={false}
-            error={null}
-          />
         </Box>
         <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
       </Box>
@@ -367,24 +404,32 @@ export function TasksScreen({
           projects={projectOptions}
           selectedProjectOptionId={selectedProjectOptionId}
           focused={focusedPane === "projects"}
+          isLoading={projectsQuery.isLoading}
+          maxVisibleProjects={maxVisibleListItems}
+          maxProjectLabelLength={maxProjectLabelLength}
         />
-        <TaskListPane
-          tasks={tasks}
-          projects={projectsQuery.data}
-          selectedTaskId={selectedTaskId}
-          width="35%"
-          focused={focusedPane === "tasks"}
-        />
-        <TaskDetailPane
-          task={selectedTask}
-          detail={selectedDetailQuery.data}
-          projects={projectsQuery.data}
-          width="40%"
-          isLoadingDetail={selectedDetailQuery.isLoading}
-          comments={commentsQuery.data}
-          isLoadingComments={commentsQuery.isLoading}
-          error={selectedDetailQuery.error ?? commentsQuery.error}
-        />
+        <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH}>
+          <TaskListPane
+            tasks={taskDetailOpen && selectedTask ? [selectedTask] : tasks}
+            projects={projectsQuery.data}
+            selectedTaskId={effectiveSelectedTaskId}
+            width="100%"
+            focused={focusedPane === "tasks"}
+            maxVisibleTasks={maxVisibleListItems}
+          />
+          {taskDetailOpen ? (
+            <TaskDetailPane
+              task={selectedTask}
+              detail={selectedDetailQuery.data}
+              projects={projectsQuery.data}
+              width="100%"
+              isLoadingDetail={selectedDetailQuery.isLoading}
+              comments={commentsQuery.data}
+              isLoadingComments={commentsQuery.isLoading}
+              error={selectedDetailQuery.error ?? commentsQuery.error}
+            />
+          ) : null}
+        </Box>
       </Box>
       {commentModalOpen ? (
         <TextInputModal
@@ -404,17 +449,29 @@ interface ProjectListPaneProps {
   projects: readonly ProjectOption[];
   selectedProjectOptionId: string;
   focused: boolean;
+  isLoading?: boolean;
+  maxVisibleProjects: number;
+  maxProjectLabelLength: number;
 }
 
 function ProjectListPane({
   projects,
   selectedProjectOptionId,
   focused,
+  isLoading = false,
+  maxVisibleProjects,
+  maxProjectLabelLength,
 }: ProjectListPaneProps): JSX.Element {
+  const visibleProjects = getVisibleTaskWindow(
+    projects,
+    selectedProjectOptionId,
+    maxVisibleProjects,
+  );
+
   return (
-    <Box flexDirection="column" width="25%" paddingRight={1}>
-      <Text color={focused ? "cyan" : "gray"}>Projects</Text>
-      {projects.map((option) => {
+    <Box flexDirection="column" width={PROJECT_PANE_WIDTH} paddingRight={1} flexShrink={0}>
+      <Text color={focused ? "cyan" : "gray"}>Projects{isLoading ? " • loading…" : ""}</Text>
+      {visibleProjects.map((option) => {
         const selected = option.id === selectedProjectOptionId;
         return (
           <Text
@@ -423,12 +480,46 @@ function ProjectListPane({
             inverse={selected && focused}
             wrap="truncate-end"
           >
-            {selected ? ">" : " "} {option.label}
+            {selected ? ">" : " "} {truncateProjectLabel(option.label, maxProjectLabelLength)}
           </Text>
         );
       })}
     </Box>
   );
+}
+
+function resolveProjectLabelLength(columns: number | undefined): number {
+  const terminalColumns = columns && columns > 0 ? columns : 80;
+  const appHorizontalPadding = 2;
+  const projectPaneRightPadding = 1;
+  const selectionPrefix = 2;
+  const availableBodyColumns = Math.max(0, terminalColumns - appHorizontalPadding);
+  const projectPaneColumns = Math.floor(availableBodyColumns * PROJECT_PANE_WIDTH_PERCENT);
+
+  return Math.max(
+    MIN_PROJECT_LABEL_LENGTH,
+    projectPaneColumns - projectPaneRightPadding - selectionPrefix,
+  );
+}
+
+function resolveMaxVisibleListItems(rows: number | undefined): number {
+  const terminalRows = rows && rows > 0 ? rows : 24;
+
+  // AppFrame reserves rows for padding, title, status, body margins, and footer.
+  // Each pane also uses one row for its title.
+  return Math.max(MIN_VISIBLE_LIST_ITEMS, terminalRows - 8);
+}
+
+function truncateProjectLabel(label: string, maxLength = 24): string {
+  if (label.length <= maxLength) {
+    return label;
+  }
+
+  if (maxLength <= 3) {
+    return label.slice(0, maxLength);
+  }
+
+  return `${label.slice(0, maxLength - 3)}...`;
 }
 
 function createTaskProjectOptions(projects: readonly Project[]): ProjectOption[] {


### PR DESCRIPTION
## Summary
- add a permanent Projects pane to the Tasks screen
- default project selection to All Projects and filter task list by selected project
- keep task detail tied to the currently selected task
- add focused task screen tests for pane rendering and project filtering
- add pending @todu/tui patch changeset

## Notes
- Scope is limited to the three-pane behavior; no broader layout redesign or styling overhaul.
- Existing task-pane navigation/actions remain available.

## Verification
- npm test -- packages/tui/src/screens/TasksScreen.test.tsx packages/tui/src/app/App.test.tsx
- npm run --workspace=@todu/tui typecheck
- npm run --workspace=@todu/tui build
- make pre-pr
- npm run check:ci

Task: task-bdfefcd0