### PR TITLE
chore: upgrade Automerge to 3.3.2

### DIFF
--- a/.changeset/calm-pandas-merge.md
+++ b/.changeset/calm-pandas-merge.md
@@ -1,0 +1,5 @@
+---
+"@todu/engine": patch
+---
+
+Upgrade Automerge to 3.3.2 so the engine and Automerge Repo use one compatible runtime instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@automerge/automerge": "3.2.6",
+        "@automerge/automerge": "3.3.2",
         "@tanstack/react-query": "^5.90.21"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       "license": "MIT"
     },
     "node_modules/@automerge/automerge": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.2.6.tgz",
-      "integrity": "sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-3.3.2.tgz",
+      "integrity": "sha512-9vCdCL7pdQwUra66SBxPVHr+/t9epXKni9KDeak2rNBFMzABVh2u6gSpcwxi3jkR5qr047jVqZv9DlrOfVxLFw==",
       "license": "MIT"
     },
     "node_modules/@automerge/automerge-repo": {
@@ -13301,7 +13301,7 @@
       "version": "0.23.3",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "3.2.6",
+        "@automerge/automerge": "3.3.2",
         "@automerge/automerge-repo": "2.5.6",
         "@automerge/automerge-repo-network-websocket": "2.5.6",
         "@automerge/automerge-repo-storage-nodefs": "2.5.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@automerge/automerge": "3.2.6",
+    "@automerge/automerge": "3.3.2",
     "@tanstack/react-query": "^5.90.21"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsgo -p tsconfig.build.json --noEmit"
   },
   "dependencies": {
-    "@automerge/automerge": "3.2.6",
+    "@automerge/automerge": "3.3.2",
     "@automerge/automerge-repo": "2.5.6",
     "@automerge/automerge-repo-network-websocket": "2.5.6",
     "@automerge/automerge-repo-storage-nodefs": "2.5.6",


### PR DESCRIPTION
## Summary

- upgrade the root and `@todu/engine` Automerge dependency to 3.3.2
- deduplicate Automerge Repo and the engine onto one runtime instance
- add an engine patch changeset

## Verification

- `make pre-pr`
- targeted storage and daemon integration tests (55 tests)
- sync-server integration tests (25 tests)
- isolated packed-engine dependency-tree verification

Task: #task-59d80ebc