### PR TITLE
Improve TUI task detail hierarchy

### DIFF
--- a/.changeset/tui-detail-hierarchy.md
+++ b/.changeset/tui-detail-hierarchy.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Improve task detail hierarchy with bounded descriptions and comments.

--- a/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
@@ -1,0 +1,97 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { createTaskDetailLines, TaskDetailPane } from "./TaskDetailPane.js";
+
+function createTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "task-1",
+    title: "Implement a clear task detail hierarchy",
+    status: "inprogress",
+    priority: "medium",
+    projectId: "project-1",
+    labels: ["tui", "layout"],
+    assigneeActorIds: [],
+    assignees: [],
+    createdAt: "2026-07-10T00:00:00.000Z",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+    description:
+      "Describe the task with enough detail for a user to understand the intended behavior.",
+    ...overrides,
+  };
+}
+
+function createComment(index: number) {
+  return {
+    id: `note-${index}`,
+    content: `Comment ${index} provides additional implementation context.`,
+    author: "Erik",
+    entityType: "task",
+    entityId: "task-1",
+    tags: [],
+    createdAt: "2026-07-10T00:00:00.000Z",
+  };
+}
+
+describe("TaskDetailPane", () => {
+  it("renders title, description, metadata, and comments in reading order", () => {
+    const { lastFrame } = render(
+      <TaskDetailPane
+        task={createTask()}
+        projects={[{ id: "project-1", name: "todu" }]}
+        comments={[createComment(1)]}
+        isLoadingDetail={false}
+        error={null}
+        maxContentWidth={60}
+        maxContentRows={12}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Implement a clear task detail hierarchy");
+    expect(frame).toContain("Description");
+    expect(frame).toContain("Metadata");
+    expect(frame).toContain("doing • med • todu • #tui #layout");
+    expect(frame).toContain("Comments");
+    expect(frame).toContain("Erik: Comment 1 provides additional");
+    expect(frame).toContain("implementation context.");
+    expect(frame.indexOf("Description")).toBeLessThan(frame.indexOf("Metadata"));
+    expect(frame.indexOf("Metadata")).toBeLessThan(frame.indexOf("Comments"));
+  });
+
+  it("scrolls long description and comment content instead of clipping it", async () => {
+    const { stdin, lastFrame } = render(
+      <TaskDetailPane
+        task={createTask({ description: "long description ".repeat(20) })}
+        projects={[{ id: "project-1", name: "todu" }]}
+        comments={Array.from({ length: 5 }, (_, index) => createComment(index + 1))}
+        isLoadingDetail={false}
+        error={null}
+        maxContentWidth={20}
+        maxContentRows={8}
+        scrollEnabled
+      />,
+    );
+
+    expect(lastFrame()).toContain("↓");
+    stdin.write("j");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(lastFrame()).toContain("↑ 1 lines");
+  });
+
+  it("wraps all detail text within narrow content widths", () => {
+    const description = "A description that should stay readable without horizontal clipping.";
+    const lines = createTaskDetailLines({
+      task: createTask({ description }),
+      projectName: "A project name that does not fit",
+      comments: [createComment(1)],
+      maxContentWidth: 12,
+    });
+    const descriptionText = lines
+      .filter((line) => /^description-\d+$/.test(line.id))
+      .map((line) => line.text)
+      .join(" ");
+
+    expect(lines.every((line) => line.text.length <= 12)).toBe(true);
+    expect(descriptionText).toBe(description);
+  });
+});

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -1,8 +1,9 @@
 import type { Note, Project, Task, TaskWithDetail } from "@todu/core";
-import { Box, Text } from "ink";
+import { Text, useInput } from "ink";
 import type { JSX } from "react";
+import { useEffect, useState } from "react";
 import { formatToduClientError } from "../../daemon/todu-client.js";
-import { createProjectNameMap, formatTaskDetailLines } from "../../formatting/task.js";
+import { createProjectNameMap, formatTaskMetadata } from "../../formatting/task.js";
 import { Pane } from "../Pane.js";
 
 export interface TaskDetailPaneProps {
@@ -14,6 +15,16 @@ export interface TaskDetailPaneProps {
   isLoadingComments?: boolean;
   error: unknown;
   width?: string;
+  maxContentWidth?: number;
+  maxContentRows?: number;
+  scrollEnabled?: boolean;
+}
+
+export interface TaskDetailLine {
+  id: string;
+  text: string;
+  color: "cyan" | "gray" | "white";
+  bold?: boolean;
 }
 
 export function TaskDetailPane({
@@ -25,41 +36,139 @@ export function TaskDetailPane({
   isLoadingComments = false,
   error,
   width = "50%",
+  maxContentWidth = 60,
+  maxContentRows = 12,
+  scrollEnabled = false,
 }: TaskDetailPaneProps): JSX.Element {
   const projectNames = createProjectNameMap(projects);
   const detailTask = detail ?? task;
-
   const loadingLabel = formatDetailLoadingLabel({ isLoadingDetail, isLoadingComments });
+  const detailLines = detailTask
+    ? createTaskDetailLines({
+        task: detailTask,
+        projectName: projectNames.get(detailTask.projectId) ?? null,
+        comments,
+        maxContentWidth,
+      })
+    : [];
+  const errorLine: TaskDetailLine | null = error
+    ? {
+        id: "error",
+        text: formatToduClientError(error),
+        color: "gray",
+      }
+    : null;
+  const allLines = errorLine ? [...detailLines, errorLine] : detailLines;
+  const visibleContentRows = Math.max(1, maxContentRows - 2);
+  const maxScrollOffset = Math.max(0, allLines.length - visibleContentRows);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  useEffect(() => {
+    setScrollOffset((current) => Math.min(current, maxScrollOffset));
+  }, [maxScrollOffset]);
+
+  useInput(
+    (input, key) => {
+      if (input === "j" || key.downArrow) {
+        setScrollOffset((current) => Math.min(maxScrollOffset, current + 1));
+        return;
+      }
+
+      if (input === "k" || key.upArrow) {
+        setScrollOffset((current) => Math.max(0, current - 1));
+      }
+    },
+    { isActive: scrollEnabled },
+  );
+
+  const visibleLines = allLines.slice(scrollOffset, scrollOffset + visibleContentRows);
+  const hiddenBelow = Math.max(0, allLines.length - (scrollOffset + visibleContentRows));
 
   return (
-    <Pane title={`Detail${loadingLabel ? ` • ${loadingLabel}` : ""}`} width={width}>
+    <Pane title={`Task detail${loadingLabel ? ` • ${loadingLabel}` : ""}`} width={width} focused>
       {!detailTask ? <Text color="gray">No task selected.</Text> : null}
-      {detailTask
-        ? formatTaskDetailLines(detailTask, projectNames.get(detailTask.projectId) ?? null).map(
-            (line, index) => (
-              <Text
-                key={`${detailTask.id}-${index}`}
-                color={index === 0 ? "white" : "gray"}
-                wrap="truncate-end"
-              >
-                {line}
-              </Text>
-            ),
-          )
-        : null}
-      {comments.length > 0 ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="cyan">Comments</Text>
-          {comments.slice(0, 5).map((comment) => (
-            <Text key={comment.id} color="gray" wrap="truncate-end">
-              {comment.content}
-            </Text>
-          ))}
-        </Box>
-      ) : null}
-      {error ? <Text color="red">{formatToduClientError(error)}</Text> : null}
+      {scrollOffset > 0 ? <Text color="gray">↑ {scrollOffset} lines</Text> : null}
+      {visibleLines.map((line) => (
+        <Text key={line.id} color={line.color} bold={line.bold} wrap="wrap">
+          {line.text}
+        </Text>
+      ))}
+      {hiddenBelow > 0 ? <Text color="gray">↓ {hiddenBelow} lines</Text> : null}
     </Pane>
   );
+}
+
+export function createTaskDetailLines({
+  task,
+  projectName,
+  comments,
+  maxContentWidth,
+}: {
+  task: TaskWithDetail | Task;
+  projectName: string | null;
+  comments: readonly Note[];
+  maxContentWidth: number;
+}): readonly TaskDetailLine[] {
+  const contentWidth = Math.max(1, maxContentWidth);
+  const description = "description" in task ? (task.description?.trim() ?? "") : "";
+  const lines: TaskDetailLine[] = [
+    ...createWrappedLines("title", task.title, contentWidth, "white", true),
+    { id: "description-heading", text: "Description", color: "cyan" },
+    ...createWrappedLines(
+      "description",
+      description || "No description.",
+      contentWidth,
+      description ? "white" : "gray",
+    ),
+    { id: "metadata-heading", text: "Metadata", color: "cyan" },
+    ...createWrappedLines("metadata", formatTaskMetadata(task, projectName), contentWidth, "gray"),
+    { id: "comments-heading", text: "Comments", color: "cyan" },
+  ];
+
+  if (comments.length === 0) {
+    lines.push({ id: "comments-empty", text: "No comments.", color: "gray" });
+    return lines;
+  }
+
+  for (const comment of comments) {
+    const label = comment.author ? `${comment.author}: ${comment.content}` : comment.content;
+    lines.push(...createWrappedLines(`comment-${comment.id}`, label, contentWidth, "white"));
+  }
+
+  return lines;
+}
+
+function createWrappedLines(
+  id: string,
+  value: string,
+  maxWidth: number,
+  color: TaskDetailLine["color"],
+  bold = false,
+): readonly TaskDetailLine[] {
+  return wrapText(value.replace(/\s+/g, " ").trim(), maxWidth).map((text, index) => ({
+    id: `${id}-${index}`,
+    text,
+    color,
+    bold,
+  }));
+}
+
+function wrapText(value: string, maxWidth: number): readonly string[] {
+  if (value.length <= maxWidth) {
+    return [value];
+  }
+
+  const lines: string[] = [];
+  let remaining = value;
+  while (remaining.length > maxWidth) {
+    const splitAt = remaining.lastIndexOf(" ", maxWidth);
+    const lineEnd = splitAt > 0 ? splitAt : maxWidth;
+    lines.push(remaining.slice(0, lineEnd));
+    remaining = remaining.slice(lineEnd).trimStart();
+  }
+  lines.push(remaining);
+
+  return lines;
 }
 
 function formatDetailLoadingLabel({

--- a/packages/tui/src/formatting/task.test.ts
+++ b/packages/tui/src/formatting/task.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatTaskDetailLines, formatTaskRow } from "./task.js";
+import { formatTaskMetadata, formatTaskRow } from "./task.js";
 
 const task = {
   id: "task-1",
@@ -21,16 +21,7 @@ describe("task formatting", () => {
     );
   });
 
-  it("formats selected task details", () => {
-    expect(formatTaskDetailLines({ ...task, description: "Read-only browsing." }, "todu")).toEqual([
-      "Ship the TUI task read model",
-      "Status: doing",
-      "Priority: med",
-      "Project: todu",
-      "Labels: #tui #spec",
-      "",
-      "Description",
-      "Read-only browsing.",
-    ]);
+  it("formats compact task metadata", () => {
+    expect(formatTaskMetadata(task, "todu")).toBe("doing • med • todu • #tui #spec");
   });
 });

--- a/packages/tui/src/formatting/task.ts
+++ b/packages/tui/src/formatting/task.ts
@@ -21,26 +21,21 @@ export function formatTaskRow(task: Task, projectName: string | null, maxTitleLe
   return parts.join(" ");
 }
 
-export function formatTaskDetailLines(
+export function formatTaskMetadata(
   task: TaskWithDetail | Task,
   projectName: string | null,
-): string[] {
-  const lines = [
-    task.title,
-    `Status: ${formatTaskStatus(task.status)}`,
-    `Priority: ${formatTaskPriority(task.priority)}`,
-    `Project: ${projectName ?? task.projectId}`,
+): string {
+  const metadata = [
+    formatTaskStatus(task.status),
+    formatTaskPriority(task.priority),
+    projectName ?? task.projectId,
   ];
 
   if (task.labels.length > 0) {
-    lines.push(`Labels: ${task.labels.map((label) => `#${label}`).join(" ")}`);
+    metadata.push(task.labels.map((label) => `#${label}`).join(" "));
   }
 
-  if ("description" in task && task.description?.trim()) {
-    lines.push("", "Description", task.description.trim());
-  }
-
-  return lines;
+  return metadata.join(" • ");
 }
 
 export function createProjectNameMap(

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -128,8 +128,8 @@ describe("TasksScreen", () => {
     stdin.write("\r");
     await waitForFrameText(lastFrame, "Existing comment");
 
-    expect(lastFrame()).toContain("Detail");
-    expect(lastFrame()).toContain("Status: active");
+    expect(lastFrame()).toContain("Task detail");
+    expect(lastFrame()).toContain("active • high • todu • #tui");
     expect(lastFrame()).toContain("Existing comment");
     expect(lastFrame()).not.toContain("Second task");
 

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -32,6 +32,7 @@ export interface TasksScreenProps {
 const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
 const ALL_PROJECTS_OPTION_ID = "__all__";
 const PROJECT_PANE_WIDTH_PERCENT = 0.36;
+const TASK_MAIN_PANE_WIDTH_PERCENT = 0.64;
 const PROJECT_PANE_WIDTH = "36%";
 const TASK_MAIN_PANE_WIDTH = "64%";
 const MIN_PROJECT_LABEL_LENGTH = 8;
@@ -342,6 +343,8 @@ export function TasksScreen({
 
   const maxVisibleListItems = resolveMaxVisibleListItems(stdout.rows);
   const maxProjectLabelLength = resolveProjectLabelLength(stdout.columns);
+  const detailContentWidth = resolveDetailContentWidth(stdout.columns);
+  const detailContentRows = resolveDetailContentRows(stdout.rows);
   const error = tasksQuery.error ?? projectsQuery.error;
   if (error) {
     return (
@@ -450,6 +453,9 @@ export function TasksScreen({
               comments={commentsQuery.data}
               isLoadingComments={commentsQuery.isLoading}
               error={selectedDetailQuery.error ?? commentsQuery.error}
+              maxContentWidth={detailContentWidth}
+              maxContentRows={detailContentRows}
+              scrollEnabled={!commentModalOpen && !confirmCancel}
             />
           ) : null}
         </Box>
@@ -512,6 +518,23 @@ function ProjectListPane({
       {belowIndicator ? <Text color="gray">{belowIndicator}</Text> : null}
     </Pane>
   );
+}
+
+function resolveDetailContentWidth(columns: number | undefined): number {
+  const terminalColumns = columns && columns > 0 ? columns : 80;
+  const appHorizontalPadding = 2;
+  const paneBorderAndPadding = 4;
+  const availableBodyColumns = Math.max(0, terminalColumns - appHorizontalPadding);
+  const taskPaneColumns = Math.floor(availableBodyColumns * TASK_MAIN_PANE_WIDTH_PERCENT);
+
+  return Math.max(8, taskPaneColumns - paneBorderAndPadding);
+}
+
+function resolveDetailContentRows(rows: number | undefined): number {
+  const terminalRows = rows && rows > 0 ? rows : 24;
+
+  // Reserve AppFrame rows, the selected-task pane, and detail pane chrome.
+  return Math.max(6, terminalRows - 15);
 }
 
 function resolveProjectLabelLength(columns: number | undefined): number {


### PR DESCRIPTION
## Summary

- Replaces flat task detail lines with title, compact metadata, description, and comments sections.
- Bounds description rows and comment rows from the inline detail pane’s terminal-size budget.
- Adds explicit truncation labels and remaining-comment indicators.
- Adds detail rendering coverage for long descriptions/comments and narrow widths.

## Verification

- `npm test -- packages/tui/src/components/tasks/TaskDetailPane.test.tsx packages/tui/src/formatting/task.test.ts packages/tui/src/screens/TasksScreen.test.tsx`
- `npm run --workspace=@todu/tui typecheck`
- `npm run --workspace=@todu/tui build`
- `make pre-pr`

Task: #task-54cafa58
