### PR TITLE
Add context-aware TUI list filters

### DIFF
--- a/.changeset/tui-list-filter-modal.md
+++ b/.changeset/tui-list-filter-modal.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Add context-aware task and project list filter modals.

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -20,6 +20,12 @@ import {
   reactiveDaemonEvents,
 } from "../state/event-invalidation.js";
 import {
+  defaultProjectListFilter,
+  defaultTaskListFilter,
+  type ProjectListFilterState,
+  type TaskListFilterState,
+} from "../state/list-filter.js";
+import {
   allProjectsFilter,
   createProjectFilter,
   type ProjectFilterState,
@@ -72,7 +78,13 @@ function AppContent({
   );
   const [routeState, setRouteState] = useState(createInitialRouteState);
   const [projectFilter, setProjectFilter] = useState<ProjectFilterState>(allProjectsFilter);
-  const taskFilter = useMemo<TuiTaskFilterState>(() => ({ projectFilter }), [projectFilter]);
+  const [taskListFilter, setTaskListFilter] = useState<TaskListFilterState>(defaultTaskListFilter);
+  const [projectListFilter, setProjectListFilter] =
+    useState<ProjectListFilterState>(defaultProjectListFilter);
+  const taskFilter = useMemo<TuiTaskFilterState>(
+    () => ({ projectFilter, ...taskListFilter }),
+    [projectFilter, taskListFilter],
+  );
   const [tasksFooterContext, setTasksFooterContext] = useState<TasksFooterContext>("tasks-list");
   const [globalInputEnabled, setGlobalInputEnabled] = useState(true);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
@@ -169,6 +181,10 @@ function AppContent({
         hasConnected={hasConnected}
         toduClient={toduClient}
         projectFilter={projectFilter}
+        taskListFilter={taskListFilter}
+        projectListFilter={projectListFilter}
+        onTaskListFilterChange={setTaskListFilter}
+        onProjectListFilterChange={setProjectListFilter}
         onSelectProject={(project) => {
           updateProjectFilter(createProjectFilter(project));
           setRouteState({ route: "tasks", previousRoute: "tasks" });
@@ -191,6 +207,10 @@ interface RouteScreenProps {
   hasConnected: boolean;
   toduClient: TuiToduClient;
   projectFilter: ProjectFilterState;
+  taskListFilter: TaskListFilterState;
+  projectListFilter: ProjectListFilterState;
+  onTaskListFilterChange: (filter: TaskListFilterState) => void;
+  onProjectListFilterChange: (filter: ProjectListFilterState) => void;
   onSelectProject: (project: import("@todu/core").Project) => void;
   onSelectAllProjects: () => void;
   onTaskProjectFilterChange: (filter: ProjectFilterState) => void;
@@ -204,6 +224,10 @@ function RouteScreen({
   hasConnected,
   toduClient,
   projectFilter,
+  taskListFilter,
+  projectListFilter,
+  onTaskListFilterChange,
+  onProjectListFilterChange,
   onSelectProject,
   onSelectAllProjects,
   onTaskProjectFilterChange,
@@ -218,8 +242,11 @@ function RouteScreen({
       <ProjectsScreen
         client={toduClient}
         projectFilter={projectFilter}
+        listFilter={projectListFilter}
+        onListFilterChange={onProjectListFilterChange}
         onSelectProject={onSelectProject}
         onSelectAllProjects={onSelectAllProjects}
+        onGlobalInputEnabledChange={onGlobalInputEnabledChange}
         dataQueriesEnabled={dataQueriesEnabled}
       />
     ) : null;
@@ -237,6 +264,10 @@ function RouteScreen({
     <TasksScreen
       client={toduClient}
       projectFilter={projectFilter}
+      taskListFilter={taskListFilter}
+      projectListFilter={projectListFilter}
+      onTaskListFilterChange={onTaskListFilterChange}
+      onProjectListFilterChange={onProjectListFilterChange}
       statusActionsEnabled={dataQueriesEnabled}
       dataQueriesEnabled={dataQueriesEnabled}
       onGlobalInputEnabledChange={onGlobalInputEnabledChange}

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -26,6 +26,7 @@ export const globalKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "c", description: "Comment" },
   { keys: "a", description: "All Projects" },
   { keys: "y/n", description: "Confirm/Cancel" },
+  { keys: "Ctrl+F", description: "Filter list" },
   { keys: "Ctrl+C", description: "Quit" },
 ] as const;
 
@@ -34,7 +35,8 @@ export type TasksFooterContext =
   | "tasks-projects"
   | "task-detail"
   | "comment-modal"
-  | "cancel-confirmation";
+  | "cancel-confirmation"
+  | "filter-modal";
 
 export type FooterContext = TasksFooterContext | "projects" | "data-status" | "help";
 
@@ -79,6 +81,14 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
   "cancel-confirmation": [
     { keys: "y", description: "Confirm" },
     { keys: "n/Esc", description: "Cancel" },
+  ],
+  "filter-modal": [
+    { keys: "↑↓", description: "Select" },
+    { keys: "Space", description: "Toggle" },
+    { keys: "←→", description: "Priority" },
+    { keys: "Enter", description: "Apply" },
+    { keys: "r", description: "Reset" },
+    { keys: "Esc", description: "Cancel" },
   ],
 };
 

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -12,6 +12,7 @@ describe("HelpBar", () => {
     ["help", ["q Back"]],
     ["comment-modal", ["Enter Submit", "Esc Cancel"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],
+    ["filter-modal", ["↑↓ Select", "Space Toggle", "←→ Priority", "Enter Apply"]],
   ] as const)("shows concise %s shortcuts", (context, expected) => {
     const { lastFrame } = render(<HelpBar context={context} />);
 

--- a/packages/tui/src/components/ListFilterModal.test.tsx
+++ b/packages/tui/src/components/ListFilterModal.test.tsx
@@ -19,6 +19,7 @@ describe("ListFilterModal", () => {
         title="Filter tasks"
         statusOptions={statuses}
         initialFilter={{ statuses: ["active"] }}
+        defaultFilter={{ statuses: ["active"] }}
         onApply={onApply}
         onCancel={vi.fn()}
       />,
@@ -36,5 +37,25 @@ describe("ListFilterModal", () => {
     stdin.write("\r");
 
     expect(onApply).toHaveBeenCalledWith({ statuses: ["active", "done"], priority: "high" });
+  });
+
+  it("resets to the supplied default draft", async () => {
+    const onApply = vi.fn();
+    const { stdin } = render(
+      <ListFilterModal
+        title="Filter tasks"
+        statusOptions={statuses}
+        initialFilter={{ statuses: ["done"], priority: "high" }}
+        defaultFilter={{ statuses: ["active"] }}
+        onApply={onApply}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    stdin.write("r");
+    await flushInput();
+    stdin.write("\r");
+
+    expect(onApply).toHaveBeenCalledWith({ statuses: ["active"] });
   });
 });

--- a/packages/tui/src/components/ListFilterModal.test.tsx
+++ b/packages/tui/src/components/ListFilterModal.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { ListFilterModal } from "./ListFilterModal.js";
+
+const statuses = [
+  { value: "active", label: "Active" },
+  { value: "done", label: "Done" },
+] as const;
+
+async function flushInput(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe("ListFilterModal", () => {
+  it("toggles statuses, changes priority, and applies the draft", async () => {
+    const onApply = vi.fn();
+    const { stdin, lastFrame } = render(
+      <ListFilterModal
+        title="Filter tasks"
+        statusOptions={statuses}
+        initialFilter={{ statuses: ["active"] }}
+        onApply={onApply}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain("[x] Active");
+    stdin.write("j");
+    await flushInput();
+    stdin.write(" ");
+    await flushInput();
+    stdin.write("j");
+    await flushInput();
+    stdin.write("\u001B[C");
+    await flushInput();
+    stdin.write("\r");
+
+    expect(onApply).toHaveBeenCalledWith({ statuses: ["active", "done"], priority: "high" });
+  });
+});

--- a/packages/tui/src/components/ListFilterModal.tsx
+++ b/packages/tui/src/components/ListFilterModal.tsx
@@ -21,6 +21,7 @@ export interface ListFilterModalProps<Status extends string> {
   title: string;
   statusOptions: readonly FilterStatusOption<Status>[];
   initialFilter: ListFilterDraft<Status>;
+  defaultFilter?: ListFilterDraft<Status>;
   onApply: (filter: ListFilterDraft<Status>) => void;
   onCancel: () => void;
 }
@@ -29,6 +30,7 @@ export function ListFilterModal<Status extends string>({
   title,
   statusOptions,
   initialFilter,
+  defaultFilter,
   onApply,
   onCancel,
 }: ListFilterModalProps<Status>): JSX.Element {
@@ -49,7 +51,7 @@ export function ListFilterModal<Status extends string>({
     }
 
     if (input === "r") {
-      setDraft(initialFilter);
+      setDraft(defaultFilter ?? initialFilter);
       return;
     }
 

--- a/packages/tui/src/components/ListFilterModal.tsx
+++ b/packages/tui/src/components/ListFilterModal.tsx
@@ -1,0 +1,127 @@
+import type { TaskPriority } from "@todu/core";
+import { Box, Text, useInput } from "ink";
+import type { JSX } from "react";
+import { useState } from "react";
+import { toggleStatus } from "../state/list-filter.js";
+
+const priorities: readonly (TaskPriority | undefined)[] = [undefined, "high", "medium", "low"];
+
+export interface FilterStatusOption<Status extends string> {
+  value: Status;
+  label: string;
+}
+
+export interface ListFilterDraft<Status extends string> {
+  statuses: readonly Status[];
+  priority?: TaskPriority;
+  includeHigherPriorities?: boolean;
+}
+
+export interface ListFilterModalProps<Status extends string> {
+  title: string;
+  statusOptions: readonly FilterStatusOption<Status>[];
+  initialFilter: ListFilterDraft<Status>;
+  onApply: (filter: ListFilterDraft<Status>) => void;
+  onCancel: () => void;
+}
+
+export function ListFilterModal<Status extends string>({
+  title,
+  statusOptions,
+  initialFilter,
+  onApply,
+  onCancel,
+}: ListFilterModalProps<Status>): JSX.Element {
+  const [draft, setDraft] = useState<ListFilterDraft<Status>>(initialFilter);
+  const [selectedRow, setSelectedRow] = useState(0);
+  const priorityRow = statusOptions.length;
+  const includeHigherPrioritiesRow = priorityRow + 1;
+
+  useInput((input, key) => {
+    if (key.escape || input === "\u001B") {
+      onCancel();
+      return;
+    }
+
+    if (key.return) {
+      onApply(draft);
+      return;
+    }
+
+    if (input === "r") {
+      setDraft(initialFilter);
+      return;
+    }
+
+    if (input === "j" || key.downArrow) {
+      setSelectedRow((row) => Math.min(row + 1, includeHigherPrioritiesRow));
+      return;
+    }
+
+    if (input === "k" || key.upArrow) {
+      setSelectedRow((row) => Math.max(row - 1, 0));
+      return;
+    }
+
+    if (input === " ") {
+      if (selectedRow < priorityRow) {
+        const status = statusOptions[selectedRow]?.value;
+        if (status) {
+          setDraft((current) => ({
+            ...current,
+            statuses: toggleStatus(current.statuses, status),
+          }));
+        }
+      }
+
+      if (selectedRow === includeHigherPrioritiesRow) {
+        setDraft((current) => ({
+          ...current,
+          includeHigherPriorities: !current.includeHigherPriorities,
+        }));
+      }
+      return;
+    }
+
+    if ((key.leftArrow || key.rightArrow) && selectedRow === priorityRow) {
+      const direction = key.rightArrow ? 1 : -1;
+      setDraft((current) => ({
+        ...current,
+        priority: cyclePriority(current.priority, direction),
+      }));
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text color="cyan">{title}</Text>
+      {statusOptions.map((status, index) => (
+        <Text key={status.value} color={selectedRow === index ? "white" : "gray"}>
+          {`${selectedRow === index ? ">" : " "} [${draft.statuses.includes(status.value) ? "x" : " "}] ${status.label}`}
+        </Text>
+      ))}
+      <Text color={selectedRow === priorityRow ? "white" : "gray"}>
+        {`${selectedRow === priorityRow ? ">" : " "} Priority: ${formatPriority(draft.priority)}`}
+      </Text>
+      <Text color={selectedRow === includeHigherPrioritiesRow ? "white" : "gray"}>
+        {`${selectedRow === includeHigherPrioritiesRow ? ">" : " "} [${draft.includeHigherPriorities ? "x" : " "}] Include higher priorities`}
+      </Text>
+      <Text color="gray">
+        ↑↓ select • Space toggle • ←→ priority • Enter apply • r reset • Esc cancel
+      </Text>
+    </Box>
+  );
+}
+
+function cyclePriority(
+  priority: TaskPriority | undefined,
+  direction: number,
+): TaskPriority | undefined {
+  const currentIndex = priorities.indexOf(priority);
+  const nextIndex = (currentIndex + direction + priorities.length) % priorities.length;
+  return priorities[nextIndex];
+}
+
+function formatPriority(priority: TaskPriority | undefined): string {
+  return priority ? `${priority[0]?.toUpperCase()}${priority.slice(1)}` : "Any";
+}

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -149,6 +149,7 @@ export function ProjectsScreen({
           title="Filter projects"
           statusOptions={projectStatusOptions}
           initialFilter={listFilter}
+          defaultFilter={defaultProjectListFilter}
           onApply={(filter) => {
             onListFilterChange?.(filter);
             setFilterModalOpen(false);

--- a/packages/tui/src/screens/ProjectsScreen.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.tsx
@@ -3,9 +3,17 @@ import type { Project } from "@todu/core";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { ListFilterModal } from "../components/ListFilterModal.js";
 import { Pane } from "../components/Pane.js";
 import { getVisibleTaskWindow } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import {
+  createProjectListQuery,
+  defaultProjectListFilter,
+  formatProjectListFilter,
+  matchesPriority,
+  type ProjectListFilterState,
+} from "../state/list-filter.js";
 import { formatListWindowIndicator, type ListWindow } from "../state/list-window.js";
 import type { ProjectFilterState } from "../state/project-filter.js";
 import { queryKeys } from "../state/query-keys.js";
@@ -17,6 +25,12 @@ const PROJECT_DETAIL_PANE_WIDTH = "60%";
 const MIN_PROJECT_LABEL_LENGTH = 8;
 const MIN_VISIBLE_PROJECTS = 1;
 
+const projectStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "done", label: "Done" },
+  { value: "canceled", label: "Canceled" },
+] as const;
+
 interface ProjectOption {
   id: string;
   label: string;
@@ -26,30 +40,44 @@ interface ProjectOption {
 export interface ProjectsScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
+  listFilter?: ProjectListFilterState;
+  onListFilterChange?: (filter: ProjectListFilterState) => void;
   onSelectProject: (project: Project) => void;
   onSelectAllProjects: () => void;
+  onGlobalInputEnabledChange?: (enabled: boolean) => void;
   dataQueriesEnabled?: boolean;
 }
 
 export function ProjectsScreen({
   client,
   projectFilter,
+  listFilter: listFilterProp,
+  onListFilterChange,
   onSelectProject,
   onSelectAllProjects,
+  onGlobalInputEnabledChange,
   dataQueriesEnabled = true,
 }: ProjectsScreenProps): JSX.Element {
+  const listFilter = listFilterProp ?? defaultProjectListFilter;
   const { stdout } = useStdout();
   const [selectedOptionId, setSelectedOptionId] = useState<string>(
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
   );
+  const [filterModalOpen, setFilterModalOpen] = useState(false);
+  const projectListQuery = createProjectListQuery(listFilter);
   const projectsQuery = useQuery({
-    queryKey: queryKeys.projects(),
-    queryFn: () => client.project.list(),
+    queryKey: queryKeys.projects(projectListQuery),
+    queryFn: () => client.project.list(projectListQuery),
     enabled: dataQueriesEnabled,
   });
   const projectOptions = useMemo(
-    () => createProjectOptions(projectsQuery.data ?? []),
-    [projectsQuery.data],
+    () =>
+      createProjectOptions(
+        (projectsQuery.data ?? []).filter((project) =>
+          matchesPriority(project.priority, listFilter),
+        ),
+      ),
+    [listFilter, projectsQuery.data],
   );
   const selectedOption =
     projectOptions.find((option) => option.id === selectedOptionId) ?? projectOptions[0];
@@ -62,6 +90,11 @@ export function ProjectsScreen({
   );
 
   useEffect(() => {
+    onGlobalInputEnabledChange?.(!filterModalOpen);
+    return () => onGlobalInputEnabledChange?.(true);
+  }, [filterModalOpen, onGlobalInputEnabledChange]);
+
+  useEffect(() => {
     if (!projectsQuery.data) {
       return;
     }
@@ -70,6 +103,15 @@ export function ProjectsScreen({
   }, [projectOptions, projectsQuery.data]);
 
   useInput((input, key) => {
+    if (filterModalOpen) {
+      return;
+    }
+
+    if (key.ctrl && input === "f") {
+      setFilterModalOpen(true);
+      return;
+    }
+
     if (input === "a") {
       onSelectAllProjects();
       return;
@@ -96,7 +138,26 @@ export function ProjectsScreen({
   });
 
   const projectCount = projectsQuery.data?.length ?? 0;
-  const listTitle = projectsQuery.isLoading ? "Projects • loading…" : `Projects (${projectCount})`;
+  const listTitle = projectsQuery.isLoading
+    ? "Projects • loading…"
+    : `Projects (${projectCount}) • ${formatProjectListFilter(listFilter)}`;
+
+  if (filterModalOpen) {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <ListFilterModal
+          title="Filter projects"
+          statusOptions={projectStatusOptions}
+          initialFilter={listFilter}
+          onApply={(filter) => {
+            onListFilterChange?.(filter);
+            setFilterModalOpen(false);
+          }}
+          onCancel={() => setFilterModalOpen(false)}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="row" flexGrow={1}>
@@ -118,6 +179,18 @@ export function ProjectsScreen({
           isEmpty={!projectsQuery.isLoading && !projectsQuery.error && projectCount === 0}
         />
       </Pane>
+      {filterModalOpen ? (
+        <ListFilterModal
+          title="Filter projects"
+          statusOptions={projectStatusOptions}
+          initialFilter={listFilter}
+          onApply={(filter) => {
+            onListFilterChange?.(filter);
+            setFilterModalOpen(false);
+          }}
+          onCancel={() => setFilterModalOpen(false)}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Project, TaskPriority, TaskStatus } from "@todu/core";
+import type { Project, TaskStatus } from "@todu/core";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { TasksFooterContext } from "../app/keymap.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
+import { ListFilterModal } from "../components/ListFilterModal.js";
 import { Pane } from "../components/Pane.js";
 import { TextInputModal } from "../components/TextInputModal.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
@@ -12,6 +13,16 @@ import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { getVisibleTaskWindow, TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { normalizeCommentContent } from "../state/comment-actions.js";
+import {
+  createProjectListQuery,
+  createTaskListQuery,
+  defaultProjectListFilter,
+  defaultTaskListFilter,
+  formatProjectListFilter,
+  matchesPriority,
+  type ProjectListFilterState,
+  type TaskListFilterState,
+} from "../state/list-filter.js";
 import { formatListWindowIndicator } from "../state/list-window.js";
 import {
   allProjectsFilter,
@@ -21,12 +32,14 @@ import {
 import { queryKeys } from "../state/query-keys.js";
 import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
 import { resolveTaskStatusAction, taskStatusActions } from "../state/task-actions.js";
-import { createOpenTaskFilter } from "../state/task-filter.js";
 
 export interface TasksScreenProps {
   client: TuiToduClient;
   projectFilter: ProjectFilterState;
-  priority?: TaskPriority;
+  taskListFilter?: TaskListFilterState;
+  projectListFilter?: ProjectListFilterState;
+  onTaskListFilterChange?: (filter: TaskListFilterState) => void;
+  onProjectListFilterChange?: (filter: ProjectListFilterState) => void;
   statusActionsEnabled?: boolean;
   dataQueriesEnabled?: boolean;
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
@@ -44,6 +57,20 @@ const MIN_VISIBLE_LIST_ITEMS = 1;
 
 type PaneFocus = "projects" | "tasks";
 
+const taskStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "inprogress", label: "In Progress" },
+  { value: "waiting", label: "Waiting" },
+  { value: "done", label: "Done" },
+  { value: "canceled", label: "Canceled" },
+] as const;
+
+const projectStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "done", label: "Done" },
+  { value: "canceled", label: "Canceled" },
+] as const;
+
 interface ProjectOption {
   id: string;
   label: string;
@@ -53,13 +80,18 @@ interface ProjectOption {
 export function TasksScreen({
   client,
   projectFilter,
-  priority,
+  taskListFilter: taskListFilterProp,
+  projectListFilter: projectListFilterProp,
+  onTaskListFilterChange,
+  onProjectListFilterChange,
   statusActionsEnabled = true,
   dataQueriesEnabled = true,
   onGlobalInputEnabledChange,
   onProjectFilterChange,
   onFooterContextChange,
 }: TasksScreenProps): JSX.Element {
+  const taskListFilter = taskListFilterProp ?? defaultTaskListFilter;
+  const projectListFilter = projectListFilterProp ?? defaultProjectListFilter;
   const queryClient = useQueryClient();
   const { stdout } = useStdout();
   const [selectedProjectOptionId, setSelectedProjectOptionId] = useState<string>(
@@ -73,25 +105,35 @@ export function TasksScreen({
   const [commentText, setCommentText] = useState("");
   const [commentError, setCommentError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
+  const [filterModalTarget, setFilterModalTarget] = useState<PaneFocus | null>(null);
+  const projectListQuery = createProjectListQuery(projectListFilter);
   const projectsQuery = useQuery({
-    queryKey: queryKeys.projects(),
-    queryFn: () => client.project.list(),
+    queryKey: queryKeys.projects(projectListQuery),
+    queryFn: () => client.project.list(projectListQuery),
     enabled: dataQueriesEnabled,
   });
   const projectOptions = useMemo(
-    () => createTaskProjectOptions(projectsQuery.data ?? []),
-    [projectsQuery.data],
+    () =>
+      createTaskProjectOptions(
+        (projectsQuery.data ?? []).filter((project) =>
+          matchesPriority(project.priority, projectListFilter),
+        ),
+      ),
+    [projectListFilter, projectsQuery.data],
   );
   const selectedProjectOption =
     projectOptions.find((option) => option.id === selectedProjectOptionId) ?? projectOptions[0];
   const selectedProjectFilter = projectFilterFromOption(selectedProjectOption);
-  const taskFilter = createOpenTaskFilter({ projectFilter: selectedProjectFilter, priority });
+  const taskFilter = createTaskListQuery(selectedProjectFilter, taskListFilter);
   const tasksQuery = useQuery({
     queryKey: queryKeys.tasks(taskFilter),
     queryFn: () => client.task.list(taskFilter),
     enabled: dataQueriesEnabled,
   });
-  const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
+  const tasks = useMemo(
+    () => (tasksQuery.data ?? []).filter((task) => matchesPriority(task.priority, taskListFilter)),
+    [taskListFilter, tasksQuery.data],
+  );
   const effectiveSelectedTaskId = resolveSelectedId(tasks, selectedTaskId);
   const selectedTask = getSelectedItem(tasks, effectiveSelectedTaskId);
   const selectedDetailQuery = useQuery({
@@ -128,6 +170,16 @@ export function TasksScreen({
   }, [projectOptions, projectsQuery.data]);
 
   useEffect(() => {
+    if (
+      projectFilter.projectId &&
+      projectsQuery.data &&
+      !projectOptions.some((option) => option.project?.id === projectFilter.projectId)
+    ) {
+      onProjectFilterChange?.(allProjectsFilter);
+    }
+  }, [onProjectFilterChange, projectFilter.projectId, projectOptions, projectsQuery.data]);
+
+  useEffect(() => {
     if (!tasksQuery.data) {
       return;
     }
@@ -136,13 +188,14 @@ export function TasksScreen({
   }, [tasksQuery.data]);
 
   useEffect(() => {
-    onGlobalInputEnabledChange?.(!commentModalOpen && !confirmCancel);
+    onGlobalInputEnabledChange?.(!commentModalOpen && !confirmCancel && !filterModalTarget);
     return () => onGlobalInputEnabledChange?.(true);
-  }, [commentModalOpen, confirmCancel, onGlobalInputEnabledChange]);
+  }, [commentModalOpen, confirmCancel, filterModalTarget, onGlobalInputEnabledChange]);
 
   const footerContext = resolveTasksFooterContext({
     commentModalOpen,
     confirmCancel,
+    filterModalTarget,
     focusedPane,
     taskDetailOpen,
   });
@@ -206,6 +259,10 @@ export function TasksScreen({
   };
 
   useInput((input, key) => {
+    if (filterModalTarget) {
+      return;
+    }
+
     if (commentModalOpen) {
       if (key.escape) {
         closeCommentModal();
@@ -244,6 +301,11 @@ export function TasksScreen({
         setConfirmCancel(false);
         setFeedback({ message: "Cancelled task action.", tone: "info" });
       }
+      return;
+    }
+
+    if (key.ctrl && input === "f" && !taskDetailOpen) {
+      setFilterModalTarget(focusedPane);
       return;
     }
 
@@ -366,6 +428,40 @@ export function TasksScreen({
     void performStatusAction(selectedTask.id, action.status, action.successLabel);
   });
 
+  if (filterModalTarget === "tasks") {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <ListFilterModal
+          title="Filter tasks"
+          statusOptions={taskStatusOptions}
+          initialFilter={taskListFilter}
+          onApply={(filter) => {
+            onTaskListFilterChange?.(filter);
+            setFilterModalTarget(null);
+          }}
+          onCancel={() => setFilterModalTarget(null)}
+        />
+      </Box>
+    );
+  }
+
+  if (filterModalTarget === "projects") {
+    return (
+      <Box flexDirection="column" flexGrow={1}>
+        <ListFilterModal
+          title="Filter projects"
+          statusOptions={projectStatusOptions}
+          initialFilter={projectListFilter}
+          onApply={(filter) => {
+            onProjectListFilterChange?.(filter);
+            setFilterModalTarget(null);
+          }}
+          onCancel={() => setFilterModalTarget(null)}
+        />
+      </Box>
+    );
+  }
+
   const maxVisibleListItems = resolveMaxVisibleListItems(stdout.rows);
   const maxProjectLabelLength = resolveProjectLabelLength(stdout.columns);
   const detailContentWidth = resolveDetailContentWidth(stdout.columns);
@@ -382,6 +478,7 @@ export function TasksScreen({
             isLoading={projectsQuery.isLoading}
             maxVisibleProjects={maxVisibleListItems}
             maxProjectLabelLength={maxProjectLabelLength}
+            listFilter={projectListFilter}
           />
           <Pane
             title="Tasks unavailable"
@@ -410,6 +507,7 @@ export function TasksScreen({
             isLoading={projectsQuery.isLoading}
             maxVisibleProjects={maxVisibleListItems}
             maxProjectLabelLength={maxProjectLabelLength}
+            listFilter={projectListFilter}
           />
           <Pane
             title="Tasks • loading…"
@@ -435,6 +533,7 @@ export function TasksScreen({
             isLoading={projectsQuery.isLoading}
             maxVisibleProjects={maxVisibleListItems}
             maxProjectLabelLength={maxProjectLabelLength}
+            listFilter={projectListFilter}
           />
           <Pane title="Tasks (0)" width={TASK_MAIN_PANE_WIDTH} focused={focusedPane === "tasks"}>
             <Text color="gray">
@@ -458,6 +557,7 @@ export function TasksScreen({
           isLoading={projectsQuery.isLoading}
           maxVisibleProjects={maxVisibleListItems}
           maxProjectLabelLength={maxProjectLabelLength}
+          listFilter={projectListFilter}
         />
         <Box flexDirection="column" width={TASK_MAIN_PANE_WIDTH}>
           <TaskListPane
@@ -485,6 +585,30 @@ export function TasksScreen({
           ) : null}
         </Box>
       </Box>
+      {filterModalTarget === "tasks" ? (
+        <ListFilterModal
+          title="Filter tasks"
+          statusOptions={taskStatusOptions}
+          initialFilter={taskListFilter}
+          onApply={(filter) => {
+            onTaskListFilterChange?.(filter);
+            setFilterModalTarget(null);
+          }}
+          onCancel={() => setFilterModalTarget(null)}
+        />
+      ) : null}
+      {filterModalTarget === "projects" ? (
+        <ListFilterModal
+          title="Filter projects"
+          statusOptions={projectStatusOptions}
+          initialFilter={projectListFilter}
+          onApply={(filter) => {
+            onProjectListFilterChange?.(filter);
+            setFilterModalTarget(null);
+          }}
+          onCancel={() => setFilterModalTarget(null)}
+        />
+      ) : null}
       {commentModalOpen ? (
         <TextInputModal
           title={selectedTask ? `Comment on ${selectedTask.title}` : "Comment"}
@@ -506,6 +630,7 @@ interface ProjectListPaneProps {
   isLoading?: boolean;
   maxVisibleProjects: number;
   maxProjectLabelLength: number;
+  listFilter: ProjectListFilterState;
 }
 
 function ProjectListPane({
@@ -515,6 +640,7 @@ function ProjectListPane({
   isLoading = false,
   maxVisibleProjects,
   maxProjectLabelLength,
+  listFilter,
 }: ProjectListPaneProps): JSX.Element {
   const projectWindow = getVisibleTaskWindow(projects, selectedProjectOptionId, maxVisibleProjects);
   const aboveIndicator = formatListWindowIndicator(projectWindow, "above");
@@ -522,7 +648,7 @@ function ProjectListPane({
 
   return (
     <Pane
-      title={`Projects${isLoading ? " • loading…" : ""}`}
+      title={`Projects • ${formatProjectListFilter(listFilter)}${isLoading ? " • loading…" : ""}`}
       width={PROJECT_PANE_WIDTH}
       focused={focused}
     >
@@ -599,14 +725,20 @@ function truncateProjectLabel(label: string, maxLength = 24): string {
 function resolveTasksFooterContext({
   commentModalOpen,
   confirmCancel,
+  filterModalTarget,
   focusedPane,
   taskDetailOpen,
 }: {
   commentModalOpen: boolean;
   confirmCancel: boolean;
+  filterModalTarget: PaneFocus | null;
   focusedPane: PaneFocus;
   taskDetailOpen: boolean;
 }): TasksFooterContext {
+  if (filterModalTarget) {
+    return "filter-modal";
+  }
+
   if (commentModalOpen) {
     return "comment-modal";
   }

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -435,6 +435,7 @@ export function TasksScreen({
           title="Filter tasks"
           statusOptions={taskStatusOptions}
           initialFilter={taskListFilter}
+          defaultFilter={defaultTaskListFilter}
           onApply={(filter) => {
             onTaskListFilterChange?.(filter);
             setFilterModalTarget(null);
@@ -452,6 +453,7 @@ export function TasksScreen({
           title="Filter projects"
           statusOptions={projectStatusOptions}
           initialFilter={projectListFilter}
+          defaultFilter={defaultProjectListFilter}
           onApply={(filter) => {
             onProjectListFilterChange?.(filter);
             setFilterModalTarget(null);

--- a/packages/tui/src/state/list-filter.test.ts
+++ b/packages/tui/src/state/list-filter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProjectListQuery,
+  createTaskListQuery,
+  defaultProjectListFilter,
+  defaultTaskListFilter,
+  formatProjectListFilter,
+  formatTaskStatusFilter,
+  toggleStatus,
+} from "./list-filter.js";
+import { allProjectsFilter } from "./project-filter.js";
+
+describe("list filters", () => {
+  it("uses Open as the default task status package", () => {
+    expect(formatTaskStatusFilter(defaultTaskListFilter.statuses)).toBe("Open");
+    expect(createTaskListQuery(allProjectsFilter, defaultTaskListFilter)).toEqual({
+      status: ["active", "inprogress", "waiting"],
+    });
+  });
+
+  it("supports custom task status and priority filters", () => {
+    expect(formatTaskStatusFilter(["active", "done"])).toBe("Active + Done");
+    expect(
+      createTaskListQuery(
+        { projectId: "project-1", projectName: "Inbox" },
+        { statuses: ["done"], priority: "high" },
+      ),
+    ).toEqual({ status: ["done"], priority: "high", projectId: "project-1" });
+  });
+
+  it("keeps at least one selected status", () => {
+    expect(toggleStatus(["active"], "active")).toEqual(["active"]);
+    expect(toggleStatus(["active"], "done")).toEqual(["active", "done"]);
+  });
+
+  it("creates project queries and summaries", () => {
+    expect(createProjectListQuery(defaultProjectListFilter)).toEqual({
+      status: ["active", "done", "canceled"],
+    });
+    expect(formatProjectListFilter({ statuses: ["active"], priority: "low" })).toBe(
+      "Active · Low priority",
+    );
+  });
+});

--- a/packages/tui/src/state/list-filter.ts
+++ b/packages/tui/src/state/list-filter.ts
@@ -1,0 +1,147 @@
+import type {
+  ProjectFilter,
+  ProjectStatus,
+  TaskFilter,
+  TaskPriority,
+  TaskStatus,
+} from "@todu/core";
+import type { ProjectFilterState } from "./project-filter.js";
+
+export interface TaskListFilterState {
+  statuses: readonly TaskStatus[];
+  priority?: TaskPriority;
+  includeHigherPriorities?: boolean;
+}
+
+export interface ProjectListFilterState {
+  statuses: readonly ProjectStatus[];
+  priority?: TaskPriority;
+  includeHigherPriorities?: boolean;
+}
+
+export const defaultTaskListFilter: TaskListFilterState = {
+  statuses: ["active", "inprogress", "waiting"],
+};
+
+export const defaultProjectListFilter: ProjectListFilterState = {
+  statuses: ["active", "done", "canceled"],
+};
+
+export function createTaskListQuery(
+  projectFilter: ProjectFilterState,
+  listFilter: TaskListFilterState,
+): TaskFilter {
+  return {
+    status: [...listFilter.statuses],
+    ...(listFilter.priority && !listFilter.includeHigherPriorities
+      ? { priority: listFilter.priority }
+      : {}),
+    ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
+  };
+}
+
+export function createProjectListQuery(listFilter: ProjectListFilterState): ProjectFilter {
+  return {
+    status: [...listFilter.statuses],
+    ...(listFilter.priority && !listFilter.includeHigherPriorities
+      ? { priority: listFilter.priority }
+      : {}),
+  };
+}
+
+export function toggleStatus<Status extends string>(
+  statuses: readonly Status[],
+  status: Status,
+): readonly Status[] {
+  if (statuses.includes(status)) {
+    return statuses.length > 1 ? statuses.filter((value) => value !== status) : statuses;
+  }
+
+  return [...statuses, status];
+}
+
+export function formatTaskStatusFilter(statuses: readonly TaskStatus[]): string {
+  if (sameStatuses(statuses, defaultTaskListFilter.statuses)) {
+    return "Open";
+  }
+
+  return formatStatusFilter(statuses, {
+    active: "Active",
+    inprogress: "In Progress",
+    waiting: "Waiting",
+    done: "Done",
+    canceled: "Canceled",
+  });
+}
+
+export function formatProjectListFilter(filter: ProjectListFilterState): string {
+  return `${formatProjectStatusFilter(filter.statuses)} · ${formatPriorityFilter(
+    filter.priority,
+    filter.includeHigherPriorities,
+  )}`;
+}
+
+export function matchesPriority(
+  priority: TaskPriority,
+  filter: Pick<TaskListFilterState, "priority" | "includeHigherPriorities">,
+): boolean {
+  if (!filter.priority) {
+    return true;
+  }
+
+  if (!filter.includeHigherPriorities) {
+    return priority === filter.priority;
+  }
+
+  return priorityRank[priority] >= priorityRank[filter.priority];
+}
+
+export function formatProjectStatusFilter(statuses: readonly ProjectStatus[]): string {
+  if (sameStatuses(statuses, defaultProjectListFilter.statuses)) {
+    return "All statuses";
+  }
+
+  return formatStatusFilter(statuses, {
+    active: "Active",
+    done: "Done",
+    canceled: "Canceled",
+  });
+}
+
+export function formatPriorityFilter(
+  priority: TaskPriority | undefined,
+  includeHigherPriorities = false,
+): string {
+  if (!priority) {
+    return "Any priority";
+  }
+
+  const label = `${priority[0]?.toUpperCase()}${priority.slice(1)} priority`;
+  return includeHigherPriorities ? `${label} and higher` : label;
+}
+
+const priorityRank: Record<TaskPriority, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+function sameStatuses<Status extends string>(
+  left: readonly Status[],
+  right: readonly Status[],
+): boolean {
+  return left.length === right.length && left.every((status) => right.includes(status));
+}
+
+function formatStatusFilter<Status extends string>(
+  statuses: readonly Status[],
+  labels: Record<Status, string>,
+): string {
+  if (statuses.length === 1) {
+    return labels[statuses[0] as Status];
+  }
+
+  return statuses.length <= 3
+    ? statuses.map((status) => labels[status]).join(" + ")
+    : `${statuses.length} statuses`;
+}

--- a/packages/tui/src/state/task-filter.ts
+++ b/packages/tui/src/state/task-filter.ts
@@ -1,33 +1,49 @@
 import type { TaskFilter, TaskPriority, TaskStatus } from "@todu/core";
+import {
+  createTaskListQuery,
+  defaultTaskListFilter,
+  formatPriorityFilter,
+  formatTaskStatusFilter,
+} from "./list-filter.js";
 import type { ProjectFilterState } from "./project-filter.js";
 
-export const openTaskStatuses = [
-  "active",
-  "inprogress",
-  "waiting",
-] as const satisfies readonly TaskStatus[];
+export const openTaskStatuses = defaultTaskListFilter.statuses;
 
 export interface TuiTaskFilterState {
   projectFilter: ProjectFilterState;
+  statuses?: readonly TaskStatus[];
   priority?: TaskPriority;
+  includeHigherPriorities?: boolean;
 }
 
-export function createOpenTaskFilter({ projectFilter, priority }: TuiTaskFilterState): TaskFilter {
-  return {
-    status: [...openTaskStatuses],
-    ...(priority ? { priority } : {}),
-    ...(projectFilter.projectId ? { projectId: projectFilter.projectId } : {}),
-  };
+export function createTaskFilter({
+  projectFilter,
+  statuses,
+  priority,
+  includeHigherPriorities,
+}: TuiTaskFilterState): TaskFilter {
+  return createTaskListQuery(projectFilter, {
+    statuses: statuses ?? defaultTaskListFilter.statuses,
+    priority,
+    includeHigherPriorities,
+  });
 }
 
-export function formatTaskFilterSummary({ projectFilter, priority }: TuiTaskFilterState): string {
-  return `Open · ${formatPriorityFilter(priority)} · ${projectFilter.projectName ?? "All Projects"}`;
+export function createOpenTaskFilter({
+  projectFilter,
+  priority,
+}: Omit<TuiTaskFilterState, "statuses">): TaskFilter {
+  return createTaskFilter({ projectFilter, priority });
 }
 
-function formatPriorityFilter(priority: TaskPriority | undefined): string {
-  if (!priority) {
-    return "Any priority";
-  }
-
-  return `${priority[0]?.toUpperCase()}${priority.slice(1)} priority`;
+export function formatTaskFilterSummary({
+  projectFilter,
+  statuses = defaultTaskListFilter.statuses,
+  priority,
+  includeHigherPriorities,
+}: TuiTaskFilterState): string {
+  return `${formatTaskStatusFilter(statuses)} · ${formatPriorityFilter(
+    priority,
+    includeHigherPriorities,
+  )} · ${projectFilter.projectName ?? "All Projects"}`;
 }


### PR DESCRIPTION
## Summary

- Adds Ctrl+F task/project filter modals targeted to the focused list.
- Supports multi-select statuses, exact priority, and selected-priority-or-higher filtering.
- Keeps filters session-scoped across project selection; resets task scope if a project filter hides it.
- Replaces list content with the modal to avoid clipping in short tmux panes.

## Verification

- `make pre-pr`
- Manual narrow-pane verification in tmux

Task: #task-ce35ce58
