### PR TITLE
feat: compose task comments in terminal editor

### DIFF
--- a/.changeset/smart-editors-comment.md
+++ b/.changeset/smart-editors-comment.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": minor
+---
+
+Open the configured terminal editor when composing task comments.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -270,7 +270,7 @@ The current TUI implements these global navigation and task-list movement keys:
 - `w`: Mark the selected task waiting.
 - `d`: Complete the selected task.
 - `x`: Cancel the selected task after confirmation.
-- `c`: Open a focused input to add a comment to the selected task.
+- `c`: Open the configured `VISUAL` or `EDITOR` terminal editor to add a comment to the selected task.
 
 ### MVP Task Actions
 
@@ -278,7 +278,7 @@ The current TUI implements these global navigation and task-list movement keys:
 - Mark waiting: set status to `waiting`.
 - Complete task: set status to `done`.
 - Cancel task: confirm, then set status to `cancelled`.
-- Add comment: open one-line or multiline modal.
+- Add comment: suspend the TUI while the configured terminal editor composes the comment, then submit non-empty saved content.
 - Refresh: manual refetch.
 
 ## Screens

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -302,7 +302,7 @@ describe("App", () => {
     expect(lastFrame()).toContain("Ctrl+C Quit");
   });
 
-  it("updates the footer for comment and cancellation modals", async () => {
+  it("updates the footer for cancellation confirmation", async () => {
     const { stdin, lastFrame } = render(
       <App
         connection={createFakeConnection(createConnectedSnapshot())}
@@ -311,16 +311,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Ship");
-    stdin.write("c");
-    await waitForFrameText(lastFrame, "Comment on Ship");
-    expect(lastFrame()).toContain("Enter Submit");
-    expect(lastFrame()).toContain("Esc Cancel");
-
-    stdin.write("\u001B");
-    await waitForFrameText(lastFrame, "Cancelled comment.");
-    await waitForFrameText(lastFrame, "↑↓ Select");
-    expect(lastFrame()).toContain("← Projects");
-    expect(lastFrame()).toContain("Enter Details");
+    expect(lastFrame()).toContain("c Comment");
 
     stdin.write("x");
     await waitForFrameText(lastFrame, "Cancel selected task?");

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -23,7 +23,7 @@ export const globalKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "w", description: "Wait" },
   { keys: "d", description: "Done" },
   { keys: "x", description: "Cancel" },
-  { keys: "c", description: "Comment" },
+  { keys: "c", description: "Comment in editor" },
   { keys: "a", description: "All Projects" },
   { keys: "y/n", description: "Confirm/Cancel" },
   { keys: "Ctrl+F", description: "Filter list" },
@@ -34,7 +34,6 @@ export type TasksFooterContext =
   | "tasks-list"
   | "tasks-projects"
   | "task-detail"
-  | "comment-modal"
   | "cancel-confirmation"
   | "filter-modal";
 
@@ -45,6 +44,7 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
     { keys: "↑↓", description: "Select" },
     { keys: "←", description: "Projects" },
     { keys: "Enter", description: "Details" },
+    { keys: "c", description: "Comment" },
     { keys: "?", description: "Help" },
     { keys: "q", description: "Quit" },
   ],
@@ -60,6 +60,7 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
     { keys: "Esc", description: "Back" },
     { keys: "s", description: "Start" },
     { keys: "d", description: "Done" },
+    { keys: "c", description: "Comment" },
     { keys: "?", description: "Help" },
   ],
   projects: [
@@ -74,10 +75,6 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
     { keys: "q", description: "Quit" },
   ],
   help: [{ keys: "q", description: "Back" }],
-  "comment-modal": [
-    { keys: "Enter", description: "Submit" },
-    { keys: "Esc", description: "Cancel" },
-  ],
   "cancel-confirmation": [
     { keys: "y", description: "Confirm" },
     { keys: "n/Esc", description: "Cancel" },

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -4,13 +4,12 @@ import { HelpBar } from "./HelpBar.js";
 
 describe("HelpBar", () => {
   it.each([
-    ["tasks-list", ["↑↓ Select", "← Projects", "Enter Details", "? Help", "q Quit"]],
+    ["tasks-list", ["↑↓ Select", "← Projects", "Enter Details", "c Comment", "? Help", "q Quit"]],
     ["tasks-projects", ["↑↓ Select", "→ Tasks", "Enter Focus", "? Help", "q Quit"]],
-    ["task-detail", ["↑↓ Scroll", "Esc Back", "s Start", "d Done", "? Help"]],
+    ["task-detail", ["↑↓ Scroll", "Esc Back", "s Start", "d Done", "c Comment", "? Help"]],
     ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
     ["data-status", ["? Help", "q Quit"]],
     ["help", ["q Back"]],
-    ["comment-modal", ["Enter Submit", "Esc Cancel"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],
     ["filter-modal", ["↑↓ Select", "Space Toggle", "←→ Priority", "Enter Apply"]],
   ] as const)("shows concise %s shortcuts", (context, expected) => {

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -316,53 +316,39 @@ describe("TasksScreen", () => {
     await waitForFrameText(lastFrame, "Cannot update task status");
   });
 
-  it("opens comment input and submits a non-empty selected-task comment", async () => {
+  it("launches the comment editor and submits its non-empty content", async () => {
     const client = createClient();
+    const composeComment = vi.fn().mockReturnValue("New task context");
     const { stdin, lastFrame } = renderWithQuery(
-      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        composeComment={composeComment}
+      />,
     );
 
     await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
-    await waitForFrameText(lastFrame, "Comment on First task");
-    stdin.write("New task context");
-    await waitForFrameText(lastFrame, "New task context_");
-    stdin.write("\r");
 
     await waitForFrameText(lastFrame, "Comment added: First task");
+    expect(composeComment).toHaveBeenCalledOnce();
     expect(client.task.createComment).toHaveBeenCalledWith("task-1", "New task context");
   });
 
-  it("rejects empty comments without sending a mutation", async () => {
+  it("treats empty editor content as cancellation without sending a mutation", async () => {
     const client = createClient();
     const { stdin, lastFrame } = renderWithQuery(
-      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        composeComment={() => "   "}
+      />,
     );
 
     await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
-    await waitForFrameText(lastFrame, "Comment on First task");
-    stdin.write("   ");
-    stdin.write("\r");
-
-    await waitForFrameText(lastFrame, "Comment cannot be empty.");
-    expect(client.task.createComment).not.toHaveBeenCalled();
-  });
-
-  it("cancels comment input without sending a mutation", async () => {
-    const client = createClient();
-    const { stdin, lastFrame } = renderWithQuery(
-      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
-    );
-
-    await waitForFrameText(lastFrame, "First task");
-    stdin.write("c");
-    await waitForFrameText(lastFrame, "Comment on First task");
-    stdin.write("Draft comment");
-    stdin.write("\u001B");
 
     await waitForFrameText(lastFrame, "Cancelled comment.");
-    expect(lastFrame()).not.toContain("Comment on First task");
     expect(client.task.createComment).not.toHaveBeenCalled();
   });
 
@@ -375,14 +361,20 @@ describe("TasksScreen", () => {
         createComment: vi.fn(),
       },
     });
+    const composeComment = vi.fn();
     const { stdin, lastFrame } = renderWithQuery(
-      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        composeComment={composeComment}
+      />,
     );
 
     await waitForFrameText(lastFrame, "No active, in-progress, or waiting");
     stdin.write("c");
 
     await waitForFrameText(lastFrame, "No task selected for comment.");
+    expect(composeComment).not.toHaveBeenCalled();
     expect(client.task.createComment).not.toHaveBeenCalled();
   });
 
@@ -393,6 +385,7 @@ describe("TasksScreen", () => {
         client={client}
         projectFilter={allProjectsFilter}
         statusActionsEnabled={false}
+        composeComment={vi.fn()}
       />,
     );
 
@@ -400,7 +393,25 @@ describe("TasksScreen", () => {
     stdin.write("c");
 
     await waitForFrameText(lastFrame, "Task actions unavailable while daemon is disconnected.");
-    expect(lastFrame()).not.toContain("Comment on First task");
+    expect(client.task.createComment).not.toHaveBeenCalled();
+  });
+
+  it("renders clear comment editor launch errors", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        composeComment={() => {
+          throw new Error('Failed to launch terminal editor "missing-editor": command not found');
+        }}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "First task");
+    stdin.write("c");
+
+    await waitForFrameText(lastFrame, "Failed to launch terminal editor");
     expect(client.task.createComment).not.toHaveBeenCalled();
   });
 
@@ -415,15 +426,15 @@ describe("TasksScreen", () => {
       }),
     );
     const { stdin, lastFrame } = renderWithQuery(
-      <TasksScreen client={client} projectFilter={allProjectsFilter} />,
+      <TasksScreen
+        client={client}
+        projectFilter={allProjectsFilter}
+        composeComment={() => "New task context"}
+      />,
     );
 
     await waitForFrameText(lastFrame, "First task");
     stdin.write("c");
-    await waitForFrameText(lastFrame, "Comment on First task");
-    stdin.write("New task context");
-    await waitForFrameText(lastFrame, "New task context_");
-    stdin.write("\r");
 
     await waitForFrameText(lastFrame, "Cannot add comment");
   });

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -1,18 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import type { Project, TaskStatus } from "@todu/core";
-import { Box, Text, useInput, useStdout } from "ink";
+import type { Project, Task, TaskStatus } from "@todu/core";
+import { Box, Text, useApp, useInput, useStdout } from "ink";
 import type { JSX } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { TasksFooterContext } from "../app/keymap.js";
 import { ConfirmDialog } from "../components/ConfirmDialog.js";
 import { ListFilterModal } from "../components/ListFilterModal.js";
 import { Pane } from "../components/Pane.js";
-import { TextInputModal } from "../components/TextInputModal.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
 import { TaskDetailPane } from "../components/tasks/TaskDetailPane.js";
 import { getVisibleTaskWindow, TaskListPane } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
-import { normalizeCommentContent } from "../state/comment-actions.js";
+import { composeTaskComment, normalizeCommentContent } from "../state/comment-actions.js";
 import {
   createProjectListQuery,
   createTaskListQuery,
@@ -45,6 +44,7 @@ export interface TasksScreenProps {
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
   onProjectFilterChange?: (filter: ProjectFilterState) => void;
   onFooterContextChange?: (context: TasksFooterContext) => void;
+  composeComment?: () => string | null;
 }
 
 const ALL_PROJECTS_OPTION_ID = "__all__";
@@ -89,10 +89,12 @@ export function TasksScreen({
   onGlobalInputEnabledChange,
   onProjectFilterChange,
   onFooterContextChange,
+  composeComment = composeTaskComment,
 }: TasksScreenProps): JSX.Element {
   const taskListFilter = taskListFilterProp ?? defaultTaskListFilter;
   const projectListFilter = projectListFilterProp ?? defaultProjectListFilter;
   const queryClient = useQueryClient();
+  const { suspendTerminal } = useApp();
   const { stdout } = useStdout();
   const [selectedProjectOptionId, setSelectedProjectOptionId] = useState<string>(
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
@@ -101,9 +103,6 @@ export function TasksScreen({
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [taskDetailOpen, setTaskDetailOpen] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
-  const [commentModalOpen, setCommentModalOpen] = useState(false);
-  const [commentText, setCommentText] = useState("");
-  const [commentError, setCommentError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
   const [filterModalTarget, setFilterModalTarget] = useState<PaneFocus | null>(null);
   const projectListQuery = createProjectListQuery(projectListFilter);
@@ -188,12 +187,11 @@ export function TasksScreen({
   }, [tasksQuery.data]);
 
   useEffect(() => {
-    onGlobalInputEnabledChange?.(!commentModalOpen && !confirmCancel && !filterModalTarget);
+    onGlobalInputEnabledChange?.(!confirmCancel && !filterModalTarget);
     return () => onGlobalInputEnabledChange?.(true);
-  }, [commentModalOpen, confirmCancel, filterModalTarget, onGlobalInputEnabledChange]);
+  }, [confirmCancel, filterModalTarget, onGlobalInputEnabledChange]);
 
   const footerContext = resolveTasksFooterContext({
-    commentModalOpen,
     confirmCancel,
     filterModalTarget,
     focusedPane,
@@ -218,72 +216,43 @@ export function TasksScreen({
     }
   };
 
-  const submitComment = async (): Promise<void> => {
-    if (!selectedTask) {
-      setCommentModalOpen(false);
-      setFeedback({ message: "No task selected for comment.", tone: "error" });
-      return;
-    }
-
-    if (!statusActionsEnabled) {
-      setCommentError("Task actions unavailable while daemon is disconnected.");
-      return;
-    }
-
-    const content = normalizeCommentContent(commentText);
-    if (!content) {
-      setCommentError("Comment cannot be empty.");
-      return;
-    }
-
+  const submitComment = async (task: Task, content: string): Promise<void> => {
     try {
-      await commentMutation.mutateAsync({ taskId: selectedTask.id, content });
-      setCommentModalOpen(false);
-      setCommentText("");
-      setCommentError(null);
-      setFeedback({ message: `Comment added: ${selectedTask.title}`, tone: "success" });
+      await commentMutation.mutateAsync({ taskId: task.id, content });
+      setFeedback({ message: `Comment added: ${task.title}`, tone: "success" });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.task(selectedTask.id) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.taskComments(selectedTask.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.task(task.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.taskComments(task.id) }),
       ]);
     } catch (error) {
-      setCommentError(formatToduClientError(error));
+      setFeedback({ message: formatToduClientError(error), tone: "error" });
     }
   };
 
-  const closeCommentModal = (): void => {
-    setCommentModalOpen(false);
-    setCommentText("");
-    setCommentError(null);
-    setFeedback({ message: "Cancelled comment.", tone: "info" });
+  const openCommentEditor = async (task: Task): Promise<void> => {
+    onGlobalInputEnabledChange?.(false);
+
+    try {
+      let composedContent: string | null = null;
+      await suspendTerminal(() => {
+        composedContent = composeComment();
+      });
+      const content = normalizeCommentContent(composedContent ?? "");
+      if (!content) {
+        setFeedback({ message: "Cancelled comment.", tone: "info" });
+        return;
+      }
+
+      await submitComment(task, content);
+    } catch (error) {
+      setFeedback({ message: formatToduClientError(error), tone: "error" });
+    } finally {
+      onGlobalInputEnabledChange?.(true);
+    }
   };
 
   useInput((input, key) => {
     if (filterModalTarget) {
-      return;
-    }
-
-    if (commentModalOpen) {
-      if (key.escape) {
-        closeCommentModal();
-        return;
-      }
-
-      if (key.return) {
-        void submitComment();
-        return;
-      }
-
-      if (key.backspace || key.delete) {
-        setCommentText((current) => current.slice(0, -1));
-        setCommentError(null);
-        return;
-      }
-
-      if (!key.ctrl && !key.meta && input.length > 0) {
-        setCommentText((current) => `${current}${input}`);
-        setCommentError(null);
-      }
       return;
     }
 
@@ -384,10 +353,8 @@ export function TasksScreen({
         return;
       }
 
-      setCommentModalOpen(true);
-      setCommentText("");
-      setCommentError(null);
       setFeedback(null);
+      void openCommentEditor(selectedTask);
       return;
     }
 
@@ -582,7 +549,7 @@ export function TasksScreen({
               error={selectedDetailQuery.error ?? commentsQuery.error}
               maxContentWidth={detailContentWidth}
               maxContentRows={detailContentRows}
-              scrollEnabled={!commentModalOpen && !confirmCancel}
+              scrollEnabled={!confirmCancel}
             />
           ) : null}
         </Box>
@@ -609,14 +576,6 @@ export function TasksScreen({
             setFilterModalTarget(null);
           }}
           onCancel={() => setFilterModalTarget(null)}
-        />
-      ) : null}
-      {commentModalOpen ? (
-        <TextInputModal
-          title={selectedTask ? `Comment on ${selectedTask.title}` : "Comment"}
-          value={commentText}
-          placeholder="Write a task comment…"
-          error={commentError}
         />
       ) : null}
       {confirmCancel ? <ConfirmDialog message="Cancel selected task?" /> : null}
@@ -725,13 +684,11 @@ function truncateProjectLabel(label: string, maxLength = 24): string {
 }
 
 function resolveTasksFooterContext({
-  commentModalOpen,
   confirmCancel,
   filterModalTarget,
   focusedPane,
   taskDetailOpen,
 }: {
-  commentModalOpen: boolean;
   confirmCancel: boolean;
   filterModalTarget: PaneFocus | null;
   focusedPane: PaneFocus;
@@ -739,10 +696,6 @@ function resolveTasksFooterContext({
 }): TasksFooterContext {
   if (filterModalTarget) {
     return "filter-modal";
-  }
-
-  if (commentModalOpen) {
-    return "comment-modal";
   }
 
   if (confirmCancel) {

--- a/packages/tui/src/state/comment-actions.test.ts
+++ b/packages/tui/src/state/comment-actions.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { normalizeCommentContent } from "./comment-actions.js";
+import { writeFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CommentEditorError,
+  composeTaskComment,
+  normalizeCommentContent,
+} from "./comment-actions.js";
 
 describe("comment actions", () => {
   it("normalizes non-empty comments", () => {
@@ -9,5 +14,55 @@ describe("comment actions", () => {
   it("rejects empty comments", () => {
     expect(normalizeCommentContent("")).toBeNull();
     expect(normalizeCommentContent("   \t  ")).toBeNull();
+  });
+
+  it("returns content saved by the configured visual editor", () => {
+    const spawnEditor = vi.fn((_command: string, args: readonly string[]) => {
+      writeFileSync(args.at(-1) ?? "", "  Composed in the editor\n");
+      return { status: 0, signal: null };
+    });
+
+    expect(
+      composeTaskComment({
+        env: { EDITOR: "ignored", VISUAL: "code --wait" },
+        spawnEditor,
+      }),
+    ).toBe("Composed in the editor");
+    expect(spawnEditor).toHaveBeenCalledWith("code", ["--wait", expect.any(String)]);
+  });
+
+  it("treats unchanged empty editor content as cancellation", () => {
+    expect(
+      composeTaskComment({
+        env: { EDITOR: "nano" },
+        spawnEditor: () => ({ status: 0, signal: null }),
+      }),
+    ).toBeNull();
+  });
+
+  it("reports missing editor configuration", () => {
+    expect(() =>
+      composeTaskComment({
+        env: {},
+        spawnEditor: () => ({ status: 0, signal: null }),
+      }),
+    ).toThrow(new CommentEditorError("No terminal editor configured. Set VISUAL or EDITOR."));
+  });
+
+  it("reports editor launch failures", () => {
+    expect(() =>
+      composeTaskComment({
+        env: { EDITOR: "missing-editor" },
+        spawnEditor: () => ({
+          status: null,
+          signal: null,
+          error: new Error("command not found"),
+        }),
+      }),
+    ).toThrow(
+      new CommentEditorError(
+        'Failed to launch terminal editor "missing-editor": command not found',
+      ),
+    );
   });
 });

--- a/packages/tui/src/state/comment-actions.ts
+++ b/packages/tui/src/state/comment-actions.ts
@@ -1,4 +1,161 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export class CommentEditorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CommentEditorError";
+  }
+}
+
+interface EditorProcessResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+}
+
+export interface ComposeTaskCommentOptions {
+  env?: NodeJS.ProcessEnv;
+  spawnEditor?: (command: string, args: readonly string[]) => EditorProcessResult;
+}
+
 export function normalizeCommentContent(content: string): string | null {
   const trimmed = content.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+export function composeTaskComment({
+  env = process.env,
+  spawnEditor = defaultSpawnEditor,
+}: ComposeTaskCommentOptions = {}): string | null {
+  const configuredEditor = env.VISUAL?.trim() || env.EDITOR?.trim();
+  if (!configuredEditor) {
+    throw new CommentEditorError("No terminal editor configured. Set VISUAL or EDITOR.");
+  }
+
+  const [command, ...editorArgs] = parseEditorCommand(configuredEditor);
+  if (!command) {
+    throw new CommentEditorError("No terminal editor configured. Set VISUAL or EDITOR.");
+  }
+
+  let temporaryDirectory: string | null = null;
+  let content: string | null = null;
+  let failure: unknown;
+
+  try {
+    temporaryDirectory = mkdtempSync(join(tmpdir(), "todu-comment-"));
+    const commentPath = join(temporaryDirectory, "comment.md");
+    writeFileSync(commentPath, "", { encoding: "utf8", mode: 0o600 });
+
+    const result = spawnEditor(command, [...editorArgs, commentPath]);
+    if (result.error) {
+      throw new CommentEditorError(
+        `Failed to launch terminal editor "${command}": ${result.error.message}`,
+      );
+    }
+    if (result.signal) {
+      throw new CommentEditorError(
+        `Terminal editor "${command}" was terminated by ${result.signal}; comment was not added.`,
+      );
+    }
+    if (result.status === null) {
+      throw new CommentEditorError(`Failed to launch terminal editor "${command}".`);
+    }
+    if (result.status !== 0) {
+      throw new CommentEditorError(
+        `Terminal editor "${command}" exited with status ${result.status}; comment was not added.`,
+      );
+    }
+
+    content = normalizeCommentContent(readFileSync(commentPath, "utf8"));
+  } catch (error) {
+    failure =
+      error instanceof CommentEditorError
+        ? error
+        : new CommentEditorError(
+            `Unable to compose task comment with terminal editor "${command}": ${formatError(error)}`,
+          );
+  }
+
+  if (temporaryDirectory) {
+    try {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    } catch (error) {
+      failure ??= new CommentEditorError(
+        `Unable to remove temporary task comment file: ${formatError(error)}`,
+      );
+    }
+  }
+
+  if (failure) {
+    throw failure;
+  }
+
+  return content;
+}
+
+function defaultSpawnEditor(command: string, args: readonly string[]): EditorProcessResult {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  return {
+    status: result.status,
+    signal: result.signal,
+    error: result.error,
+  };
+}
+
+function parseEditorCommand(value: string): readonly string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += character;
+  }
+
+  if (escaped) {
+    current += "\\";
+  }
+  if (quote) {
+    throw new CommentEditorError(`Invalid terminal editor configuration: unmatched ${quote}.`);
+  }
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }


### PR DESCRIPTION
## Summary

- open `VISUAL` or `EDITOR` when adding TUI task comments
- suspend and restore the Ink terminal around editor composition
- skip empty comments and report configuration or launch failures clearly
- update comment key hints, architecture documentation, tests, and the TUI changeset

## Verification

- `make pre-pr`

Task: #task-a339b22c