### PR TITLE
chore: release engine 0.23.4

### DIFF
--- a/.changeset/calm-pandas-merge.md
+++ b/.changeset/calm-pandas-merge.md
@@ -1,5 +1,0 @@
----
-"@todu/engine": patch
----
-
-Upgrade Automerge to 3.3.2 so the engine and Automerge Repo use one compatible runtime instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13298,7 +13298,7 @@
     },
     "packages/engine": {
       "name": "@todu/engine",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "3.3.2",

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @todu/engine
 
+## 0.23.4
+
+### Patch Changes
+
+- 5c54998: Upgrade Automerge to 3.3.2 so the engine and Automerge Repo use one compatible runtime instance.
+
 ## 0.23.3
 
 ### Patch Changes

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@todu/engine",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Task management engine with offline-first CRDT storage and sync",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- release `@todu/engine@0.23.4`
- include the Automerge 3.3.2 compatibility fix
- update the engine changelog and lockfile

## Verification

- `npm run check:ci`
- `npm test` (832 tests)
- `make version-check`

Merging this PR triggers the NPM Release workflow.

Task: #task-59d80ebc