### PR TITLE
Render Markdown in TUI task details

### DIFF
--- a/.changeset/tui-task-detail-markdown.md
+++ b/.changeset/tui-task-detail-markdown.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": patch
+---
+
+Render supported Markdown in task detail descriptions and comments.

--- a/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
@@ -52,10 +52,31 @@ describe("TaskDetailPane", () => {
     expect(frame).toContain("Metadata");
     expect(frame).toContain("doing • med • todu • #tui #layout");
     expect(frame).toContain("Comments");
+    expect(frame).toContain("Erik:");
     expect(frame).toContain("Erik: Comment 1 provides additional");
     expect(frame).toContain("implementation context.");
     expect(frame.indexOf("Description")).toBeLessThan(frame.indexOf("Metadata"));
     expect(frame.indexOf("Metadata")).toBeLessThan(frame.indexOf("Comments"));
+  });
+
+  it("renders supported Markdown in descriptions and comments", () => {
+    const markdown =
+      "# Heading\n- **bold** and *italic* with `code`\n[Docs](https://example.com)\n<div>literal</div>";
+    const comment = createComment(1);
+    comment.content = "> ~~quoted~~ comment";
+    const lines = createTaskDetailLines({
+      task: createTask({ description: markdown }),
+      projectName: "todu",
+      comments: [comment],
+      maxContentWidth: 80,
+    });
+
+    expect(lines.some((line) => line.text === "Heading" && line.bold)).toBe(true);
+    expect(lines.some((line) => line.text.includes("• bold and italic with code"))).toBe(true);
+    expect(lines.some((line) => line.text.includes("Docs <https://example.com>"))).toBe(true);
+    expect(lines.some((line) => line.text === "<div>literal</div>")).toBe(true);
+    expect(lines.some((line) => line.text.includes("│ quoted comment"))).toBe(true);
+    expect(lines.flatMap((line) => line.spans ?? []).some((span) => span.strikethrough)).toBe(true);
   });
 
   it("scrolls long description and comment content instead of clipping it", async () => {

--- a/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
@@ -99,6 +99,26 @@ describe("TaskDetailPane", () => {
     expect(lastFrame()).toContain("↑ 1 lines");
   });
 
+  it("wraps formatted Markdown spans within narrow content widths", () => {
+    const lines = createTaskDetailLines({
+      task: createTask({
+        description: "**Important Markdown** [documentation](https://example.com)",
+      }),
+      projectName: "todu",
+      comments: [],
+      maxContentWidth: 12,
+    });
+    const descriptionLines = lines.filter((line) => /^description-\d+$/.test(line.id));
+
+    expect(descriptionLines.every((line) => line.text.length <= 12)).toBe(true);
+    expect(descriptionLines.flatMap((line) => line.spans ?? []).some((span) => span.bold)).toBe(
+      true,
+    );
+    expect(
+      descriptionLines.flatMap((line) => line.spans ?? []).some((span) => span.color === "cyan"),
+    ).toBe(true);
+  });
+
   it("wraps all detail text within narrow content widths", () => {
     const description = "A description that should stay readable without horizontal clipping.";
     const lines = createTaskDetailLines({

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -3,6 +3,7 @@ import { Text, useInput } from "ink";
 import type { JSX } from "react";
 import { useEffect, useState } from "react";
 import { formatToduClientError } from "../../daemon/todu-client.js";
+import { type MarkdownSpan, renderMarkdownLines } from "../../formatting/markdown.js";
 import { createProjectNameMap, formatTaskMetadata } from "../../formatting/task.js";
 import { Pane } from "../Pane.js";
 
@@ -25,6 +26,7 @@ export interface TaskDetailLine {
   text: string;
   color: "cyan" | "gray" | "white";
   bold?: boolean;
+  spans?: readonly MarkdownSpan[];
 }
 
 export function TaskDetailPane({
@@ -90,7 +92,17 @@ export function TaskDetailPane({
       {scrollOffset > 0 ? <Text color="gray">↑ {scrollOffset} lines</Text> : null}
       {visibleLines.map((line) => (
         <Text key={line.id} color={line.color} bold={line.bold} wrap="wrap">
-          {line.text}
+          {line.spans?.map((span) => (
+            <Text
+              key={`${line.id}-${span.text}-${span.color ?? "default"}-${span.bold ?? false}-${span.italic ?? false}-${span.strikethrough ?? false}`}
+              color={span.color}
+              bold={span.bold}
+              italic={span.italic}
+              strikethrough={span.strikethrough}
+            >
+              {span.text}
+            </Text>
+          )) ?? line.text}
         </Text>
       ))}
       {hiddenBelow > 0 ? <Text color="gray">↓ {hiddenBelow} lines</Text> : null}
@@ -114,12 +126,9 @@ export function createTaskDetailLines({
   const lines: TaskDetailLine[] = [
     ...createWrappedLines("title", task.title, contentWidth, "white", true),
     { id: "description-heading", text: "Description", color: "cyan" },
-    ...createWrappedLines(
-      "description",
-      description || "No description.",
-      contentWidth,
-      description ? "white" : "gray",
-    ),
+    ...(description
+      ? createMarkdownDetailLines("description", description, contentWidth)
+      : createWrappedLines("description", "No description.", contentWidth, "gray")),
     { id: "metadata-heading", text: "Metadata", color: "cyan" },
     ...createWrappedLines("metadata", formatTaskMetadata(task, projectName), contentWidth, "gray"),
     { id: "comments-heading", text: "Comments", color: "cyan" },
@@ -131,11 +140,43 @@ export function createTaskDetailLines({
   }
 
   for (const comment of comments) {
-    const label = comment.author ? `${comment.author}: ${comment.content}` : comment.content;
-    lines.push(...createWrappedLines(`comment-${comment.id}`, label, contentWidth, "white"));
+    const isBlockMarkdown = /^(?:\s*>|\s*#{1,6}\s|\s*[-*+]\s|\s*\d+[.)]\s|\s*```)/.test(
+      comment.content,
+    );
+    if (comment.author && isBlockMarkdown) {
+      lines.push(
+        ...createWrappedLines(
+          `comment-${comment.id}-author`,
+          `${comment.author}:`,
+          contentWidth,
+          "gray",
+        ),
+      );
+      lines.push(
+        ...createMarkdownDetailLines(`comment-${comment.id}`, comment.content, contentWidth),
+      );
+      continue;
+    }
+
+    const content = comment.author ? `${comment.author}: ${comment.content}` : comment.content;
+    lines.push(...createMarkdownDetailLines(`comment-${comment.id}`, content, contentWidth));
   }
 
   return lines;
+}
+
+function createMarkdownDetailLines(
+  id: string,
+  markdown: string,
+  maxWidth: number,
+): readonly TaskDetailLine[] {
+  return renderMarkdownLines({ id, markdown, maxWidth }).map((line) => ({
+    id: line.id,
+    text: line.text,
+    spans: line.spans,
+    color: line.color,
+    bold: line.bold,
+  }));
 }
 
 function createWrappedLines(

--- a/packages/tui/src/formatting/markdown.ts
+++ b/packages/tui/src/formatting/markdown.ts
@@ -1,0 +1,205 @@
+export interface MarkdownSpan {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  strikethrough?: boolean;
+  color?: "cyan" | "gray" | "white";
+}
+
+export interface MarkdownLine {
+  text: string;
+  spans: readonly MarkdownSpan[];
+  color: "cyan" | "gray" | "white";
+  bold?: boolean;
+}
+
+export function renderMarkdownLines({
+  id,
+  markdown,
+  maxWidth,
+  color = "white",
+}: {
+  id: string;
+  markdown: string;
+  maxWidth: number;
+  color?: MarkdownLine["color"];
+}): readonly (MarkdownLine & { id: string })[] {
+  const lines: Array<MarkdownLine & { id: string }> = [];
+  const sourceLines = markdown.split(/\r?\n/);
+  let codeBlock = false;
+
+  for (const sourceLine of sourceLines) {
+    if (/^\s*```/.test(sourceLine)) {
+      codeBlock = !codeBlock;
+      continue;
+    }
+
+    const block = parseBlock(sourceLine, codeBlock, color);
+    const wrapped = wrapMarkdownSpans(block.spans, maxWidth);
+    for (const spans of wrapped) {
+      lines.push({
+        id: `${id}-${lines.length}`,
+        text: spans.map((span) => span.text).join(""),
+        spans,
+        color: block.color,
+        bold: block.bold,
+      });
+    }
+  }
+
+  return lines.length > 0 ? lines : [{ id: `${id}-0`, text: "", spans: [], color }];
+}
+
+function parseBlock(
+  sourceLine: string,
+  codeBlock: boolean,
+  defaultColor: MarkdownLine["color"],
+): MarkdownLine {
+  if (codeBlock) {
+    return { text: sourceLine, spans: [{ text: sourceLine }], color: "gray" };
+  }
+
+  const heading = /^(#{1,6})\s+(.+)$/.exec(sourceLine);
+  if (heading) {
+    const text = heading[2] ?? "";
+    return { text, spans: parseInline(text), color: "cyan", bold: true };
+  }
+
+  const bullet = /^\s*[-*+]\s+(.+)$/.exec(sourceLine);
+  if (bullet) {
+    return {
+      text: `• ${bullet[1] ?? ""}`,
+      spans: [{ text: "• " }, ...parseInline(bullet[1] ?? "")],
+      color: defaultColor,
+    };
+  }
+
+  const ordered = /^\s*(\d+[.)])\s+(.+)$/.exec(sourceLine);
+  if (ordered) {
+    const marker = ordered[1] ?? "";
+    const content = ordered[2] ?? "";
+    return {
+      text: `${marker} ${content}`,
+      spans: [{ text: `${marker} ` }, ...parseInline(content)],
+      color: defaultColor,
+    };
+  }
+
+  const quote = /^>\s?(.*)$/.exec(sourceLine);
+  if (quote) {
+    const content = quote[1] ?? "";
+    return {
+      text: `│ ${content}`,
+      spans: [{ text: "│ ", color: "gray" }, ...parseInline(content)],
+      color: "gray",
+    };
+  }
+
+  return { text: sourceLine, spans: parseInline(sourceLine), color: defaultColor };
+}
+
+function parseInline(value: string): readonly MarkdownSpan[] {
+  const spans: MarkdownSpan[] = [];
+  let remaining = value;
+
+  while (remaining) {
+    const match =
+      /(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__|~~[^~]+~~|\*[^*]+\*|_[^_]+_|\[[^\]]+\]\([^\s)]+\))/.exec(
+        remaining,
+      );
+    if (!match || match.index === undefined) {
+      spans.push({ text: remaining });
+      break;
+    }
+
+    if (match.index > 0) {
+      spans.push({ text: remaining.slice(0, match.index) });
+    }
+
+    const token = match[0];
+    if (token.startsWith("`")) {
+      spans.push({ text: token.slice(1, -1), color: "gray" });
+    } else if (token.startsWith("**") || token.startsWith("__")) {
+      spans.push({ text: token.slice(2, -2), bold: true });
+    } else if (token.startsWith("~~")) {
+      spans.push({ text: token.slice(2, -2), strikethrough: true });
+    } else if (token.startsWith("[") && token.includes("](")) {
+      const [, label = "", url = ""] = /^\[([^\]]+)\]\(([^\s)]+)\)$/.exec(token) ?? [];
+      spans.push({ text: label, color: "cyan" }, { text: ` <${url}>`, color: "gray" });
+    } else {
+      spans.push({ text: token.slice(1, -1), italic: true });
+    }
+
+    remaining = remaining.slice(match.index + token.length);
+  }
+
+  return spans;
+}
+
+function wrapMarkdownSpans(
+  spans: readonly MarkdownSpan[],
+  maxWidth: number,
+): readonly MarkdownSpan[][] {
+  const width = Math.max(1, maxWidth);
+  const lines: MarkdownSpan[][] = [];
+  let line: MarkdownSpan[] = [];
+  let lineWidth = 0;
+
+  const append = (span: MarkdownSpan): void => {
+    const previous = line.at(-1);
+    if (previous && sameStyle(previous, span)) {
+      previous.text += span.text;
+    } else {
+      line.push({ ...span });
+    }
+    lineWidth += span.text.length;
+  };
+  const pushLine = (): void => {
+    const lastSpan = line.at(-1);
+    if (lastSpan?.text.endsWith(" ")) {
+      lastSpan.text = lastSpan.text.slice(0, -1);
+    }
+    lines.push(line);
+    line = [];
+    lineWidth = 0;
+  };
+
+  for (const span of spans) {
+    for (const token of span.text.replace(/\s+/g, " ").split(/( )/)) {
+      if (!token) {
+        continue;
+      }
+      if (token === " ") {
+        if (lineWidth > 0 && lineWidth < width) {
+          append({ ...span, text: " " });
+        }
+        continue;
+      }
+
+      let word = token;
+      if (lineWidth > 0 && lineWidth + word.length > width) {
+        pushLine();
+      }
+      while (word.length > width) {
+        append({ ...span, text: word.slice(0, width - lineWidth) });
+        pushLine();
+        word = word.slice(width);
+      }
+      append({ ...span, text: word });
+    }
+  }
+
+  if (line.length > 0 || lines.length === 0) {
+    lines.push(line);
+  }
+  return lines;
+}
+
+function sameStyle(left: MarkdownSpan, right: MarkdownSpan): boolean {
+  return (
+    left.bold === right.bold &&
+    left.italic === right.italic &&
+    left.strikethrough === right.strikethrough &&
+    left.color === right.color
+  );
+}


### PR DESCRIPTION
## Summary

- Adds terminal-friendly Markdown rendering for task-detail descriptions and comments.
- Supports headings, emphasis, strikethrough, inline/fenced code, lists, quotes, and links.
- Keeps unsupported HTML visible literally and preserves existing wrapping/scrolling.

## Verification

- `make pre-pr`

Task: #task-60436e3d
