### PR TITLE
Add full-height TUI pane layout

### DIFF
--- a/.changeset/tui-full-height-panes.md
+++ b/.changeset/tui-full-height-panes.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add bordered full-height pane layouts for Tasks and Projects screens.

--- a/packages/tui/src/components/Pane.tsx
+++ b/packages/tui/src/components/Pane.tsx
@@ -1,0 +1,27 @@
+import { Box, Text } from "ink";
+import type { JSX, ReactNode } from "react";
+
+export interface PaneProps {
+  title: string;
+  children: ReactNode;
+  focused?: boolean;
+  width?: string | number;
+}
+
+export function Pane({ title, children, focused = false, width = "100%" }: PaneProps): JSX.Element {
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      flexGrow={1}
+      borderStyle="single"
+      borderColor={focused ? "cyan" : "gray"}
+      paddingX={1}
+    >
+      <Text color={focused ? "cyan" : "gray"} wrap="truncate-end">
+        {title}
+      </Text>
+      {children}
+    </Box>
+  );
+}

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "ink";
 import type { JSX } from "react";
 import { formatToduClientError } from "../../daemon/todu-client.js";
 import { createProjectNameMap, formatTaskDetailLines } from "../../formatting/task.js";
+import { Pane } from "../Pane.js";
 
 export interface TaskDetailPaneProps {
   task: Task | null;
@@ -31,8 +32,7 @@ export function TaskDetailPane({
   const loadingLabel = formatDetailLoadingLabel({ isLoadingDetail, isLoadingComments });
 
   return (
-    <Box flexDirection="column" width={width} paddingLeft={1}>
-      <Text color="cyan">Detail{loadingLabel ? ` • ${loadingLabel}` : ""}</Text>
+    <Pane title={`Detail${loadingLabel ? ` • ${loadingLabel}` : ""}`} width={width}>
       {!detailTask ? <Text color="gray">No task selected.</Text> : null}
       {detailTask
         ? formatTaskDetailLines(detailTask, projectNames.get(detailTask.projectId) ?? null).map(
@@ -58,7 +58,7 @@ export function TaskDetailPane({
         </Box>
       ) : null}
       {error ? <Text color="red">{formatToduClientError(error)}</Text> : null}
-    </Box>
+    </Pane>
   );
 }
 

--- a/packages/tui/src/components/tasks/TaskListPane.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.tsx
@@ -1,7 +1,8 @@
 import type { Project, Task } from "@todu/core";
-import { Box, Text } from "ink";
+import { Text } from "ink";
 import type { JSX } from "react";
 import { createProjectNameMap, formatTaskRow } from "../../formatting/task.js";
+import { Pane } from "../Pane.js";
 
 const DEFAULT_MAX_VISIBLE_TASKS = 12;
 
@@ -26,8 +27,7 @@ export function TaskListPane({
   const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, maxVisibleTasks);
 
   return (
-    <Box flexDirection="column" width={width} paddingRight={1}>
-      <Text color={focused ? "cyan" : "gray"}>Tasks ({tasks.length})</Text>
+    <Pane title={`Tasks (${tasks.length})`} width={width} focused={focused}>
       {visibleTasks.map((task) => {
         const selected = task.id === selectedTaskId;
         const prefix = selected ? ">" : " ";
@@ -42,7 +42,7 @@ export function TaskListPane({
           </Text>
         );
       })}
-    </Box>
+    </Pane>
   );
 }
 

--- a/packages/tui/src/screens/ProjectsScreen.test.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.test.tsx
@@ -87,6 +87,8 @@ describe("ProjectsScreen", () => {
 
     await waitForFrameText(lastFrame, "Projects (2)");
 
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("└");
     expect(lastFrame()).toContain("> All projects");
     expect(lastFrame()).toContain("Inbox");
     expect(lastFrame()).toContain("Work");
@@ -132,6 +134,25 @@ describe("ProjectsScreen", () => {
     expect(onSelectAllProjects).toHaveBeenCalledTimes(1);
   });
 
+  it("renders loading state inside the pane layout", async () => {
+    const client = createClient({
+      project: { list: vi.fn().mockImplementation(() => new Promise(() => {})), get: vi.fn() },
+    });
+    const { lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Projects • loading…");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Loading projects…");
+    expect(lastFrame()).toContain("Project details will appear after projects load.");
+  });
+
   it("renders empty state", async () => {
     const client = createClient({
       project: { list: vi.fn().mockResolvedValue([]), get: vi.fn() },
@@ -146,6 +167,8 @@ describe("ProjectsScreen", () => {
     );
 
     await waitForFrameText(lastFrame, "No projects available.");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Project detail");
   });
 
   it("renders user-facing errors", async () => {
@@ -172,6 +195,8 @@ describe("ProjectsScreen", () => {
     );
 
     await waitForFrameText(lastFrame, "Projects unavailable");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Project detail");
     expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");
   });
 });

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -1,13 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Project } from "@todu/core";
-import { Box, Text, useInput } from "ink";
+import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { Pane } from "../components/Pane.js";
+import { getVisibleTaskWindow } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import type { ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 
 const ALL_PROJECTS_OPTION_ID = "__all__";
+const PROJECT_LIST_PANE_WIDTH_PERCENT = 0.4;
+const PROJECT_LIST_PANE_WIDTH = "40%";
+const PROJECT_DETAIL_PANE_WIDTH = "60%";
+const MIN_PROJECT_LABEL_LENGTH = 8;
+const MIN_VISIBLE_PROJECTS = 6;
 
 interface ProjectOption {
   id: string;
@@ -30,6 +37,7 @@ export function ProjectsScreen({
   onSelectAllProjects,
   dataQueriesEnabled = true,
 }: ProjectsScreenProps): JSX.Element {
+  const { stdout } = useStdout();
   const [selectedOptionId, setSelectedOptionId] = useState<string>(
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
   );
@@ -44,6 +52,13 @@ export function ProjectsScreen({
   );
   const selectedOption =
     projectOptions.find((option) => option.id === selectedOptionId) ?? projectOptions[0];
+  const maxVisibleProjects = resolveMaxVisibleProjects(stdout.rows);
+  const maxProjectLabelLength = resolveProjectLabelLength(stdout.columns);
+  const visibleProjects = getVisibleTaskWindow(
+    projectOptions,
+    selectedOption?.id ?? selectedOptionId,
+    maxVisibleProjects,
+  );
 
   useEffect(() => {
     if (!projectsQuery.data) {
@@ -79,23 +94,64 @@ export function ProjectsScreen({
     }
   });
 
-  if (projectsQuery.error) {
+  const projectCount = projectsQuery.data?.length ?? 0;
+  const listTitle = projectsQuery.isLoading ? "Projects • loading…" : `Projects (${projectCount})`;
+
+  return (
+    <Box flexDirection="row" flexGrow={1}>
+      <Pane title={listTitle} width={PROJECT_LIST_PANE_WIDTH} focused>
+        <ProjectListContent
+          error={projectsQuery.error}
+          isLoading={projectsQuery.isLoading}
+          projects={visibleProjects}
+          selectedOptionId={selectedOption?.id ?? selectedOptionId}
+          maxProjectLabelLength={maxProjectLabelLength}
+        />
+      </Pane>
+      <Pane title="Project detail" width={PROJECT_DETAIL_PANE_WIDTH}>
+        <ProjectDetailContent
+          option={selectedOption}
+          activeFilter={projectFilter}
+          error={projectsQuery.error}
+          isLoading={projectsQuery.isLoading}
+          isEmpty={!projectsQuery.isLoading && !projectsQuery.error && projectCount === 0}
+        />
+      </Pane>
+    </Box>
+  );
+}
+
+function ProjectListContent({
+  error,
+  isLoading,
+  projects,
+  selectedOptionId,
+  maxProjectLabelLength,
+}: {
+  error: unknown;
+  isLoading: boolean;
+  projects: readonly ProjectOption[];
+  selectedOptionId: string;
+  maxProjectLabelLength: number;
+}): JSX.Element {
+  if (error) {
     return (
       <Box flexDirection="column">
         <Text color="red">Projects unavailable</Text>
-        <Text color="gray">{formatToduClientError(projectsQuery.error)}</Text>
+        <Text color="gray" wrap="truncate-end">
+          {formatToduClientError(error)}
+        </Text>
       </Box>
     );
   }
 
-  if (projectsQuery.isLoading) {
-    return <Text color="yellow">Loading projects…</Text>;
+  if (isLoading) {
+    return <Text color="gray">Loading projects…</Text>;
   }
 
-  if ((projectsQuery.data ?? []).length === 0) {
+  if (projects.length === 1 && projects[0]?.id === ALL_PROJECTS_OPTION_ID) {
     return (
       <Box flexDirection="column">
-        <Text color="cyan">Projects</Text>
         <Text color="gray">No projects available.</Text>
         <Text color="gray">Press a to show tasks from all projects.</Text>
       </Box>
@@ -103,39 +159,55 @@ export function ProjectsScreen({
   }
 
   return (
-    <Box flexDirection="row">
-      <Box flexDirection="column" width="50%" paddingRight={1}>
-        <Text color="cyan">Projects ({projectsQuery.data?.length ?? 0})</Text>
-        {projectOptions.map((option) => {
-          const selected = option.id === selectedOption?.id;
-          return (
-            <Text
-              key={option.id}
-              color={selected ? "cyan" : undefined}
-              inverse={selected}
-              wrap="truncate-end"
-            >
-              {selected ? ">" : " "} {option.label}
-            </Text>
-          );
-        })}
-      </Box>
-      <ProjectDetail option={selectedOption} activeFilter={projectFilter} />
+    <Box flexDirection="column">
+      {projects.map((option) => {
+        const selected = option.id === selectedOptionId;
+        return (
+          <Text
+            key={option.id}
+            color={selected ? "cyan" : undefined}
+            inverse={selected}
+            wrap="truncate-end"
+          >
+            {selected ? ">" : " "} {truncateProjectLabel(option.label, maxProjectLabelLength)}
+          </Text>
+        );
+      })}
     </Box>
   );
 }
 
-function ProjectDetail({
+function ProjectDetailContent({
   option,
   activeFilter,
+  error,
+  isLoading,
+  isEmpty,
 }: {
   option: ProjectOption | undefined;
   activeFilter: ProjectFilterState;
+  error: unknown;
+  isLoading: boolean;
+  isEmpty: boolean;
 }): JSX.Element {
-  if (!option?.project) {
+  if (error) {
     return (
-      <Box flexDirection="column" width="50%" paddingLeft={1}>
-        <Text color="cyan">Project detail</Text>
+      <Box flexDirection="column">
+        <Text color="red">Projects unavailable</Text>
+        <Text color="gray" wrap="truncate-end">
+          {formatToduClientError(error)}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (isLoading) {
+    return <Text color="gray">Project details will appear after projects load.</Text>;
+  }
+
+  if (isEmpty || !option?.project) {
+    return (
+      <Box flexDirection="column">
         <Text color="gray">All projects</Text>
         <Text color="gray">Press Enter or a to show tasks from every project.</Text>
         <Text color="gray">Current filter: {activeFilter.projectName ?? "All projects"}</Text>
@@ -145,8 +217,7 @@ function ProjectDetail({
 
   const project = option.project;
   return (
-    <Box flexDirection="column" width="50%" paddingLeft={1}>
-      <Text color="cyan">Project detail</Text>
+    <Box flexDirection="column">
       <Text color="white" wrap="truncate-end">
         {project.name}
       </Text>
@@ -161,6 +232,40 @@ function ProjectDetail({
       <Text color="gray">Press a for all projects.</Text>
     </Box>
   );
+}
+
+function resolveProjectLabelLength(columns: number | undefined): number {
+  const terminalColumns = columns && columns > 0 ? columns : 80;
+  const appHorizontalPadding = 2;
+  const paneBorderAndPadding = 4;
+  const selectionPrefix = 2;
+  const availableBodyColumns = Math.max(0, terminalColumns - appHorizontalPadding);
+  const projectPaneColumns = Math.floor(availableBodyColumns * PROJECT_LIST_PANE_WIDTH_PERCENT);
+
+  return Math.max(
+    MIN_PROJECT_LABEL_LENGTH,
+    projectPaneColumns - paneBorderAndPadding - selectionPrefix,
+  );
+}
+
+function resolveMaxVisibleProjects(rows: number | undefined): number {
+  const terminalRows = rows && rows > 0 ? rows : 24;
+
+  // AppFrame reserves rows for padding, title, status, body margins, and footer.
+  // The pane reserves rows for borders and title.
+  return Math.max(MIN_VISIBLE_PROJECTS, terminalRows - 10);
+}
+
+function truncateProjectLabel(label: string, maxLength = 24): string {
+  if (label.length <= maxLength) {
+    return label;
+  }
+
+  if (maxLength <= 3) {
+    return label.slice(0, maxLength);
+  }
+
+  return `${label.slice(0, maxLength - 3)}...`;
 }
 
 export function createProjectOptions(projects: readonly Project[]): ProjectOption[] {

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -116,6 +116,8 @@ describe("TasksScreen", () => {
 
     await waitForFrameText(lastFrame, "First task");
 
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("└");
     expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("> All Projects");
     expect(lastFrame()).toContain("Tasks (2)");
@@ -426,6 +428,25 @@ describe("TasksScreen", () => {
     await waitForFrameText(lastFrame, "Cannot add comment");
   });
 
+  it("renders loading state inside the pane layout", async () => {
+    const client = createClient({
+      task: {
+        list: vi.fn().mockImplementation(() => new Promise(() => {})),
+        get: vi.fn(),
+        update: vi.fn(),
+        createComment: vi.fn(),
+      },
+    });
+    const { lastFrame } = renderWithQuery(
+      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+    );
+
+    await waitForFrameText(lastFrame, "Tasks • loading…");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Projects");
+    expect(lastFrame()).toContain("Loading active, in-progress, and waiting tasks…");
+  });
+
   it("renders empty state", async () => {
     const client = createClient({
       task: {
@@ -440,6 +461,8 @@ describe("TasksScreen", () => {
     );
 
     await waitForFrameText(lastFrame, "No active, in-progress, or waiting");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Tasks (0)");
   });
 
   it("renders user-facing errors", async () => {
@@ -463,6 +486,8 @@ describe("TasksScreen", () => {
     );
 
     await waitForFrameText(lastFrame, "Tasks unavailable");
+    expect(lastFrame()).toContain("┌");
+    expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("Daemon unavailable. Start it with: todu daemon start.");
   });
 });

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { Pane } from "../components/Pane.js";
 import { TextInputModal } from "../components/TextInputModal.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
@@ -343,17 +344,8 @@ export function TasksScreen({
   const error = tasksQuery.error ?? projectsQuery.error;
   if (error) {
     return (
-      <Box flexDirection="column">
-        <Text color="red">Tasks unavailable</Text>
-        <Text color="gray">{formatToduClientError(error)}</Text>
-      </Box>
-    );
-  }
-
-  if (tasksQuery.isLoading) {
-    return (
-      <Box flexDirection="column">
-        <Box flexDirection="row">
+      <Box flexDirection="column" flexGrow={1}>
+        <Box flexDirection="row" flexGrow={1}>
           <ProjectListPane
             projects={projectOptions}
             selectedProjectOptionId={selectedProjectOptionId}
@@ -362,10 +354,41 @@ export function TasksScreen({
             maxVisibleProjects={maxVisibleListItems}
             maxProjectLabelLength={maxProjectLabelLength}
           />
-          <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH} paddingRight={1}>
-            <Text color={focusedPane === "tasks" ? "cyan" : "gray"}>Tasks • loading…</Text>
+          <Pane
+            title="Tasks unavailable"
+            width={TASK_MAIN_PANE_WIDTH}
+            focused={focusedPane === "tasks"}
+          >
+            <Text color="red">Tasks unavailable</Text>
+            <Text color="gray" wrap="truncate-end">
+              {formatToduClientError(error)}
+            </Text>
+          </Pane>
+        </Box>
+        <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
+      </Box>
+    );
+  }
+
+  if (tasksQuery.isLoading) {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <Box flexDirection="row" flexGrow={1}>
+          <ProjectListPane
+            projects={projectOptions}
+            selectedProjectOptionId={selectedProjectOptionId}
+            focused={focusedPane === "projects"}
+            isLoading={projectsQuery.isLoading}
+            maxVisibleProjects={maxVisibleListItems}
+            maxProjectLabelLength={maxProjectLabelLength}
+          />
+          <Pane
+            title="Tasks • loading…"
+            width={TASK_MAIN_PANE_WIDTH}
+            focused={focusedPane === "tasks"}
+          >
             <Text color="gray">Loading active, in-progress, and waiting tasks…</Text>
-          </Box>
+          </Pane>
         </Box>
         <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
       </Box>
@@ -374,8 +397,8 @@ export function TasksScreen({
 
   if (tasks.length === 0) {
     return (
-      <Box flexDirection="column">
-        <Box flexDirection="row">
+      <Box flexDirection="column" flexGrow={1}>
+        <Box flexDirection="row" flexGrow={1}>
           <ProjectListPane
             projects={projectOptions}
             selectedProjectOptionId={selectedProjectOptionId}
@@ -384,13 +407,12 @@ export function TasksScreen({
             maxVisibleProjects={maxVisibleListItems}
             maxProjectLabelLength={maxProjectLabelLength}
           />
-          <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH} paddingRight={1}>
-            <Text color={focusedPane === "tasks" ? "cyan" : "gray"}>Tasks (0)</Text>
+          <Pane title="Tasks (0)" width={TASK_MAIN_PANE_WIDTH} focused={focusedPane === "tasks"}>
             <Text color="gray">
               No active, in-progress, or waiting tasks for{" "}
               {describeProjectFilter(selectedProjectFilter)}.
             </Text>
-          </Box>
+          </Pane>
         </Box>
         <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
       </Box>
@@ -398,8 +420,8 @@ export function TasksScreen({
   }
 
   return (
-    <Box flexDirection="column">
-      <Box flexDirection="row">
+    <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="row" flexGrow={1}>
         <ProjectListPane
           projects={projectOptions}
           selectedProjectOptionId={selectedProjectOptionId}
@@ -469,8 +491,11 @@ function ProjectListPane({
   );
 
   return (
-    <Box flexDirection="column" width={PROJECT_PANE_WIDTH} paddingRight={1} flexShrink={0}>
-      <Text color={focused ? "cyan" : "gray"}>Projects{isLoading ? " • loading…" : ""}</Text>
+    <Pane
+      title={`Projects${isLoading ? " • loading…" : ""}`}
+      width={PROJECT_PANE_WIDTH}
+      focused={focused}
+    >
       {visibleProjects.map((option) => {
         const selected = option.id === selectedProjectOptionId;
         return (
@@ -484,7 +509,7 @@ function ProjectListPane({
           </Text>
         );
       })}
-    </Box>
+    </Pane>
   );
 }
 
@@ -506,8 +531,8 @@ function resolveMaxVisibleListItems(rows: number | undefined): number {
   const terminalRows = rows && rows > 0 ? rows : 24;
 
   // AppFrame reserves rows for padding, title, status, body margins, and footer.
-  // Each pane also uses one row for its title.
-  return Math.max(MIN_VISIBLE_LIST_ITEMS, terminalRows - 8);
+  // Bordered panes reserve rows for borders and title.
+  return Math.max(MIN_VISIBLE_LIST_ITEMS, terminalRows - 10);
 }
 
 function truncateProjectLabel(label: string, maxLength = 24): string {


### PR DESCRIPTION
## Summary

- Adds a shared bordered `Pane` component for full-height TUI panes.
- Updates Tasks screen loading, empty, error, project, task list, and inline detail states to render inside separated panes.
- Updates Projects screen from a raw 50/50 split to intentional list/detail panes with loading, empty, and error states inside the layout.
- Adds pane rendering coverage for Tasks and Projects screens.

## Verification

- `npm test -- packages/tui/src/screens/ProjectsScreen.test.tsx packages/tui/src/screens/TasksScreen.test.tsx packages/tui/src/app/App.test.tsx`
- `npm run --workspace=@todu/tui typecheck`
- `npm run --workspace=@todu/tui build`
- `make pre-pr`

Task: #task-9f2ec62b
