### PR TITLE
Make TUI lists viewport aware

### DIFF
--- a/.changeset/tui-viewport-aware-lists.md
+++ b/.changeset/tui-viewport-aware-lists.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add viewport-aware task and project list windows with scroll indicators.

--- a/packages/tui/src/components/tasks/TaskListPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { TaskListPane } from "./TaskListPane.js";
+
+function createTask(index: number) {
+  return {
+    id: `task-${index}`,
+    title: `Task ${index}`,
+    status: "active",
+    priority: "medium",
+    projectId: "project-1",
+    labels: [],
+    assigneeActorIds: [],
+    assignees: [],
+    createdAt: "2026-07-10T00:00:00.000Z",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+describe("TaskListPane", () => {
+  it("shows above and below indicators around a long selected task window", () => {
+    const tasks = Array.from({ length: 8 }, (_, index) => createTask(index + 1));
+    const { lastFrame } = render(
+      <TaskListPane tasks={tasks} selectedTaskId="task-5" maxVisibleTasks={3} width="60" />,
+    );
+
+    expect(lastFrame()).toContain("↑ 3 more");
+    expect(lastFrame()).toContain("> [med] [active] Task 5");
+    expect(lastFrame()).toContain("↓ 2 more");
+    expect(lastFrame()).not.toContain("Task 1");
+    expect(lastFrame()).not.toContain("Task 8");
+  });
+});

--- a/packages/tui/src/components/tasks/TaskListPane.tsx
+++ b/packages/tui/src/components/tasks/TaskListPane.tsx
@@ -2,6 +2,11 @@ import type { Project, Task } from "@todu/core";
 import { Text } from "ink";
 import type { JSX } from "react";
 import { createProjectNameMap, formatTaskRow } from "../../formatting/task.js";
+import {
+  formatListWindowIndicator,
+  getVisibleListWindow,
+  type ListWindow,
+} from "../../state/list-window.js";
 import { Pane } from "../Pane.js";
 
 const DEFAULT_MAX_VISIBLE_TASKS = 12;
@@ -24,11 +29,14 @@ export function TaskListPane({
   maxVisibleTasks = DEFAULT_MAX_VISIBLE_TASKS,
 }: TaskListPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
-  const visibleTasks = getVisibleTaskWindow(tasks, selectedTaskId, maxVisibleTasks);
+  const taskWindow = getVisibleListWindow(tasks, selectedTaskId, maxVisibleTasks);
+  const aboveIndicator = formatListWindowIndicator(taskWindow, "above");
+  const belowIndicator = formatListWindowIndicator(taskWindow, "below");
 
   return (
     <Pane title={`Tasks (${tasks.length})`} width={width} focused={focused}>
-      {visibleTasks.map((task) => {
+      {aboveIndicator ? <Text color="gray">{aboveIndicator}</Text> : null}
+      {taskWindow.items.map((task) => {
         const selected = task.id === selectedTaskId;
         const prefix = selected ? ">" : " ";
         return (
@@ -42,6 +50,7 @@ export function TaskListPane({
           </Text>
         );
       })}
+      {belowIndicator ? <Text color="gray">{belowIndicator}</Text> : null}
     </Pane>
   );
 }
@@ -50,19 +59,6 @@ export function getVisibleTaskWindow<T extends { id: string }>(
   tasks: readonly T[],
   selectedTaskId: string | null,
   maxVisible: number,
-): readonly T[] {
-  if (tasks.length <= maxVisible) {
-    return tasks;
-  }
-
-  const selectedIndex = selectedTaskId
-    ? Math.max(
-        0,
-        tasks.findIndex((task) => task.id === selectedTaskId),
-      )
-    : 0;
-  const halfWindow = Math.floor(maxVisible / 2);
-  const start = Math.min(Math.max(0, selectedIndex - halfWindow), tasks.length - maxVisible);
-
-  return tasks.slice(start, start + maxVisible);
+): ListWindow<T> {
+  return getVisibleListWindow(tasks, selectedTaskId, maxVisible);
 }

--- a/packages/tui/src/screens/ProjectsScreen.test.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.test.tsx
@@ -117,6 +117,32 @@ describe("ProjectsScreen", () => {
     expect(onSelectProject).toHaveBeenCalledWith(expect.objectContaining({ id: "project-1" }));
   });
 
+  it("windows long project lists and keeps the selected project visible", async () => {
+    const projects = Array.from({ length: 15 }, (_, index) =>
+      createProject({ id: `project-${index + 1}`, name: `Project ${index + 1}` }),
+    );
+    const client = createClient({
+      project: { list: vi.fn().mockResolvedValue(projects), get: vi.fn() },
+    });
+    const { stdin, lastFrame } = renderWithQuery(
+      <ProjectsScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        onSelectProject={vi.fn()}
+        onSelectAllProjects={vi.fn()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "↓ 4 more");
+    for (let index = 0; index < 8; index += 1) {
+      stdin.write("j");
+    }
+
+    await waitForFrameText(lastFrame, "> Project 8");
+    expect(lastFrame()).toContain("↑ 2 more");
+    expect(lastFrame()).toContain("↓ 2 more");
+  });
+
   it("clears to all projects with a", async () => {
     const onSelectAllProjects = vi.fn();
     const { stdin, lastFrame } = renderWithQuery(

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Pane } from "../components/Pane.js";
 import { getVisibleTaskWindow } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { formatListWindowIndicator, type ListWindow } from "../state/list-window.js";
 import type { ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
 
@@ -14,7 +15,7 @@ const PROJECT_LIST_PANE_WIDTH_PERCENT = 0.4;
 const PROJECT_LIST_PANE_WIDTH = "40%";
 const PROJECT_DETAIL_PANE_WIDTH = "60%";
 const MIN_PROJECT_LABEL_LENGTH = 8;
-const MIN_VISIBLE_PROJECTS = 6;
+const MIN_VISIBLE_PROJECTS = 1;
 
 interface ProjectOption {
   id: string;
@@ -54,7 +55,7 @@ export function ProjectsScreen({
     projectOptions.find((option) => option.id === selectedOptionId) ?? projectOptions[0];
   const maxVisibleProjects = resolveMaxVisibleProjects(stdout.rows);
   const maxProjectLabelLength = resolveProjectLabelLength(stdout.columns);
-  const visibleProjects = getVisibleTaskWindow(
+  const projectWindow = getVisibleTaskWindow(
     projectOptions,
     selectedOption?.id ?? selectedOptionId,
     maxVisibleProjects,
@@ -103,7 +104,7 @@ export function ProjectsScreen({
         <ProjectListContent
           error={projectsQuery.error}
           isLoading={projectsQuery.isLoading}
-          projects={visibleProjects}
+          projectWindow={projectWindow}
           selectedOptionId={selectedOption?.id ?? selectedOptionId}
           maxProjectLabelLength={maxProjectLabelLength}
         />
@@ -124,13 +125,13 @@ export function ProjectsScreen({
 function ProjectListContent({
   error,
   isLoading,
-  projects,
+  projectWindow,
   selectedOptionId,
   maxProjectLabelLength,
 }: {
   error: unknown;
   isLoading: boolean;
-  projects: readonly ProjectOption[];
+  projectWindow: ListWindow<ProjectOption>;
   selectedOptionId: string;
   maxProjectLabelLength: number;
 }): JSX.Element {
@@ -149,7 +150,7 @@ function ProjectListContent({
     return <Text color="gray">Loading projects…</Text>;
   }
 
-  if (projects.length === 1 && projects[0]?.id === ALL_PROJECTS_OPTION_ID) {
+  if (projectWindow.total === 1 && projectWindow.items[0]?.id === ALL_PROJECTS_OPTION_ID) {
     return (
       <Box flexDirection="column">
         <Text color="gray">No projects available.</Text>
@@ -158,9 +159,13 @@ function ProjectListContent({
     );
   }
 
+  const aboveIndicator = formatListWindowIndicator(projectWindow, "above");
+  const belowIndicator = formatListWindowIndicator(projectWindow, "below");
+
   return (
     <Box flexDirection="column">
-      {projects.map((option) => {
+      {aboveIndicator ? <Text color="gray">{aboveIndicator}</Text> : null}
+      {projectWindow.items.map((option) => {
         const selected = option.id === selectedOptionId;
         return (
           <Text
@@ -173,6 +178,7 @@ function ProjectListContent({
           </Text>
         );
       })}
+      {belowIndicator ? <Text color="gray">{belowIndicator}</Text> : null}
     </Box>
   );
 }
@@ -252,8 +258,8 @@ function resolveMaxVisibleProjects(rows: number | undefined): number {
   const terminalRows = rows && rows > 0 ? rows : 24;
 
   // AppFrame reserves rows for padding, title, status, body margins, and footer.
-  // The pane reserves rows for borders and title.
-  return Math.max(MIN_VISIBLE_PROJECTS, terminalRows - 10);
+  // Bordered panes and potential above/below indicators reserve four more rows.
+  return Math.max(MIN_VISIBLE_PROJECTS, terminalRows - 12);
 }
 
 function truncateProjectLabel(label: string, maxLength = 24): string {

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -11,6 +11,7 @@ import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { getVisibleTaskWindow, TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { normalizeCommentContent } from "../state/comment-actions.js";
+import { formatListWindowIndicator } from "../state/list-window.js";
 import {
   allProjectsFilter,
   describeProjectFilter,
@@ -34,7 +35,7 @@ const PROJECT_PANE_WIDTH_PERCENT = 0.36;
 const PROJECT_PANE_WIDTH = "36%";
 const TASK_MAIN_PANE_WIDTH = "64%";
 const MIN_PROJECT_LABEL_LENGTH = 8;
-const MIN_VISIBLE_LIST_ITEMS = 6;
+const MIN_VISIBLE_LIST_ITEMS = 1;
 
 type PaneFocus = "projects" | "tasks";
 
@@ -484,11 +485,9 @@ function ProjectListPane({
   maxVisibleProjects,
   maxProjectLabelLength,
 }: ProjectListPaneProps): JSX.Element {
-  const visibleProjects = getVisibleTaskWindow(
-    projects,
-    selectedProjectOptionId,
-    maxVisibleProjects,
-  );
+  const projectWindow = getVisibleTaskWindow(projects, selectedProjectOptionId, maxVisibleProjects);
+  const aboveIndicator = formatListWindowIndicator(projectWindow, "above");
+  const belowIndicator = formatListWindowIndicator(projectWindow, "below");
 
   return (
     <Pane
@@ -496,7 +495,8 @@ function ProjectListPane({
       width={PROJECT_PANE_WIDTH}
       focused={focused}
     >
-      {visibleProjects.map((option) => {
+      {aboveIndicator ? <Text color="gray">{aboveIndicator}</Text> : null}
+      {projectWindow.items.map((option) => {
         const selected = option.id === selectedProjectOptionId;
         return (
           <Text
@@ -509,6 +509,7 @@ function ProjectListPane({
           </Text>
         );
       })}
+      {belowIndicator ? <Text color="gray">{belowIndicator}</Text> : null}
     </Pane>
   );
 }
@@ -531,8 +532,8 @@ function resolveMaxVisibleListItems(rows: number | undefined): number {
   const terminalRows = rows && rows > 0 ? rows : 24;
 
   // AppFrame reserves rows for padding, title, status, body margins, and footer.
-  // Bordered panes reserve rows for borders and title.
-  return Math.max(MIN_VISIBLE_LIST_ITEMS, terminalRows - 10);
+  // Bordered panes and potential above/below indicators reserve four more rows.
+  return Math.max(MIN_VISIBLE_LIST_ITEMS, terminalRows - 12);
 }
 
 function truncateProjectLabel(label: string, maxLength = 24): string {

--- a/packages/tui/src/state/list-window.test.ts
+++ b/packages/tui/src/state/list-window.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatListWindowIndicator, getVisibleListWindow } from "./list-window.js";
+
+const items = Array.from({ length: 10 }, (_, index) => ({ id: `item-${index + 1}` }));
+
+describe("getVisibleListWindow", () => {
+  it("returns every item without indicators when the list fits", () => {
+    const window = getVisibleListWindow(items.slice(0, 3), "item-2", 4);
+
+    expect(window.items).toEqual(items.slice(0, 3));
+    expect(window.start).toBe(0);
+    expect(window.end).toBe(3);
+    expect(window.hasAbove).toBe(false);
+    expect(window.hasBelow).toBe(false);
+  });
+
+  it("keeps the selected item visible in a long list and reports rows above and below", () => {
+    const window = getVisibleListWindow(items, "item-6", 4);
+
+    expect(window.items.map((item) => item.id)).toEqual(["item-4", "item-5", "item-6", "item-7"]);
+    expect(window.start).toBe(3);
+    expect(window.end).toBe(7);
+    expect(window.hasAbove).toBe(true);
+    expect(window.hasBelow).toBe(true);
+    expect(formatListWindowIndicator(window, "above")).toBe("↑ 3 more");
+    expect(formatListWindowIndicator(window, "below")).toBe("↓ 3 more");
+  });
+
+  it("handles very short panes by showing one selected row", () => {
+    const window = getVisibleListWindow(items, "item-10", 0);
+
+    expect(window.items.map((item) => item.id)).toEqual(["item-10"]);
+    expect(window.start).toBe(9);
+    expect(window.end).toBe(10);
+    expect(formatListWindowIndicator(window, "above")).toBe("↑ 9 more");
+    expect(formatListWindowIndicator(window, "below")).toBeNull();
+  });
+});

--- a/packages/tui/src/state/list-window.ts
+++ b/packages/tui/src/state/list-window.ts
@@ -1,0 +1,58 @@
+export interface ListWindow<T> {
+  items: readonly T[];
+  start: number;
+  end: number;
+  total: number;
+  hasAbove: boolean;
+  hasBelow: boolean;
+}
+
+export function getVisibleListWindow<T extends { id: string }>(
+  items: readonly T[],
+  selectedId: string | null,
+  maxVisible: number,
+): ListWindow<T> {
+  const boundedMaxVisible = Math.max(1, maxVisible);
+  if (items.length <= boundedMaxVisible) {
+    return {
+      items,
+      start: 0,
+      end: items.length,
+      total: items.length,
+      hasAbove: false,
+      hasBelow: false,
+    };
+  }
+
+  const selectedIndex = selectedId
+    ? Math.max(
+        0,
+        items.findIndex((item) => item.id === selectedId),
+      )
+    : 0;
+  const halfWindow = Math.floor(boundedMaxVisible / 2);
+  const start = Math.min(Math.max(0, selectedIndex - halfWindow), items.length - boundedMaxVisible);
+  const end = start + boundedMaxVisible;
+
+  return {
+    items: items.slice(start, end),
+    start,
+    end,
+    total: items.length,
+    hasAbove: start > 0,
+    hasBelow: end < items.length,
+  };
+}
+
+export function formatListWindowIndicator(
+  window: ListWindow<unknown>,
+  direction: "above" | "below",
+): string | null {
+  const count = direction === "above" ? window.start : window.total - window.end;
+
+  if (count <= 0) {
+    return null;
+  }
+
+  return `${direction === "above" ? "↑" : "↓"} ${count} more`;
+}


### PR DESCRIPTION
## Summary

- Adds shared list-window metadata for selected-item viewporting.
- Adds above/below row indicators to task and project lists.
- Reserves indicator rows and permits one-row windows for very short terminals.
- Adds coverage for long lists, selection visibility, short panes, and indicators.

## Verification

- `npm test -- packages/tui/src/state/list-window.test.ts packages/tui/src/components/tasks/TaskListPane.test.tsx packages/tui/src/screens/TasksScreen.test.tsx packages/tui/src/screens/ProjectsScreen.test.tsx`
- `npm run --workspace=@todu/tui typecheck`
- `make pre-pr`

Task: #task-ae0383b0
