### PR TITLE
Make TUI footer context-aware

### DIFF
--- a/.changeset/tui-contextual-footer.md
+++ b/.changeset/tui-contextual-footer.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Show concise context-aware footer shortcuts and move route navigation into the TUI header.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -164,7 +164,11 @@ describe("App", () => {
     expect(lastFrame()).toContain("Daemon unavailable");
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Tasks");
-    expect(lastFrame()).toContain("q Back/Quit");
+    expect(lastFrame()).toContain("2 Projects");
+    expect(lastFrame()).toContain("3 Data Status");
+    expect(lastFrame()).toContain("↑↓ Select");
+    expect(lastFrame()).toContain("← Projects");
+    expect(lastFrame()).toContain("Enter Details");
   });
 
   it("shows connected daemon status without body handshake diagnostics", async () => {
@@ -199,10 +203,15 @@ describe("App", () => {
     await waitForFrameText(lastFrame, "Project detail");
     expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
+    expect(lastFrame()).toContain("↑↓ Select");
+    expect(lastFrame()).toContain("Enter Open Tasks");
+    expect(lastFrame()).toContain("a All Projects");
 
     stdin.write("3");
     await waitForFrameText(lastFrame, "Data status ready");
     expect(lastFrame()).toContain("Projects: 1");
+    expect(lastFrame()).toContain("? Help");
+    expect(lastFrame()).toContain("q Quit");
     expect(lastFrame()).toContain("Tasks: 1");
   });
 
@@ -281,16 +290,42 @@ describe("App", () => {
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
 
-    expect(lastFrame()).toContain("1      Tasks");
-    expect(lastFrame()).toContain("2      Projects");
-    expect(lastFrame()).toContain("3      Data Status");
+    expect(lastFrame()).toContain("1/2/3  Tasks/Projects/Data Status");
     expect(lastFrame()).toContain("?      Help");
     expect(lastFrame()).toContain("j/↓    Down");
-    expect(lastFrame()).toContain("Enter  Select Project");
+    expect(lastFrame()).toContain("Enter  Select/Open/Submit");
+    expect(lastFrame()).toContain("Esc    Back/Cancel");
     expect(lastFrame()).toContain("a      All Projects");
     expect(lastFrame()).toContain("c      Comment");
+    expect(lastFrame()).toContain("y/n    Confirm/Cancel");
     expect(lastFrame()).toContain("q      Back/Quit");
     expect(lastFrame()).toContain("Ctrl+C Quit");
+  });
+
+  it("updates the footer for comment and cancellation modals", async () => {
+    const { stdin, lastFrame } = render(
+      <App
+        connection={createFakeConnection(createConnectedSnapshot())}
+        toduClient={createFakeClient()}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Ship");
+    stdin.write("c");
+    await waitForFrameText(lastFrame, "Comment on Ship");
+    expect(lastFrame()).toContain("Enter Submit");
+    expect(lastFrame()).toContain("Esc Cancel");
+
+    stdin.write("\u001B");
+    await waitForFrameText(lastFrame, "Cancelled comment.");
+    await waitForFrameText(lastFrame, "↑↓ Select");
+    expect(lastFrame()).toContain("← Projects");
+    expect(lastFrame()).toContain("Enter Details");
+
+    stdin.write("x");
+    await waitForFrameText(lastFrame, "Cancel selected task?");
+    expect(lastFrame()).toContain("y Confirm");
+    expect(lastFrame()).toContain("n/Esc Cancel");
   });
 
   it("backs out of help before quitting from a root route", async () => {
@@ -374,6 +409,7 @@ describe("App", () => {
       <AppFrame
         route="data-status"
         taskFilter={{ projectFilter: allProjectsFilter }}
+        footerContext="data-status"
         terminalWidth={24}
       >
         <TextFixture />

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -29,7 +29,9 @@ import type { TuiTaskFilterState } from "../state/task-filter.js";
 import {
   applyNavigationAction,
   createInitialRouteState,
+  type FooterContext,
   resolveGlobalKeyAction,
+  type TasksFooterContext,
 } from "./keymap.js";
 import type { AppRoute } from "./routes.js";
 
@@ -71,6 +73,7 @@ function AppContent({
   const [routeState, setRouteState] = useState(createInitialRouteState);
   const [projectFilter, setProjectFilter] = useState<ProjectFilterState>(allProjectsFilter);
   const taskFilter = useMemo<TuiTaskFilterState>(() => ({ projectFilter }), [projectFilter]);
+  const [tasksFooterContext, setTasksFooterContext] = useState<TasksFooterContext>("tasks-list");
   const [globalInputEnabled, setGlobalInputEnabled] = useState(true);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
@@ -155,8 +158,10 @@ function AppContent({
     };
   }, [connection, connectionSnapshot.state, queryClient]);
 
+  const footerContext = resolveFooterContext(routeState.route, tasksFooterContext);
+
   return (
-    <AppFrame route={routeState.route} taskFilter={taskFilter}>
+    <AppFrame route={routeState.route} taskFilter={taskFilter} footerContext={footerContext}>
       <ConnectionState connection={connectionSnapshot} />
       <RouteScreen
         route={routeState.route}
@@ -173,6 +178,7 @@ function AppContent({
           setRouteState({ route: "tasks", previousRoute: "tasks" });
         }}
         onTaskProjectFilterChange={updateProjectFilter}
+        onTasksFooterContextChange={setTasksFooterContext}
         onGlobalInputEnabledChange={setGlobalInputEnabled}
       />
     </AppFrame>
@@ -188,6 +194,7 @@ interface RouteScreenProps {
   onSelectProject: (project: import("@todu/core").Project) => void;
   onSelectAllProjects: () => void;
   onTaskProjectFilterChange: (filter: ProjectFilterState) => void;
+  onTasksFooterContextChange: (context: TasksFooterContext) => void;
   onGlobalInputEnabledChange: (enabled: boolean) => void;
 }
 
@@ -200,6 +207,7 @@ function RouteScreen({
   onSelectProject,
   onSelectAllProjects,
   onTaskProjectFilterChange,
+  onTasksFooterContextChange,
   onGlobalInputEnabledChange,
 }: RouteScreenProps): JSX.Element | null {
   const dataQueriesEnabled = connection.state === "connected";
@@ -233,6 +241,18 @@ function RouteScreen({
       dataQueriesEnabled={dataQueriesEnabled}
       onGlobalInputEnabledChange={onGlobalInputEnabledChange}
       onProjectFilterChange={onTaskProjectFilterChange}
+      onFooterContextChange={onTasksFooterContextChange}
     />
   ) : null;
+}
+
+function resolveFooterContext(
+  route: AppRoute,
+  tasksFooterContext: TasksFooterContext,
+): FooterContext {
+  if (route === "tasks") {
+    return tasksFooterContext;
+  }
+
+  return route;
 }

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -5,23 +5,82 @@ export interface TuiKeyBinding {
   description: string;
 }
 
-export const globalKeyBindings: readonly TuiKeyBinding[] = [
+export const primaryRouteKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "1", description: "Tasks" },
   { keys: "2", description: "Projects" },
   { keys: "3", description: "Data Status" },
+] as const;
+
+export const globalKeyBindings: readonly TuiKeyBinding[] = [
+  { keys: "1/2/3", description: "Tasks/Projects/Data Status" },
   { keys: "?", description: "Help" },
   { keys: "q", description: "Back/Quit" },
   { keys: "j/↓", description: "Down" },
   { keys: "k/↑", description: "Up" },
-  { keys: "Enter", description: "Select Project" },
+  { keys: "Enter", description: "Select/Open/Submit" },
+  { keys: "Esc", description: "Back/Cancel" },
   { keys: "s", description: "Start" },
   { keys: "w", description: "Wait" },
   { keys: "d", description: "Done" },
   { keys: "x", description: "Cancel" },
   { keys: "c", description: "Comment" },
   { keys: "a", description: "All Projects" },
+  { keys: "y/n", description: "Confirm/Cancel" },
   { keys: "Ctrl+C", description: "Quit" },
 ] as const;
+
+export type TasksFooterContext =
+  | "tasks-list"
+  | "tasks-projects"
+  | "task-detail"
+  | "comment-modal"
+  | "cancel-confirmation";
+
+export type FooterContext = TasksFooterContext | "projects" | "data-status" | "help";
+
+export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBinding[]>> = {
+  "tasks-list": [
+    { keys: "↑↓", description: "Select" },
+    { keys: "←", description: "Projects" },
+    { keys: "Enter", description: "Details" },
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  "tasks-projects": [
+    { keys: "↑↓", description: "Select" },
+    { keys: "→", description: "Tasks" },
+    { keys: "Enter", description: "Focus" },
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  "task-detail": [
+    { keys: "↑↓", description: "Scroll" },
+    { keys: "Esc", description: "Back" },
+    { keys: "s", description: "Start" },
+    { keys: "d", description: "Done" },
+    { keys: "?", description: "Help" },
+  ],
+  projects: [
+    { keys: "↑↓", description: "Select" },
+    { keys: "Enter", description: "Open Tasks" },
+    { keys: "a", description: "All Projects" },
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  "data-status": [
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  help: [{ keys: "q", description: "Back" }],
+  "comment-modal": [
+    { keys: "Enter", description: "Submit" },
+    { keys: "Esc", description: "Cancel" },
+  ],
+  "cancel-confirmation": [
+    { keys: "y", description: "Confirm" },
+    { keys: "n/Esc", description: "Cancel" },
+  ],
+};
 
 export type AppKeyAction =
   | { type: "navigate"; route: PrimaryAppRoute }

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -22,6 +22,7 @@ describe("AppFrame", () => {
       <AppFrame
         route="tasks"
         taskFilter={{ projectFilter: allProjectsFilter }}
+        footerContext="tasks-list"
         terminalWidth={60}
         terminalHeight={12}
       >
@@ -31,7 +32,12 @@ describe("AppFrame", () => {
 
     expect(lastFrame()).toContain("Tasks");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
-    expect(lastFrame()).toContain("body content");
     expect(lastFrame()).toContain("1 Tasks");
+    expect(lastFrame()).toContain("2 Projects");
+    expect(lastFrame()).toContain("3 Data Status");
+    expect(lastFrame()).toContain("body content");
+    expect(lastFrame()).toContain("↑↓ Select");
+    expect(lastFrame()).toContain("← Projects");
+    expect(lastFrame()).toContain("Enter Details");
   });
 });

--- a/packages/tui/src/components/AppFrame.tsx
+++ b/packages/tui/src/components/AppFrame.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useStdout } from "ink";
 import type { JSX, ReactNode } from "react";
+import { type FooterContext, primaryRouteKeyBindings } from "../app/keymap.js";
 import { type AppRoute, routeLabels } from "../app/routes.js";
 import type { TuiTaskFilterState } from "../state/task-filter.js";
 import { formatTaskFilterSummary } from "../state/task-filter.js";
@@ -8,6 +9,7 @@ import { HelpBar } from "./HelpBar.js";
 export interface AppFrameProps {
   route: AppRoute;
   taskFilter: TuiTaskFilterState;
+  footerContext: FooterContext;
   children: ReactNode;
   terminalWidth?: number;
   terminalHeight?: number;
@@ -16,6 +18,7 @@ export interface AppFrameProps {
 export function AppFrame({
   route,
   taskFilter,
+  footerContext,
   children,
   terminalWidth,
   terminalHeight,
@@ -38,11 +41,18 @@ export function AppFrame({
           {formatTaskFilterSummary(taskFilter)}
         </Text>
       </Box>
+      <Box height={1} flexShrink={0}>
+        <Text color="gray" wrap="truncate-end">
+          {primaryRouteKeyBindings
+            .map((binding) => `${binding.keys} ${binding.description}`)
+            .join("  •  ")}
+        </Text>
+      </Box>
       <Box flexDirection="column" flexGrow={1} marginY={1}>
         {children}
       </Box>
       <Box height={1} flexShrink={0}>
-        <HelpBar />
+        <HelpBar context={footerContext} />
       </Box>
     </Box>
   );

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { HelpBar } from "./HelpBar.js";
+
+describe("HelpBar", () => {
+  it.each([
+    ["tasks-list", ["↑↓ Select", "← Projects", "Enter Details", "? Help", "q Quit"]],
+    ["tasks-projects", ["↑↓ Select", "→ Tasks", "Enter Focus", "? Help", "q Quit"]],
+    ["task-detail", ["↑↓ Scroll", "Esc Back", "s Start", "d Done", "? Help"]],
+    ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
+    ["data-status", ["? Help", "q Quit"]],
+    ["help", ["q Back"]],
+    ["comment-modal", ["Enter Submit", "Esc Cancel"]],
+    ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],
+  ] as const)("shows concise %s shortcuts", (context, expected) => {
+    const { lastFrame } = render(<HelpBar context={context} />);
+
+    for (const binding of expected) {
+      expect(lastFrame()).toContain(binding);
+    }
+  });
+});

--- a/packages/tui/src/components/HelpBar.tsx
+++ b/packages/tui/src/components/HelpBar.tsx
@@ -1,12 +1,18 @@
 import { Box, Text } from "ink";
 import type { JSX } from "react";
-import { globalKeyBindings } from "../app/keymap.js";
+import { type FooterContext, footerKeyBindings } from "../app/keymap.js";
 
-export function HelpBar(): JSX.Element {
+export interface HelpBarProps {
+  context: FooterContext;
+}
+
+export function HelpBar({ context }: HelpBarProps): JSX.Element {
   return (
     <Box flexDirection="row">
       <Text color="gray" wrap="truncate-end">
-        {globalKeyBindings.map((binding) => `${binding.keys} ${binding.description}`).join("  •  ")}
+        {footerKeyBindings[context]
+          .map((binding) => `${binding.keys} ${binding.description}`)
+          .join("  •  ")}
       </Text>
     </Box>
   );

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -3,6 +3,7 @@ import type { Project, TaskPriority, TaskStatus } from "@todu/core";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
+import type { TasksFooterContext } from "../app/keymap.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { Pane } from "../components/Pane.js";
 import { TextInputModal } from "../components/TextInputModal.js";
@@ -30,6 +31,7 @@ export interface TasksScreenProps {
   dataQueriesEnabled?: boolean;
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
   onProjectFilterChange?: (filter: ProjectFilterState) => void;
+  onFooterContextChange?: (context: TasksFooterContext) => void;
 }
 
 const ALL_PROJECTS_OPTION_ID = "__all__";
@@ -56,6 +58,7 @@ export function TasksScreen({
   dataQueriesEnabled = true,
   onGlobalInputEnabledChange,
   onProjectFilterChange,
+  onFooterContextChange,
 }: TasksScreenProps): JSX.Element {
   const queryClient = useQueryClient();
   const { stdout } = useStdout();
@@ -133,9 +136,19 @@ export function TasksScreen({
   }, [tasksQuery.data]);
 
   useEffect(() => {
-    onGlobalInputEnabledChange?.(!commentModalOpen);
+    onGlobalInputEnabledChange?.(!commentModalOpen && !confirmCancel);
     return () => onGlobalInputEnabledChange?.(true);
-  }, [commentModalOpen, onGlobalInputEnabledChange]);
+  }, [commentModalOpen, confirmCancel, onGlobalInputEnabledChange]);
+
+  const footerContext = resolveTasksFooterContext({
+    commentModalOpen,
+    confirmCancel,
+    focusedPane,
+    taskDetailOpen,
+  });
+  useEffect(() => {
+    onFooterContextChange?.(footerContext);
+  }, [footerContext, onFooterContextChange]);
 
   const performStatusAction = async (
     taskId: string,
@@ -581,6 +594,32 @@ function truncateProjectLabel(label: string, maxLength = 24): string {
   }
 
   return `${label.slice(0, maxLength - 3)}...`;
+}
+
+function resolveTasksFooterContext({
+  commentModalOpen,
+  confirmCancel,
+  focusedPane,
+  taskDetailOpen,
+}: {
+  commentModalOpen: boolean;
+  confirmCancel: boolean;
+  focusedPane: PaneFocus;
+  taskDetailOpen: boolean;
+}): TasksFooterContext {
+  if (commentModalOpen) {
+    return "comment-modal";
+  }
+
+  if (confirmCancel) {
+    return "cancel-confirmation";
+  }
+
+  if (taskDetailOpen) {
+    return "task-detail";
+  }
+
+  return focusedPane === "projects" ? "tasks-projects" : "tasks-list";
 }
 
 function projectFilterFromOption(option: ProjectOption | undefined): ProjectFilterState {


### PR DESCRIPTION
## Summary

- Replaces the always-long TUI footer with concise shortcuts for Tasks, Projects, Data Status, Help, task detail, and modal states.
- Moves numbered route navigation to a third header row.
- Keeps every binding on the Help screen in a compact format that fits the viewport.
- Disables global navigation while comment and cancellation modal controls are active.

## Verification

- `make pre-pr`

Task: #task-07ee2e0f
