### PR TITLE
feat: add interactive habits TUI section

### DIFF
--- a/.changeset/tidy-habits-toggle.md
+++ b/.changeset/tidy-habits-toggle.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": minor
+---
+
+Add an interactive habits section with today's check-in state and keyboard toggling.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -258,13 +258,14 @@ The current TUI implements these global navigation and task-list movement keys:
 
 - `1`: Tasks.
 - `2`: Projects.
-- `3`: Data Status.
+- `3`: Habits.
+- `4`: Data Status.
 - `?`: Help.
 - `q`: Back from Help or quit from a root route.
 - `Ctrl+C`: Quit immediately.
-- `j` / `Down Arrow`: Move down in the Tasks or Projects list.
-- `k` / `Up Arrow`: Move up in the Tasks or Projects list.
-- `Enter`: Select the focused project and open Tasks filtered by that project.
+- `j` / `Down Arrow`: Move down in the Tasks, Projects, or Habits list.
+- `k` / `Up Arrow`: Move up in the Tasks, Projects, or Habits list.
+- `Enter`: Select the focused project and open Tasks filtered by that project, or toggle the focused habit's check-in.
 - `a`: Clear the project filter and open Tasks for all projects.
 - `s`: Start the selected task (`inprogress`).
 - `w`: Mark the selected task waiting.
@@ -299,23 +300,27 @@ The current TUI implements these global navigation and task-list movement keys:
    - `a` clears the filter and returns to all-project Tasks.
    - The active project filter is shown in the shell status line.
 
-3. **Task detail**
+3. **Habits**
+   - Active habit list with today's completion state.
+   - `j` / `k` and arrow-key selection.
+   - `Enter` toggles today's check-in and refreshes the displayed checkbox.
+
+4. **Task detail**
    - Full title, status, priority, project, labels, assignees.
    - Description rendered as terminal markdown where practical.
    - Recent comments/notes.
    - Status/comment actions.
 
-4. **Help / command palette**
+5. **Help / command palette**
    - Discoverable shortcuts.
    - Command execution for less common actions.
 
-5. **Connection/error screen**
+6. **Connection/error screen**
    - Shows daemon unavailable, reconnecting, protocol mismatch, or timeout.
    - Gives command guidance such as `todu daemon start`.
 
 ### Later Screens
 
-- Habits.
 - Recurring templates.
 - Journal/notes.
 - Approvals.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -266,6 +266,7 @@ The current TUI implements these global navigation and task-list movement keys:
 - `j` / `Down Arrow`: Move down in the Tasks, Projects, or Habits list.
 - `k` / `Up Arrow`: Move up in the Tasks, Projects, or Habits list.
 - `Enter`: Select the focused project and open Tasks filtered by that project, or toggle the focused habit's check-in.
+- `Space`: Toggle the focused habit's check-in.
 - `a`: Clear the project filter and open Tasks for all projects.
 - `s`: Start the selected task (`inprogress`).
 - `w`: Mark the selected task waiting.
@@ -303,7 +304,7 @@ The current TUI implements these global navigation and task-list movement keys:
 3. **Habits**
    - Active habit list with today's completion state.
    - `j` / `k` and arrow-key selection.
-   - `Enter` toggles today's check-in and refreshes the displayed checkbox.
+   - `Enter` or `Space` toggles today's check-in and refreshes the displayed checkbox.
 
 4. **Task detail**
    - Full title, status, priority, project, labels, assignees.

--- a/docs/plans/tui/architecture.md
+++ b/docs/plans/tui/architecture.md
@@ -256,9 +256,9 @@ The TUI should be optimized for fast keyboard workflows.
 
 The current TUI implements these global navigation and task-list movement keys:
 
-- `1`: Tasks.
-- `2`: Projects.
-- `3`: Habits.
+- `1`: Habits (the default startup screen).
+- `2`: Tasks.
+- `3`: Projects.
 - `4`: Data Status.
 - `?`: Help.
 - `q`: Back from Help or quit from a root route.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -183,17 +183,16 @@ describe("App", () => {
 
     const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
 
-    expect(lastFrame()).toContain("Tasks");
+    expect(lastFrame()).toContain("Habits");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("Daemon unavailable");
     expect(lastFrame()).toContain("todu daemon start");
-    expect(lastFrame()).toContain("1 Tasks");
-    expect(lastFrame()).toContain("2 Projects");
-    expect(lastFrame()).toContain("3 Habits");
+    expect(lastFrame()).toContain("1 Habits");
+    expect(lastFrame()).toContain("2 Tasks");
+    expect(lastFrame()).toContain("3 Projects");
     expect(lastFrame()).toContain("4 Data Status");
     expect(lastFrame()).toContain("↑↓ Select");
-    expect(lastFrame()).toContain("← Projects");
-    expect(lastFrame()).toContain("Enter Details");
+    expect(lastFrame()).toContain("Enter/Space Toggle");
   });
 
   it("shows connected daemon status without body handshake diagnostics", async () => {
@@ -204,8 +203,9 @@ describe("App", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Ship");
+    await waitForFrameText(lastFrame, "Meditate");
 
+    expect(lastFrame()).toContain("Habits (1)");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).not.toContain("Daemon: connected");
     expect(lastFrame()).not.toContain("Daemon connected");
@@ -221,21 +221,20 @@ describe("App", () => {
       />,
     );
 
+    await waitForFrameText(lastFrame, "Meditate");
+    expect(lastFrame()).toContain("Habits (1)");
+
+    stdin.write("2");
     await waitForFrameText(lastFrame, "Ship");
     expect(lastFrame()).toContain("Tasks");
 
-    stdin.write("2");
+    stdin.write("3");
     await waitForFrameText(lastFrame, "Project detail");
     expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("Enter Open Tasks");
     expect(lastFrame()).toContain("a All Projects");
-
-    stdin.write("3");
-    await waitForFrameText(lastFrame, "Meditate");
-    expect(lastFrame()).toContain("Habits (1)");
-    expect(lastFrame()).toContain("Enter/Space Toggle");
 
     stdin.write("4");
     await waitForFrameText(lastFrame, "Data status ready");
@@ -251,9 +250,10 @@ describe("App", () => {
       <App connection={createFakeConnection(createConnectedSnapshot())} toduClient={client} />,
     );
 
-    await waitForFrameText(lastFrame, "Ship");
-    stdin.write("2");
+    await waitForFrameText(lastFrame, "Meditate");
+    stdin.write("3");
     await waitForFrameText(lastFrame, "Project detail");
+    await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
     await waitForFrameText(lastFrame, "Default project");
     stdin.write("\r");
@@ -273,6 +273,8 @@ describe("App", () => {
       <App connection={createFakeConnection(createConnectedSnapshot())} toduClient={client} />,
     );
 
+    await waitForFrameText(lastFrame, "Meditate");
+    stdin.write("2");
     await waitForFrameText(lastFrame, "Ship");
     stdin.write("h");
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -295,15 +297,16 @@ describe("App", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Ship");
-    stdin.write("2");
+    await waitForFrameText(lastFrame, "Meditate");
+    stdin.write("3");
     await waitForFrameText(lastFrame, "Project detail");
+    await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
     await waitForFrameText(lastFrame, "Default project");
     stdin.write("\r");
     await waitForFrameText(lastFrame, "Open · Any priority · Inbox");
 
-    stdin.write("2");
+    stdin.write("3");
     await waitForFrameText(lastFrame, "Project detail");
     stdin.write("a");
     await waitForFrameText(lastFrame, "Open · Any priority · All Projects");
@@ -320,7 +323,7 @@ describe("App", () => {
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
 
-    expect(lastFrame()).toContain("1/2/3/4 Tasks/Projects/Habits/Data Status");
+    expect(lastFrame()).toContain("1/2/3/4 Habits/Tasks/Projects/Data Status");
     expect(lastFrame()).toContain("?      Help");
     expect(lastFrame()).toContain("j/↓    Down");
     expect(lastFrame()).toContain("Enter  Select/Open/Submit");
@@ -340,6 +343,8 @@ describe("App", () => {
       />,
     );
 
+    await waitForFrameText(lastFrame, "Meditate");
+    stdin.write("2");
     await waitForFrameText(lastFrame, "Ship");
     expect(lastFrame()).toContain("c Comment");
 
@@ -359,7 +364,7 @@ describe("App", () => {
       />,
     );
 
-    stdin.write("2");
+    stdin.write("3");
     await waitForFrameText(lastFrame, "Project detail");
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
@@ -375,7 +380,8 @@ describe("App", () => {
   it("refetches active task data when data.changed is received", async () => {
     const connection = createFakeConnection(createConnectedSnapshot());
     const client = createFakeClient();
-    render(<App connection={connection} toduClient={client} />);
+    const { stdin } = render(<App connection={connection} toduClient={client} />);
+    stdin.write("2");
 
     await vi.waitFor(() => {
       expect(client.task.list).toHaveBeenCalledTimes(1);
@@ -395,8 +401,12 @@ describe("App", () => {
 
   it("resubscribes and keeps task data visible across reconnect", async () => {
     const connection = createFakeConnection(createConnectedSnapshot());
-    const { lastFrame } = render(<App connection={connection} toduClient={createFakeClient()} />);
+    const { stdin, lastFrame } = render(
+      <App connection={connection} toduClient={createFakeClient()} />,
+    );
 
+    await waitForFrameText(lastFrame, "Meditate");
+    stdin.write("2");
     await waitForFrameText(lastFrame, "Ship");
     await vi.waitFor(() => {
       expect(connection.request).toHaveBeenCalledTimes(1);

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -134,6 +134,30 @@ function createFakeClient(): TuiToduClient {
       createComment: vi.fn(),
     },
     note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    habit: {
+      list: vi.fn().mockImplementation((filter = {}) =>
+        Promise.resolve(
+          filter.checkedToday
+            ? []
+            : [
+                {
+                  id: "hab-1",
+                  title: "Meditate",
+                  projectId: "project-1",
+                  schedule: "FREQ=DAILY",
+                  timezone: "America/Chicago",
+                  startDate: "2026-07-01",
+                  nextDue: "2026-07-20",
+                  paused: false,
+                  createdAt: "2026-07-01T00:00:00.000Z",
+                  updatedAt: "2026-07-01T00:00:00.000Z",
+                },
+              ],
+        ),
+      ),
+      check: vi.fn().mockResolvedValue({ date: "2026-07-20", completed: true }),
+      uncheck: vi.fn().mockResolvedValue({ date: "2026-07-20", completed: false }),
+    },
     sync: {
       status: vi
         .fn()
@@ -165,7 +189,8 @@ describe("App", () => {
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Tasks");
     expect(lastFrame()).toContain("2 Projects");
-    expect(lastFrame()).toContain("3 Data Status");
+    expect(lastFrame()).toContain("3 Habits");
+    expect(lastFrame()).toContain("4 Data Status");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("← Projects");
     expect(lastFrame()).toContain("Enter Details");
@@ -208,6 +233,11 @@ describe("App", () => {
     expect(lastFrame()).toContain("a All Projects");
 
     stdin.write("3");
+    await waitForFrameText(lastFrame, "Meditate");
+    expect(lastFrame()).toContain("Habits (1)");
+    expect(lastFrame()).toContain("Enter Toggle");
+
+    stdin.write("4");
     await waitForFrameText(lastFrame, "Data status ready");
     expect(lastFrame()).toContain("Projects: 1");
     expect(lastFrame()).toContain("? Help");
@@ -290,7 +320,7 @@ describe("App", () => {
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
 
-    expect(lastFrame()).toContain("1/2/3  Tasks/Projects/Data Status");
+    expect(lastFrame()).toContain("1/2/3/4 Tasks/Projects/Habits/Data Status");
     expect(lastFrame()).toContain("?      Help");
     expect(lastFrame()).toContain("j/↓    Down");
     expect(lastFrame()).toContain("Enter  Select/Open/Submit");

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -235,7 +235,7 @@ describe("App", () => {
     stdin.write("3");
     await waitForFrameText(lastFrame, "Meditate");
     expect(lastFrame()).toContain("Habits (1)");
-    expect(lastFrame()).toContain("Enter Toggle");
+    expect(lastFrame()).toContain("Enter/Space Toggle");
 
     stdin.write("4");
     await waitForFrameText(lastFrame, "Data status ready");

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "../daemon/connection.js";
 import { createTuiToduClient, type TuiToduClient } from "../daemon/todu-client.js";
 import { DataStatusScreen } from "../screens/DataStatusScreen.js";
+import { HabitsScreen } from "../screens/HabitsScreen.js";
 import { HelpScreen } from "../screens/HelpScreen.js";
 import { ProjectsScreen } from "../screens/ProjectsScreen.js";
 import { TasksScreen } from "../screens/TasksScreen.js";
@@ -249,6 +250,12 @@ function RouteScreen({
         onGlobalInputEnabledChange={onGlobalInputEnabledChange}
         dataQueriesEnabled={dataQueriesEnabled}
       />
+    ) : null;
+  }
+
+  if (route === "habits") {
+    return canShowDataScreens ? (
+      <HabitsScreen client={toduClient} dataQueriesEnabled={dataQueriesEnabled} />
     ) : null;
   }
 

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -6,14 +6,14 @@ export interface TuiKeyBinding {
 }
 
 export const primaryRouteKeyBindings: readonly TuiKeyBinding[] = [
-  { keys: "1", description: "Tasks" },
-  { keys: "2", description: "Projects" },
-  { keys: "3", description: "Habits" },
+  { keys: "1", description: "Habits" },
+  { keys: "2", description: "Tasks" },
+  { keys: "3", description: "Projects" },
   { keys: "4", description: "Data Status" },
 ] as const;
 
 export const globalKeyBindings: readonly TuiKeyBinding[] = [
-  { keys: "1/2/3/4", description: "Tasks/Projects/Habits/Data Status" },
+  { keys: "1/2/3/4", description: "Habits/Tasks/Projects/Data Status" },
   { keys: "?", description: "Help" },
   { keys: "q", description: "Back/Quit" },
   { keys: "j/↓", description: "Down" },
@@ -118,15 +118,15 @@ export function resolveGlobalKeyAction(input: string, key: AppKeyboardKey): AppK
   }
 
   if (input === "1") {
-    return { type: "navigate", route: "tasks" };
+    return { type: "navigate", route: "habits" };
   }
 
   if (input === "2") {
-    return { type: "navigate", route: "projects" };
+    return { type: "navigate", route: "tasks" };
   }
 
   if (input === "3") {
-    return { type: "navigate", route: "habits" };
+    return { type: "navigate", route: "projects" };
   }
 
   if (input === "4") {

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -73,7 +73,7 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
   ],
   habits: [
     { keys: "↑↓", description: "Select" },
-    { keys: "Enter", description: "Toggle" },
+    { keys: "Enter/Space", description: "Toggle" },
     { keys: "?", description: "Help" },
     { keys: "q", description: "Quit" },
   ],

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -8,11 +8,12 @@ export interface TuiKeyBinding {
 export const primaryRouteKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "1", description: "Tasks" },
   { keys: "2", description: "Projects" },
-  { keys: "3", description: "Data Status" },
+  { keys: "3", description: "Habits" },
+  { keys: "4", description: "Data Status" },
 ] as const;
 
 export const globalKeyBindings: readonly TuiKeyBinding[] = [
-  { keys: "1/2/3", description: "Tasks/Projects/Data Status" },
+  { keys: "1/2/3/4", description: "Tasks/Projects/Habits/Data Status" },
   { keys: "?", description: "Help" },
   { keys: "q", description: "Back/Quit" },
   { keys: "j/↓", description: "Down" },
@@ -37,7 +38,7 @@ export type TasksFooterContext =
   | "cancel-confirmation"
   | "filter-modal";
 
-export type FooterContext = TasksFooterContext | "projects" | "data-status" | "help";
+export type FooterContext = TasksFooterContext | "projects" | "habits" | "data-status" | "help";
 
 export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBinding[]>> = {
   "tasks-list": [
@@ -67,6 +68,12 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
     { keys: "↑↓", description: "Select" },
     { keys: "Enter", description: "Open Tasks" },
     { keys: "a", description: "All Projects" },
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  habits: [
+    { keys: "↑↓", description: "Select" },
+    { keys: "Enter", description: "Toggle" },
     { keys: "?", description: "Help" },
     { keys: "q", description: "Quit" },
   ],
@@ -119,6 +126,10 @@ export function resolveGlobalKeyAction(input: string, key: AppKeyboardKey): AppK
   }
 
   if (input === "3") {
+    return { type: "navigate", route: "habits" };
+  }
+
+  if (input === "4") {
     return { type: "navigate", route: "data-status" };
   }
 

--- a/packages/tui/src/app/routes.ts
+++ b/packages/tui/src/app/routes.ts
@@ -1,9 +1,9 @@
-export const appRoutes = ["tasks", "projects", "habits", "data-status", "help"] as const;
+export const appRoutes = ["habits", "tasks", "projects", "data-status", "help"] as const;
 
 export type AppRoute = (typeof appRoutes)[number];
 export type PrimaryAppRoute = Exclude<AppRoute, "help">;
 
-export const defaultRoute: PrimaryAppRoute = "tasks";
+export const defaultRoute: PrimaryAppRoute = "habits";
 
 export const routeLabels: Record<AppRoute, string> = {
   tasks: "Tasks",

--- a/packages/tui/src/app/routes.ts
+++ b/packages/tui/src/app/routes.ts
@@ -1,4 +1,4 @@
-export const appRoutes = ["tasks", "projects", "data-status", "help"] as const;
+export const appRoutes = ["tasks", "projects", "habits", "data-status", "help"] as const;
 
 export type AppRoute = (typeof appRoutes)[number];
 export type PrimaryAppRoute = Exclude<AppRoute, "help">;
@@ -8,6 +8,7 @@ export const defaultRoute: PrimaryAppRoute = "tasks";
 export const routeLabels: Record<AppRoute, string> = {
   tasks: "Tasks",
   projects: "Projects",
+  habits: "Habits",
   "data-status": "Data Status",
   help: "Help",
 };

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -32,9 +32,9 @@ describe("AppFrame", () => {
 
     expect(lastFrame()).toContain("Tasks");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
-    expect(lastFrame()).toContain("1 Tasks");
-    expect(lastFrame()).toContain("2 Projects");
-    expect(lastFrame()).toContain("3 Habits");
+    expect(lastFrame()).toContain("1 Habits");
+    expect(lastFrame()).toContain("2 Tasks");
+    expect(lastFrame()).toContain("3 Projects");
     expect(lastFrame()).toContain("4 Data Status");
     expect(lastFrame()).toContain("body content");
     expect(lastFrame()).toContain("↑↓ Select");

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -23,7 +23,7 @@ describe("AppFrame", () => {
         route="tasks"
         taskFilter={{ projectFilter: allProjectsFilter }}
         footerContext="tasks-list"
-        terminalWidth={60}
+        terminalWidth={80}
         terminalHeight={12}
       >
         <Text>body content</Text>
@@ -34,7 +34,8 @@ describe("AppFrame", () => {
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("1 Tasks");
     expect(lastFrame()).toContain("2 Projects");
-    expect(lastFrame()).toContain("3 Data Status");
+    expect(lastFrame()).toContain("3 Habits");
+    expect(lastFrame()).toContain("4 Data Status");
     expect(lastFrame()).toContain("body content");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("← Projects");

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -8,6 +8,7 @@ describe("HelpBar", () => {
     ["tasks-projects", ["↑↓ Select", "→ Tasks", "Enter Focus", "? Help", "q Quit"]],
     ["task-detail", ["↑↓ Scroll", "Esc Back", "s Start", "d Done", "c Comment", "? Help"]],
     ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
+    ["habits", ["↑↓ Select", "Enter Toggle", "? Help", "q Quit"]],
     ["data-status", ["? Help", "q Quit"]],
     ["help", ["q Back"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -8,7 +8,7 @@ describe("HelpBar", () => {
     ["tasks-projects", ["↑↓ Select", "→ Tasks", "Enter Focus", "? Help", "q Quit"]],
     ["task-detail", ["↑↓ Scroll", "Esc Back", "s Start", "d Done", "c Comment", "? Help"]],
     ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
-    ["habits", ["↑↓ Select", "Enter Toggle", "? Help", "q Quit"]],
+    ["habits", ["↑↓ Select", "Enter/Space Toggle", "? Help", "q Quit"]],
     ["data-status", ["? Help", "q Quit"]],
     ["help", ["q Back"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],

--- a/packages/tui/src/daemon/todu-client.test.ts
+++ b/packages/tui/src/daemon/todu-client.test.ts
@@ -72,6 +72,31 @@ describe("createTuiToduClient", () => {
     });
   });
 
+  it("maps habit list and check-in methods to daemon RPC params", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: [{ id: "hab-1", title: "Meditate" }] })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { date: "2026-07-20", completed: true },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { date: "2026-07-20", completed: false },
+      });
+    const client = createTuiToduClient(createMockDaemon(request));
+
+    await client.habit.list({ paused: false, checkedToday: true });
+    await client.habit.check("hab-1");
+    await client.habit.uncheck("hab-1");
+
+    expect(request).toHaveBeenNthCalledWith(1, "habit.list", {
+      filter: { paused: false, checkedToday: true },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "habit.check", { id: "hab-1" });
+    expect(request).toHaveBeenNthCalledWith(3, "habit.uncheck", { id: "hab-1" });
+  });
+
   it("maps actor, note, and sync status methods", async () => {
     const request = vi
       .fn()

--- a/packages/tui/src/daemon/todu-client.ts
+++ b/packages/tui/src/daemon/todu-client.ts
@@ -1,6 +1,10 @@
 import type {
   Actor,
   CreateNoteInput,
+  Habit,
+  HabitEntry,
+  HabitFilter,
+  HabitId,
   Note,
   NoteFilter,
   Project,
@@ -43,6 +47,11 @@ export interface TuiToduClient {
   note: {
     list(filter?: NoteFilter): Promise<Note[]>;
     create(input: CreateNoteInput): Promise<Note>;
+  };
+  habit: {
+    list(filter?: HabitFilter): Promise<Habit[]>;
+    check(id: HabitId | string): Promise<HabitEntry>;
+    uncheck(id: HabitId | string): Promise<HabitEntry>;
   };
   sync: {
     status(): Promise<TuiSyncStatus>;
@@ -99,6 +108,11 @@ export function createTuiToduClient(daemon: Pick<DaemonConnection, "request">): 
     note: {
       list: (filter) => invoke<Note[]>("note.list", { filter }),
       create: (input) => invoke<Note>("note.create", { input }),
+    },
+    habit: {
+      list: (filter) => invoke<Habit[]>("habit.list", { filter }),
+      check: (id) => invoke<HabitEntry>("habit.check", { id }),
+      uncheck: (id) => invoke<HabitEntry>("habit.uncheck", { id }),
     },
     sync: {
       status: () => invoke<TuiSyncStatus>("sync.status", {}),

--- a/packages/tui/src/screens/DataStatusScreen.test.tsx
+++ b/packages/tui/src/screens/DataStatusScreen.test.tsx
@@ -32,6 +32,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
       createComment: vi.fn(),
     },
     note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
       status: vi
         .fn()

--- a/packages/tui/src/screens/HabitsScreen.test.tsx
+++ b/packages/tui/src/screens/HabitsScreen.test.tsx
@@ -106,7 +106,7 @@ describe("HabitsScreen", () => {
     await waitForFrameText(lastFrame, "> [ ] Meditate");
   });
 
-  it("checks and unchecks the selected habit with Enter and updates immediately", async () => {
+  it("toggles the selected habit with Enter or Space and updates immediately", async () => {
     const client = createClient();
     const { stdin, lastFrame } = renderWithQuery(<HabitsScreen client={client} />);
 
@@ -115,7 +115,7 @@ describe("HabitsScreen", () => {
     await waitForFrameText(lastFrame, "> [x] Meditate");
     expect(client.habit.check).toHaveBeenCalledWith("hab-1");
 
-    stdin.write("\r");
+    stdin.write(" ");
     await waitForFrameText(lastFrame, "> [ ] Meditate");
     expect(client.habit.uncheck).toHaveBeenCalledWith("hab-1");
   });

--- a/packages/tui/src/screens/HabitsScreen.test.tsx
+++ b/packages/tui/src/screens/HabitsScreen.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "ink-testing-library";
+import type { JSX, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { TuiToduClient } from "../daemon/todu-client.js";
+import { createTuiQueryClient } from "../state/query-client.js";
+import { HabitsScreen } from "./HabitsScreen.js";
+
+function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
+  const queryClient = createTuiQueryClient();
+  function Wrapper(): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return render(<Wrapper />);
+}
+
+function createHabit(id: string, title: string) {
+  return {
+    id,
+    title,
+    projectId: "project-1",
+    schedule: "FREQ=DAILY",
+    timezone: "America/Chicago",
+    startDate: "2026-07-01",
+    nextDue: "2026-07-20",
+    paused: false,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+  };
+}
+
+function createClient(): TuiToduClient {
+  const habits = [createHabit("hab-1", "Meditate"), createHabit("hab-2", "Stretch")];
+  const checkedIds = new Set(["hab-2"]);
+
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: { list: vi.fn().mockResolvedValue([]), get: vi.fn() },
+    task: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn(),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    habit: {
+      list: vi
+        .fn()
+        .mockImplementation((filter = {}) =>
+          Promise.resolve(
+            filter.checkedToday ? habits.filter((habit) => checkedIds.has(habit.id)) : habits,
+          ),
+        ),
+      check: vi.fn().mockImplementation((id: string) => {
+        checkedIds.add(id);
+        return Promise.resolve({ date: "2026-07-20", completed: true });
+      }),
+      uncheck: vi.fn().mockImplementation((id: string) => {
+        checkedIds.delete(id);
+        return Promise.resolve({ date: "2026-07-20", completed: false });
+      }),
+    },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (lastFrame()?.includes(text)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
+describe("HabitsScreen", () => {
+  it("renders available habits with accurate completion checkboxes", async () => {
+    const { lastFrame } = renderWithQuery(<HabitsScreen client={createClient()} />);
+
+    await waitForFrameText(lastFrame, "Habits (2)");
+
+    expect(lastFrame()).toContain("> [ ] Meditate");
+    expect(lastFrame()).toContain("[x] Stretch");
+  });
+
+  it("moves selection predictably with j, k, and arrow keys", async () => {
+    const { stdin, lastFrame } = renderWithQuery(<HabitsScreen client={createClient()} />);
+
+    await waitForFrameText(lastFrame, "> [ ] Meditate");
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "> [x] Stretch");
+    stdin.write("j");
+    expect(lastFrame()).toContain("> [x] Stretch");
+    stdin.write("k");
+    await waitForFrameText(lastFrame, "> [ ] Meditate");
+    stdin.write("\u001B[B");
+    await waitForFrameText(lastFrame, "> [x] Stretch");
+    stdin.write("\u001B[A");
+    await waitForFrameText(lastFrame, "> [ ] Meditate");
+  });
+
+  it("checks and unchecks the selected habit with Enter and updates immediately", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(<HabitsScreen client={client} />);
+
+    await waitForFrameText(lastFrame, "> [ ] Meditate");
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "> [x] Meditate");
+    expect(client.habit.check).toHaveBeenCalledWith("hab-1");
+
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "> [ ] Meditate");
+    expect(client.habit.uncheck).toHaveBeenCalledWith("hab-1");
+  });
+});

--- a/packages/tui/src/screens/HabitsScreen.tsx
+++ b/packages/tui/src/screens/HabitsScreen.tsx
@@ -100,7 +100,11 @@ export function HabitsScreen({
       return;
     }
 
-    if ((key.return || input === "\r") && selectedHabit && !toggleMutation.isPending) {
+    if (
+      (key.return || input === "\r" || input === " ") &&
+      selectedHabit &&
+      !toggleMutation.isPending
+    ) {
       void toggleHabit(selectedHabit);
     }
   });

--- a/packages/tui/src/screens/HabitsScreen.tsx
+++ b/packages/tui/src/screens/HabitsScreen.tsx
@@ -1,0 +1,166 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Habit, HabitFilter } from "@todu/core";
+import { Box, Text, useInput, useStdout } from "ink";
+import type { JSX } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Pane } from "../components/Pane.js";
+import { ToastLine, type ToastTone } from "../components/ToastLine.js";
+import { getVisibleTaskWindow } from "../components/tasks/TaskListPane.js";
+import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { formatListWindowIndicator } from "../state/list-window.js";
+import { queryKeys } from "../state/query-keys.js";
+import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
+
+const availableHabitsFilter = { paused: false } satisfies HabitFilter;
+const checkedTodayHabitsFilter = {
+  paused: false,
+  checkedToday: true,
+} satisfies HabitFilter;
+const MIN_VISIBLE_HABITS = 1;
+
+export interface HabitsScreenProps {
+  client: TuiToduClient;
+  dataQueriesEnabled?: boolean;
+}
+
+export function HabitsScreen({
+  client,
+  dataQueriesEnabled = true,
+}: HabitsScreenProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const { stdout } = useStdout();
+  const [selectedHabitId, setSelectedHabitId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
+  const habitsQuery = useQuery({
+    queryKey: queryKeys.habits(availableHabitsFilter),
+    queryFn: () => client.habit.list(availableHabitsFilter),
+    enabled: dataQueriesEnabled,
+  });
+  const checkedTodayQuery = useQuery({
+    queryKey: queryKeys.habits(checkedTodayHabitsFilter),
+    queryFn: () => client.habit.list(checkedTodayHabitsFilter),
+    enabled: dataQueriesEnabled,
+  });
+  const habits = habitsQuery.data ?? [];
+  const checkedTodayIds = useMemo(
+    () => new Set((checkedTodayQuery.data ?? []).map((habit) => habit.id)),
+    [checkedTodayQuery.data],
+  );
+  const effectiveSelectedHabitId = resolveSelectedId(habits, selectedHabitId);
+  const selectedHabit = getSelectedItem(habits, effectiveSelectedHabitId);
+  const maxVisibleHabits = resolveMaxVisibleHabits(stdout.rows);
+  const habitWindow = getVisibleTaskWindow(habits, effectiveSelectedHabitId, maxVisibleHabits);
+  const toggleMutation = useMutation({
+    mutationFn: ({ habit, completed }: { habit: Habit; completed: boolean }) =>
+      completed ? client.habit.uncheck(habit.id) : client.habit.check(habit.id),
+  });
+
+  useEffect(() => {
+    if (!habitsQuery.data) {
+      return;
+    }
+
+    setSelectedHabitId((current) => resolveSelectedId(habitsQuery.data ?? [], current));
+  }, [habitsQuery.data]);
+
+  const toggleHabit = async (habit: Habit): Promise<void> => {
+    if (!dataQueriesEnabled) {
+      setFeedback({
+        message: "Habit actions unavailable while daemon is disconnected.",
+        tone: "error",
+      });
+      return;
+    }
+
+    const wasCompleted = checkedTodayIds.has(habit.id);
+    try {
+      const entry = await toggleMutation.mutateAsync({ habit, completed: wasCompleted });
+      queryClient.setQueryData<Habit[]>(
+        queryKeys.habits(checkedTodayHabitsFilter),
+        (current = []) => updateCheckedTodayHabits(current, habit, entry.completed),
+      );
+      setFeedback({
+        message: `Habit ${entry.completed ? "checked" : "unchecked"}: ${habit.title}`,
+        tone: "success",
+      });
+      await queryClient.invalidateQueries({ queryKey: ["habits"] });
+    } catch (error) {
+      setFeedback({ message: formatToduClientError(error), tone: "error" });
+    }
+  };
+
+  useInput((input, key) => {
+    if (input === "j" || key.downArrow) {
+      setSelectedHabitId((current) => moveSelection(habits, current, "next"));
+      return;
+    }
+
+    if (input === "k" || key.upArrow) {
+      setSelectedHabitId((current) => moveSelection(habits, current, "previous"));
+      return;
+    }
+
+    if ((key.return || input === "\r") && selectedHabit && !toggleMutation.isPending) {
+      void toggleHabit(selectedHabit);
+    }
+  });
+
+  const error = habitsQuery.error ?? checkedTodayQuery.error;
+  const isLoading = habitsQuery.isLoading || checkedTodayQuery.isLoading;
+  const title = isLoading ? "Habits • loading…" : `Habits (${habits.length})`;
+  const aboveIndicator = formatListWindowIndicator(habitWindow, "above");
+  const belowIndicator = formatListWindowIndicator(habitWindow, "below");
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Pane title={title} width="100%" focused>
+        {error ? (
+          <Box flexDirection="column">
+            <Text color="red">Habits unavailable</Text>
+            <Text color="gray">{formatToduClientError(error)}</Text>
+          </Box>
+        ) : null}
+        {!error && isLoading ? <Text color="gray">Loading habits…</Text> : null}
+        {!error && !isLoading && habits.length === 0 ? (
+          <Text color="gray">No active habits available.</Text>
+        ) : null}
+        {!error && !isLoading && aboveIndicator ? <Text color="gray">{aboveIndicator}</Text> : null}
+        {!error && !isLoading
+          ? habitWindow.items.map((habit) => {
+              const selected = habit.id === effectiveSelectedHabitId;
+              const completed = checkedTodayIds.has(habit.id);
+              return (
+                <Text
+                  key={habit.id}
+                  color={selected ? "cyan" : undefined}
+                  inverse={selected}
+                  wrap="truncate-end"
+                >
+                  {selected ? ">" : " "} [{completed ? "x" : " "}] {habit.title}
+                </Text>
+              );
+            })
+          : null}
+        {!error && !isLoading && belowIndicator ? <Text color="gray">{belowIndicator}</Text> : null}
+      </Pane>
+      <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
+    </Box>
+  );
+}
+
+export function updateCheckedTodayHabits(
+  current: readonly Habit[],
+  habit: Habit,
+  completed: boolean,
+): Habit[] {
+  if (!completed) {
+    return current.filter((entry) => entry.id !== habit.id);
+  }
+
+  return current.some((entry) => entry.id === habit.id) ? [...current] : [...current, habit];
+}
+
+function resolveMaxVisibleHabits(rows: number | undefined): number {
+  const terminalRows = rows && rows > 0 ? rows : 24;
+  return Math.max(MIN_VISIBLE_HABITS, terminalRows - 11);
+}

--- a/packages/tui/src/screens/ProjectsScreen.test.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.test.tsx
@@ -54,6 +54,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
       createComment: vi.fn(),
     },
     note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
       status: vi
         .fn()

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -87,6 +87,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
         ),
       create: vi.fn(),
     },
+    habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
       status: vi
         .fn()

--- a/packages/tui/src/state/event-invalidation.test.ts
+++ b/packages/tui/src/state/event-invalidation.test.ts
@@ -25,6 +25,7 @@ describe("event invalidation", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["projects"] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["tasks"] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["notes"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["habits"] });
   });
 
   it("invalidates domain and sync queries on reconnect", async () => {

--- a/packages/tui/src/state/event-invalidation.ts
+++ b/packages/tui/src/state/event-invalidation.ts
@@ -16,6 +16,7 @@ export async function invalidateDataChangedQueries(queryClient: QueryClient): Pr
     queryClient.invalidateQueries({ queryKey: ["projects"] }),
     queryClient.invalidateQueries({ queryKey: ["tasks"] }),
     queryClient.invalidateQueries({ queryKey: ["notes"] }),
+    queryClient.invalidateQueries({ queryKey: ["habits"] }),
   ]);
 }
 

--- a/packages/tui/src/state/query-keys.ts
+++ b/packages/tui/src/state/query-keys.ts
@@ -1,4 +1,11 @@
-import type { NoteFilter, ProjectFilter, TaskFilter, TaskId, TaskSortOptions } from "@todu/core";
+import type {
+  HabitFilter,
+  NoteFilter,
+  ProjectFilter,
+  TaskFilter,
+  TaskId,
+  TaskSortOptions,
+} from "@todu/core";
 
 export const queryKeys = {
   actors: () => ["actors"] as const,
@@ -9,5 +16,6 @@ export const queryKeys = {
   task: (id: TaskId | string) => ["tasks", id] as const,
   notes: (filter?: NoteFilter) => ["notes", filter ?? null] as const,
   taskComments: (taskId: TaskId | string) => ["tasks", taskId, "comments"] as const,
+  habits: (filter?: HabitFilter) => ["habits", filter ?? null] as const,
   syncStatus: () => ["sync", "status"] as const,
 };


### PR DESCRIPTION
## Summary

- add a Habits primary route with checkbox rendering for today's completion state
- support j/k and arrow selection plus Enter check-in toggling
- keep habit query state synchronized after mutations and daemon data events
- extend the thin TUI daemon client, navigation help, architecture docs, tests, and changeset

## Verification

- `make pre-pr`

Task: #task-b877d6aa