### PR TITLE
Show task filters in TUI header

### DIFF
--- a/.changeset/tui-header-filter-summary.md
+++ b/.changeset/tui-header-filter-summary.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Show current view and task-filter summary in the TUI header.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -159,14 +159,12 @@ describe("App", () => {
 
     const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
 
-    expect(lastFrame()).toContain("Todu • Tasks");
-    expect(lastFrame()).toContain("View: Tasks");
-    expect(lastFrame()).toContain("Daemon: unavailable");
+    expect(lastFrame()).toContain("Tasks");
+    expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("Daemon unavailable");
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Tasks");
     expect(lastFrame()).toContain("q Back/Quit");
-    expect(lastFrame()).toContain("Project: All projects");
   });
 
   it("shows connected daemon status without body handshake diagnostics", async () => {
@@ -179,7 +177,8 @@ describe("App", () => {
 
     await waitForFrameText(lastFrame, "Ship");
 
-    expect(lastFrame()).toContain("Daemon: connected (dev)");
+    expect(lastFrame()).toContain("Open · Any priority · All Projects");
+    expect(lastFrame()).not.toContain("Daemon: connected");
     expect(lastFrame()).not.toContain("Daemon connected");
     expect(lastFrame()).not.toContain("Handshake: daemon.hello OK");
     expect(lastFrame()).not.toContain("Daemon version:");
@@ -198,7 +197,8 @@ describe("App", () => {
 
     stdin.write("2");
     await waitForFrameText(lastFrame, "Project detail");
-    expect(lastFrame()).toContain("View: Projects");
+    expect(lastFrame()).toContain("Projects");
+    expect(lastFrame()).toContain("Open · Any priority · All Projects");
 
     stdin.write("3");
     await waitForFrameText(lastFrame, "Data status ready");
@@ -218,8 +218,28 @@ describe("App", () => {
     stdin.write("j");
     await waitForFrameText(lastFrame, "Default project");
     stdin.write("\r");
-    await waitForFrameText(lastFrame, "Project: Inbox");
+    await waitForFrameText(lastFrame, "Open · Any priority · Inbox");
 
+    await vi.waitFor(() => {
+      expect(client.task.list).toHaveBeenCalledWith({
+        status: ["active", "inprogress", "waiting"],
+        projectId: "project-1",
+      });
+    });
+  });
+
+  it("updates the header filter from permanent Tasks-pane project selection", async () => {
+    const client = createFakeClient();
+    const { stdin, lastFrame } = render(
+      <App connection={createFakeConnection(createConnectedSnapshot())} toduClient={client} />,
+    );
+
+    await waitForFrameText(lastFrame, "Ship");
+    stdin.write("h");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    stdin.write("j");
+
+    await waitForFrameText(lastFrame, "Open · Any priority · Inbox");
     await vi.waitFor(() => {
       expect(client.task.list).toHaveBeenCalledWith({
         status: ["active", "inprogress", "waiting"],
@@ -242,12 +262,12 @@ describe("App", () => {
     stdin.write("j");
     await waitForFrameText(lastFrame, "Default project");
     stdin.write("\r");
-    await waitForFrameText(lastFrame, "Project: Inbox");
+    await waitForFrameText(lastFrame, "Open · Any priority · Inbox");
 
     stdin.write("2");
     await waitForFrameText(lastFrame, "Project detail");
     stdin.write("a");
-    await waitForFrameText(lastFrame, "Project: All projects");
+    await waitForFrameText(lastFrame, "Open · Any priority · All Projects");
   });
 
   it("shows help with implemented keys", async () => {
@@ -317,19 +337,6 @@ describe("App", () => {
     });
   });
 
-  it("updates sync status line from sync.statusChanged without a full app refresh", async () => {
-    const connection = createFakeConnection(createConnectedSnapshot());
-    const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
-
-    await waitForFrameText(lastFrame, "Ship");
-    connection.emitEvent({
-      event: "sync.statusChanged",
-      payload: { local: { mode: "standalone" }, remote: { state: "connected" } },
-    });
-
-    await waitForFrameText(lastFrame, "Sync: connected");
-  });
-
   it("resubscribes and keeps task data visible across reconnect", async () => {
     const connection = createFakeConnection(createConnectedSnapshot());
     const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
@@ -341,7 +348,6 @@ describe("App", () => {
 
     connection.emitSnapshot({ ...createConnectedSnapshot(), state: "reconnecting", hello: null });
     await waitForFrameText(lastFrame, "Daemon disconnected; reconnecting");
-    expect(lastFrame()).toContain("Daemon: reconnecting");
     expect(lastFrame()).toContain("Ship");
 
     connection.emitSnapshot(createConnectedSnapshot());
@@ -367,16 +373,15 @@ describe("App", () => {
     const { lastFrame } = render(
       <AppFrame
         route="data-status"
-        connection={createConnectedSnapshot()}
-        projectFilter={allProjectsFilter}
+        taskFilter={{ projectFilter: allProjectsFilter }}
         terminalWidth={24}
       >
         <TextFixture />
       </AppFrame>,
     );
 
-    expect(lastFrame()).toContain("Todu");
-    expect(lastFrame()).toContain("View: Data Status");
+    expect(lastFrame()).toContain("Data Status");
+    expect(lastFrame()).toContain("Open");
     expect(lastFrame()).toContain("fixture");
   });
 });

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -1,6 +1,6 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useApp, useInput } from "ink";
-import { type JSX, useEffect, useMemo, useRef, useState } from "react";
+import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AppFrame } from "../components/AppFrame.js";
 import { ConnectionState } from "../components/ConnectionState.js";
 import {
@@ -25,7 +25,7 @@ import {
   type ProjectFilterState,
 } from "../state/project-filter.js";
 import { createTuiQueryClient, TuiQueryProvider } from "../state/query-client.js";
-import { queryKeys } from "../state/query-keys.js";
+import type { TuiTaskFilterState } from "../state/task-filter.js";
 import {
   applyNavigationAction,
   createInitialRouteState,
@@ -70,22 +70,21 @@ function AppContent({
   );
   const [routeState, setRouteState] = useState(createInitialRouteState);
   const [projectFilter, setProjectFilter] = useState<ProjectFilterState>(allProjectsFilter);
+  const taskFilter = useMemo<TuiTaskFilterState>(() => ({ projectFilter }), [projectFilter]);
   const [globalInputEnabled, setGlobalInputEnabled] = useState(true);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
   );
   const [hasConnected, setHasConnected] = useState(connectionSnapshot.state === "connected");
   const previousConnectionState = useRef(connectionSnapshot.state);
-  const syncStatus = useQuery({
-    queryKey: queryKeys.syncStatus(),
-    queryFn: () => toduClient.sync.status(),
-    enabled: connectionSnapshot.state === "connected",
-  });
-
   const requestExit = (): void => {
     onExit?.();
     exit();
   };
+
+  const updateProjectFilter = useCallback((nextFilter: ProjectFilterState): void => {
+    setProjectFilter(nextFilter);
+  }, []);
 
   useInput(
     (input, key) => {
@@ -157,12 +156,7 @@ function AppContent({
   }, [connection, connectionSnapshot.state, queryClient]);
 
   return (
-    <AppFrame
-      route={routeState.route}
-      connection={connectionSnapshot}
-      projectFilter={projectFilter}
-      syncStatus={syncStatus.data}
-    >
+    <AppFrame route={routeState.route} taskFilter={taskFilter}>
       <ConnectionState connection={connectionSnapshot} />
       <RouteScreen
         route={routeState.route}
@@ -171,13 +165,14 @@ function AppContent({
         toduClient={toduClient}
         projectFilter={projectFilter}
         onSelectProject={(project) => {
-          setProjectFilter(createProjectFilter(project));
+          updateProjectFilter(createProjectFilter(project));
           setRouteState({ route: "tasks", previousRoute: "tasks" });
         }}
         onSelectAllProjects={() => {
-          setProjectFilter(allProjectsFilter);
+          updateProjectFilter(allProjectsFilter);
           setRouteState({ route: "tasks", previousRoute: "tasks" });
         }}
+        onTaskProjectFilterChange={updateProjectFilter}
         onGlobalInputEnabledChange={setGlobalInputEnabled}
       />
     </AppFrame>
@@ -192,6 +187,7 @@ interface RouteScreenProps {
   projectFilter: ProjectFilterState;
   onSelectProject: (project: import("@todu/core").Project) => void;
   onSelectAllProjects: () => void;
+  onTaskProjectFilterChange: (filter: ProjectFilterState) => void;
   onGlobalInputEnabledChange: (enabled: boolean) => void;
 }
 
@@ -203,6 +199,7 @@ function RouteScreen({
   projectFilter,
   onSelectProject,
   onSelectAllProjects,
+  onTaskProjectFilterChange,
   onGlobalInputEnabledChange,
 }: RouteScreenProps): JSX.Element | null {
   const dataQueriesEnabled = connection.state === "connected";
@@ -235,6 +232,7 @@ function RouteScreen({
       statusActionsEnabled={dataQueriesEnabled}
       dataQueriesEnabled={dataQueriesEnabled}
       onGlobalInputEnabledChange={onGlobalInputEnabledChange}
+      onProjectFilterChange={onTaskProjectFilterChange}
     />
   ) : null;
 }

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -21,20 +21,7 @@ describe("AppFrame", () => {
     const { lastFrame } = render(
       <AppFrame
         route="tasks"
-        connection={{
-          state: "connected",
-          socketPath: "/tmp/todu.sock",
-          hello: {
-            protocolVersion: 1,
-            daemonVersion: "dev",
-            pid: 123,
-            capabilities: [],
-          },
-          error: null,
-          reconnectAttempt: 0,
-          reconnectDelayMs: null,
-        }}
-        projectFilter={allProjectsFilter}
+        taskFilter={{ projectFilter: allProjectsFilter }}
         terminalWidth={60}
         terminalHeight={12}
       >
@@ -42,8 +29,8 @@ describe("AppFrame", () => {
       </AppFrame>,
     );
 
-    expect(lastFrame()).toContain("Todu • Tasks");
-    expect(lastFrame()).toContain("View: Tasks");
+    expect(lastFrame()).toContain("Tasks");
+    expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("body content");
     expect(lastFrame()).toContain("1 Tasks");
   });

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -1,17 +1,13 @@
 import { Box, Text, useStdout } from "ink";
 import type { JSX, ReactNode } from "react";
 import { type AppRoute, routeLabels } from "../app/routes.js";
-import type { DaemonConnectionSnapshot } from "../daemon/connection.js";
-import type { TuiSyncStatus } from "../daemon/todu-client.js";
-import type { ProjectFilterState } from "../state/project-filter.js";
+import type { TuiTaskFilterState } from "../state/task-filter.js";
+import { formatTaskFilterSummary } from "../state/task-filter.js";
 import { HelpBar } from "./HelpBar.js";
-import { StatusLine } from "./StatusLine.js";
 
 export interface AppFrameProps {
   route: AppRoute;
-  connection: DaemonConnectionSnapshot;
-  projectFilter: ProjectFilterState;
-  syncStatus?: TuiSyncStatus;
+  taskFilter: TuiTaskFilterState;
   children: ReactNode;
   terminalWidth?: number;
   terminalHeight?: number;
@@ -19,9 +15,7 @@ export interface AppFrameProps {
 
 export function AppFrame({
   route,
-  connection,
-  projectFilter,
-  syncStatus,
+  taskFilter,
   children,
   terminalWidth,
   terminalHeight,
@@ -34,22 +28,15 @@ export function AppFrame({
 
   return (
     <Box flexDirection="column" paddingX={1} paddingY={1} width={size.width} height={size.height}>
-      <Box flexDirection="row" height={1} flexShrink={0}>
+      <Box height={1} flexShrink={0}>
         <Text color="cyan" bold wrap="truncate-end">
-          Todu
-        </Text>
-        <Text color="gray" wrap="truncate-end">
-          {" "}
-          • {routeLabels[route]}
+          {routeLabels[route]}
         </Text>
       </Box>
       <Box height={1} flexShrink={0}>
-        <StatusLine
-          route={route}
-          connection={connection}
-          projectFilter={projectFilter}
-          syncStatus={syncStatus}
-        />
+        <Text color="white" wrap="truncate-end">
+          {formatTaskFilterSummary(taskFilter)}
+        </Text>
       </Box>
       <Box flexDirection="column" flexGrow={1} marginY={1}>
         {children}

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Project, TaskStatus } from "@todu/core";
+import type { Project, TaskPriority, TaskStatus } from "@todu/core";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
@@ -20,16 +20,18 @@ import {
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
 import { resolveTaskStatusAction, taskStatusActions } from "../state/task-actions.js";
+import { createOpenTaskFilter } from "../state/task-filter.js";
 
 export interface TasksScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
+  priority?: TaskPriority;
   statusActionsEnabled?: boolean;
   dataQueriesEnabled?: boolean;
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
+  onProjectFilterChange?: (filter: ProjectFilterState) => void;
 }
 
-const visibleTaskStatuses = ["active", "inprogress", "waiting"] as const;
 const ALL_PROJECTS_OPTION_ID = "__all__";
 const PROJECT_PANE_WIDTH_PERCENT = 0.36;
 const TASK_MAIN_PANE_WIDTH_PERCENT = 0.64;
@@ -49,9 +51,11 @@ interface ProjectOption {
 export function TasksScreen({
   client,
   projectFilter,
+  priority,
   statusActionsEnabled = true,
   dataQueriesEnabled = true,
   onGlobalInputEnabledChange,
+  onProjectFilterChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
   const { stdout } = useStdout();
@@ -77,16 +81,8 @@ export function TasksScreen({
   );
   const selectedProjectOption =
     projectOptions.find((option) => option.id === selectedProjectOptionId) ?? projectOptions[0];
-  const selectedProjectFilter: ProjectFilterState = selectedProjectOption?.project
-    ? {
-        projectId: selectedProjectOption.project.id,
-        projectName: selectedProjectOption.project.name,
-      }
-    : allProjectsFilter;
-  const taskFilter = {
-    status: [...visibleTaskStatuses],
-    ...(selectedProjectFilter.projectId ? { projectId: selectedProjectFilter.projectId } : {}),
-  };
+  const selectedProjectFilter = projectFilterFromOption(selectedProjectOption);
+  const taskFilter = createOpenTaskFilter({ projectFilter: selectedProjectFilter, priority });
   const tasksQuery = useQuery({
     queryKey: queryKeys.tasks(taskFilter),
     queryFn: () => client.task.list(taskFilter),
@@ -255,8 +251,16 @@ export function TasksScreen({
 
     if (focusedPane === "projects") {
       if (input === "j" || key.downArrow) {
-        setSelectedProjectOptionId((current) =>
-          moveTaskProjectOption(projectOptions, current, "next"),
+        const nextProjectOptionId = moveTaskProjectOption(
+          projectOptions,
+          selectedProjectOptionId,
+          "next",
+        );
+        setSelectedProjectOptionId(nextProjectOptionId);
+        onProjectFilterChange?.(
+          projectFilterFromOption(
+            projectOptions.find((option) => option.id === nextProjectOptionId),
+          ),
         );
         setTaskDetailOpen(false);
         setFeedback(null);
@@ -264,8 +268,16 @@ export function TasksScreen({
       }
 
       if (input === "k" || key.upArrow) {
-        setSelectedProjectOptionId((current) =>
-          moveTaskProjectOption(projectOptions, current, "previous"),
+        const nextProjectOptionId = moveTaskProjectOption(
+          projectOptions,
+          selectedProjectOptionId,
+          "previous",
+        );
+        setSelectedProjectOptionId(nextProjectOptionId);
+        onProjectFilterChange?.(
+          projectFilterFromOption(
+            projectOptions.find((option) => option.id === nextProjectOptionId),
+          ),
         );
         setTaskDetailOpen(false);
         setFeedback(null);
@@ -569,6 +581,15 @@ function truncateProjectLabel(label: string, maxLength = 24): string {
   }
 
   return `${label.slice(0, maxLength - 3)}...`;
+}
+
+function projectFilterFromOption(option: ProjectOption | undefined): ProjectFilterState {
+  return option?.project
+    ? {
+        projectId: option.project.id,
+        projectName: option.project.name,
+      }
+    : allProjectsFilter;
 }
 
 function createTaskProjectOptions(projects: readonly Project[]): ProjectOption[] {

--- a/packages/tui/src/state/task-filter.test.ts
+++ b/packages/tui/src/state/task-filter.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { allProjectsFilter } from "./project-filter.js";
+import { createOpenTaskFilter, formatTaskFilterSummary } from "./task-filter.js";
+
+describe("task filter helpers", () => {
+  it("creates the Open query filter without a priority restriction", () => {
+    expect(createOpenTaskFilter({ projectFilter: allProjectsFilter })).toEqual({
+      status: ["active", "inprogress", "waiting"],
+    });
+  });
+
+  it.each([
+    [undefined, "Any priority"],
+    ["high", "High priority"],
+    ["medium", "Medium priority"],
+    ["low", "Low priority"],
+  ] as const)("formats %s as %s", (priority, expectedLabel) => {
+    expect(
+      formatTaskFilterSummary({
+        projectFilter: { projectId: null, projectName: "todu" },
+        priority,
+      }),
+    ).toBe(`Open · ${expectedLabel} · todu`);
+  });
+
+  it("formats the default task filter", () => {
+    expect(formatTaskFilterSummary({ projectFilter: allProjectsFilter })).toBe(
+      "Open · Any priority · All Projects",
+    );
+  });
+});

--- a/packages/tui/src/state/task-filter.ts
+++ b/packages/tui/src/state/task-filter.ts
@@ -1,0 +1,33 @@
+import type { TaskFilter, TaskPriority, TaskStatus } from "@todu/core";
+import type { ProjectFilterState } from "./project-filter.js";
+
+export const openTaskStatuses = [
+  "active",
+  "inprogress",
+  "waiting",
+] as const satisfies readonly TaskStatus[];
+
+export interface TuiTaskFilterState {
+  projectFilter: ProjectFilterState;
+  priority?: TaskPriority;
+}
+
+export function createOpenTaskFilter({ projectFilter, priority }: TuiTaskFilterState): TaskFilter {
+  return {
+    status: [...openTaskStatuses],
+    ...(priority ? { priority } : {}),
+    ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
+  };
+}
+
+export function formatTaskFilterSummary({ projectFilter, priority }: TuiTaskFilterState): string {
+  return `Open · ${formatPriorityFilter(priority)} · ${projectFilter.projectName ?? "All Projects"}`;
+}
+
+function formatPriorityFilter(priority: TaskPriority | undefined): string {
+  if (!priority) {
+    return "Any priority";
+  }
+
+  return `${priority[0]?.toUpperCase()}${priority.slice(1)} priority`;
+}


### PR DESCRIPTION
## Summary

- Replaces normal daemon/sync header text with primary route title and task-filter summary.
- Defines `Open` as active, doing, and waiting tasks.
- Derives project and priority labels from the query filter model.
- Lifts permanent Tasks-pane project selection into app state so the header and list remain synchronized.
- Adds coverage for priority labels, project selection, and narrow headers.

## Verification

- `npm test -- packages/tui/src/state/task-filter.test.ts packages/tui/src/components/AppFrame.test.tsx packages/tui/src/app/App.test.tsx packages/tui/src/screens/TasksScreen.test.tsx`
- `npm run --workspace=@todu/tui typecheck`
- `make pre-pr`

Task: #task-50f263c0
