### PR TITLE
feat: launch TUI from bare command

### DIFF
--- a/.changeset/quick-tigers-launch.md
+++ b/.changeset/quick-tigers-launch.md
@@ -1,0 +1,5 @@
+---
+"@todu/cli": minor
+---
+
+Launch the terminal UI when `todu` runs without arguments.

--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ Run the standalone TUI command:
 todu-tui
 ```
 
-If `@todu/cli` is also installed, you can launch the same TUI through the CLI wrapper:
+If `@todu/cli` is also installed, running it without arguments launches the same TUI:
 
 ```bash
-todu tui
+todu
 ```
+
+The explicit wrapper remains available as `todu tui`.
 
 From a source checkout, build the workspace first with `npm run build` or run the wrapper from the checkout where `tsx` is installed for development fallback.
 

--- a/docs/cli-daemon-usage.md
+++ b/docs/cli-daemon-usage.md
@@ -36,11 +36,13 @@ npm install -g @todu/tui
 todu-tui
 ```
 
-If `@todu/cli` is installed too, the CLI exposes a convenience wrapper that launches the same TUI entrypoint:
+If `@todu/cli` is installed too, running it without arguments launches the same TUI entrypoint:
 
 ```bash
-todu tui
+todu
 ```
+
+The explicit `todu tui` wrapper remains available.
 
 Use the same version alignment rule as the CLI: prefer matching `@todu/tui`, `@todu/cli`, and desktop app versions. The TUI is released independently so each incremental terminal UI improvement can be versioned and published as soon as it lands.
 

--- a/packages/cli/src/commands/tui.test.ts
+++ b/packages/cli/src/commands/tui.test.ts
@@ -79,6 +79,17 @@ describe("tui command", () => {
     expect(target).toBeNull();
   });
 
+  it("launches the TUI when todu runs without arguments", async () => {
+    const program = new Command();
+    const launch = vi.fn<(_: readonly string[]) => Promise<number>>().mockResolvedValue(0);
+
+    program.name("todu");
+    registerTuiCommand(program, launch);
+    await program.parseAsync([], { from: "user" });
+
+    expect(launch).toHaveBeenCalledWith([]);
+  });
+
   it("registers todu tui and forwards arguments to the launcher", async () => {
     const program = new Command();
     const launch = vi.fn<(_: readonly string[]) => Promise<number>>().mockResolvedValue(0);

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -30,17 +30,20 @@ export function registerTuiCommand(
   program: Command,
   launch: (args: readonly string[]) => Promise<number> = launchTui,
 ): void {
+  const runTui = async (args: readonly string[]): Promise<void> => {
+    const exitCode = await launch(args);
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+  };
+
+  program.action(() => runTui([]));
   program
     .command("tui")
     .description("Launch the Todu terminal UI")
     .argument("[args...]", "arguments to pass to todu-tui")
     .allowUnknownOption(true)
-    .action(async (args: string[]) => {
-      const exitCode = await launch(args);
-      if (exitCode !== 0) {
-        process.exitCode = exitCode;
-      }
-    });
+    .action((args: string[]) => runTui(args));
 }
 
 export async function launchTui(


### PR DESCRIPTION
## Summary

- launch the terminal UI when `todu` runs without arguments
- preserve `todu tui` and argument forwarding
- document the default CLI behavior
- add a minor CLI changeset

## Verification

- `make pre-pr`
- manual checks of `todu`, `todu --help`, and `todu --version`

Task: #task-ff583b3f