### PR TITLE
Test TUI connection status display

### DIFF
--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -161,11 +161,28 @@ describe("App", () => {
 
     expect(lastFrame()).toContain("Todu • Tasks");
     expect(lastFrame()).toContain("View: Tasks");
+    expect(lastFrame()).toContain("Daemon: unavailable");
     expect(lastFrame()).toContain("Daemon unavailable");
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Tasks");
     expect(lastFrame()).toContain("q Back/Quit");
     expect(lastFrame()).toContain("Project: All projects");
+  });
+
+  it("shows connected daemon status without body handshake diagnostics", async () => {
+    const { lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Ship");
+
+    expect(lastFrame()).toContain("Daemon: connected (dev)");
+    expect(lastFrame()).not.toContain("Daemon connected");
+    expect(lastFrame()).not.toContain("Handshake: daemon.hello OK");
+    expect(lastFrame()).not.toContain("Daemon version:");
   });
 
   it("switches between primary routes", async () => {
@@ -324,6 +341,7 @@ describe("App", () => {
 
     connection.emitSnapshot({ ...createConnectedSnapshot(), state: "reconnecting", hello: null });
     await waitForFrameText(lastFrame, "Daemon disconnected; reconnecting");
+    expect(lastFrame()).toContain("Daemon: reconnecting");
     expect(lastFrame()).toContain("Ship");
 
     connection.emitSnapshot(createConnectedSnapshot());


### PR DESCRIPTION
## Summary

- Adds coverage that connected TUI state uses compact status-line daemon text without body handshake diagnostics.
- Strengthens failed startup coverage for status-line unavailable state and daemon start guidance.
- Strengthens reconnect coverage that cached task content remains visible while reconnect status is shown.

## Verification

- npm test -- packages/tui/src/app/App.test.tsx
- make pre-pr

Task: #task-b1203472

No changeset: test-only change.