### PR TITLE
fix: show task ID in task details screen

### DIFF
--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -10,44 +10,6 @@ describe("task commands", () => {
     process.exitCode = undefined;
   });
 
-  it("displays the task ID in task details", async () => {
-    const invokeDaemonMock = vi.fn(async (method: string) => {
-      if (method === "task.get") {
-        return {
-          ok: true,
-          value: {
-            id: "task-1",
-            title: "Task details",
-            status: "active",
-            priority: "medium",
-            projectId: "proj-1",
-            labels: [],
-            assigneeActorIds: [],
-            assignees: [],
-            createdAt: "2026-03-01T00:00:00.000Z",
-            updatedAt: "2026-03-01T00:00:00.000Z",
-            notes: [],
-          },
-        };
-      }
-      if (method === "project.list" || method === "actor.list") {
-        return { ok: true, value: [] };
-      }
-
-      throw new Error(`Unexpected method: ${method}`);
-    });
-    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const program = new Command();
-    program.name("todu").option("--format <type>", "output format (text or json)", "text");
-    registerTaskCommands(program, invokeDaemon);
-
-    await program.parseAsync(["task", "show", "task-1"], { from: "user" });
-
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ID:          task-1"));
-  });
-
   it("passes actor assignee updates through on task update", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "task.update") {

--- a/packages/cli/src/commands/task.test.ts
+++ b/packages/cli/src/commands/task.test.ts
@@ -10,6 +10,44 @@ describe("task commands", () => {
     process.exitCode = undefined;
   });
 
+  it("displays the task ID in task details", async () => {
+    const invokeDaemonMock = vi.fn(async (method: string) => {
+      if (method === "task.get") {
+        return {
+          ok: true,
+          value: {
+            id: "task-1",
+            title: "Task details",
+            status: "active",
+            priority: "medium",
+            projectId: "proj-1",
+            labels: [],
+            assigneeActorIds: [],
+            assignees: [],
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:00:00.000Z",
+            notes: [],
+          },
+        };
+      }
+      if (method === "project.list" || method === "actor.list") {
+        return { ok: true, value: [] };
+      }
+
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const invokeDaemon = invokeDaemonMock as unknown as CliDaemonInvoker;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const program = new Command();
+    program.name("todu").option("--format <type>", "output format (text or json)", "text");
+    registerTaskCommands(program, invokeDaemon);
+
+    await program.parseAsync(["task", "show", "task-1"], { from: "user" });
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ID:          task-1"));
+  });
+
   it("passes actor assignee updates through on task update", async () => {
     const invokeDaemonMock = vi.fn(async (method: string) => {
       if (method === "task.update") {

--- a/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
@@ -50,6 +50,7 @@ describe("TaskDetailPane", () => {
     expect(frame).toContain("Implement a clear task detail hierarchy");
     expect(frame).toContain("Description");
     expect(frame).toContain("Metadata");
+    expect(frame).toContain("ID: task-1");
     expect(frame).toContain("doing • med • todu • #tui #layout");
     expect(frame).toContain("Comments");
     expect(frame).toContain("Erik:");

--- a/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.test.tsx
@@ -56,8 +56,8 @@ describe("TaskDetailPane", () => {
     expect(frame).toContain("Erik:");
     expect(frame).toContain("Erik: Comment 1 provides additional");
     expect(frame).toContain("implementation context.");
-    expect(frame.indexOf("Description")).toBeLessThan(frame.indexOf("Metadata"));
-    expect(frame.indexOf("Metadata")).toBeLessThan(frame.indexOf("Comments"));
+    expect(frame.indexOf("Metadata")).toBeLessThan(frame.indexOf("Description"));
+    expect(frame.indexOf("Description")).toBeLessThan(frame.indexOf("Comments"));
   });
 
   it("renders supported Markdown in descriptions and comments", () => {

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -125,10 +125,6 @@ export function createTaskDetailLines({
   const description = "description" in task ? (task.description?.trim() ?? "") : "";
   const lines: TaskDetailLine[] = [
     ...createWrappedLines("title", task.title, contentWidth, "white", true),
-    { id: "description-heading", text: "Description", color: "cyan" },
-    ...(description
-      ? createMarkdownDetailLines("description", description, contentWidth)
-      : createWrappedLines("description", "No description.", contentWidth, "gray")),
     { id: "metadata-heading", text: "Metadata", color: "cyan" },
     ...createWrappedLines(
       "metadata",
@@ -136,6 +132,10 @@ export function createTaskDetailLines({
       contentWidth,
       "gray",
     ),
+    { id: "description-heading", text: "Description", color: "cyan" },
+    ...(description
+      ? createMarkdownDetailLines("description", description, contentWidth)
+      : createWrappedLines("description", "No description.", contentWidth, "gray")),
     { id: "comments-heading", text: "Comments", color: "cyan" },
   ];
 

--- a/packages/tui/src/components/tasks/TaskDetailPane.tsx
+++ b/packages/tui/src/components/tasks/TaskDetailPane.tsx
@@ -130,7 +130,12 @@ export function createTaskDetailLines({
       ? createMarkdownDetailLines("description", description, contentWidth)
       : createWrappedLines("description", "No description.", contentWidth, "gray")),
     { id: "metadata-heading", text: "Metadata", color: "cyan" },
-    ...createWrappedLines("metadata", formatTaskMetadata(task, projectName), contentWidth, "gray"),
+    ...createWrappedLines(
+      "metadata",
+      `ID: ${task.id} • ${formatTaskMetadata(task, projectName)}`,
+      contentWidth,
+      "gray",
+    ),
     { id: "comments-heading", text: "Comments", color: "cyan" },
   ];
 


### PR DESCRIPTION
## Summary

- display the selected task ID in the TUI task details metadata
- place metadata above the description so identifying information stays at the top
- preserve the compact metadata layout and add regression coverage

## Verification

- `npm run test -- packages/tui/src/components/tasks/TaskDetailPane.test.tsx packages/tui/src/screens/TasksScreen.test.tsx`
- `make pre-pr`

Task: #task-05f052a8