### PR TITLE
feat: add weekly journal to TUI

### DIFF
--- a/.changeset/bright-journals-flow.md
+++ b/.changeset/bright-journals-flow.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": minor
+---
+
+Add a weekly Journal screen with terminal-editor entry creation and Sunday-through-Saturday navigation.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -133,7 +133,7 @@ function createFakeClient(): TuiToduClient {
       update: vi.fn(),
       createComment: vi.fn(),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
     habit: {
       list: vi.fn().mockImplementation((filter = {}) =>
         Promise.resolve(
@@ -233,6 +233,8 @@ describe("App", () => {
     stdin.write("3");
     await waitForFrameText(lastFrame, "No journal entries this week.");
     expect(lastFrame()).toContain("Journal");
+    expect(lastFrame()).toContain("j/k/↑↓ Select");
+    expect(lastFrame()).toContain("Enter Edit");
     expect(lastFrame()).toContain("Shift+H/L Previous/Next Week");
     expect(lastFrame()).toContain("n New Entry");
 

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -189,9 +189,10 @@ describe("App", () => {
     expect(lastFrame()).toContain("todu daemon start");
     expect(lastFrame()).toContain("1 Home");
     expect(lastFrame()).toContain("2 Habits");
-    expect(lastFrame()).toContain("3 Tasks");
-    expect(lastFrame()).toContain("4 Projects");
-    expect(lastFrame()).toContain("5 Data Status");
+    expect(lastFrame()).toContain("3 Journal");
+    expect(lastFrame()).toContain("4 Tasks");
+    expect(lastFrame()).toContain("5 Projects");
+    expect(lastFrame()).toContain("6 Data Status");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("Shift+J/K Section");
   });
@@ -230,10 +231,16 @@ describe("App", () => {
     expect(lastFrame()).toContain("Habits");
 
     stdin.write("3");
+    await waitForFrameText(lastFrame, "No journal entries this week.");
+    expect(lastFrame()).toContain("Journal");
+    expect(lastFrame()).toContain("Shift+H/L Previous/Next Week");
+    expect(lastFrame()).toContain("n New Entry");
+
+    stdin.write("4");
     await waitForFrameText(lastFrame, "Ship");
     expect(lastFrame()).toContain("Tasks");
 
-    stdin.write("4");
+    stdin.write("5");
     await waitForFrameText(lastFrame, "Project detail");
     expect(lastFrame()).toContain("Projects");
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
@@ -241,7 +248,7 @@ describe("App", () => {
     expect(lastFrame()).toContain("Enter Open Tasks");
     expect(lastFrame()).toContain("a All Projects");
 
-    stdin.write("5");
+    stdin.write("6");
     await waitForFrameText(lastFrame, "Data status ready");
     expect(lastFrame()).toContain("Projects: 1");
     expect(lastFrame()).toContain("? Help");
@@ -256,7 +263,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Home");
-    stdin.write("4");
+    stdin.write("5");
     await waitForFrameText(lastFrame, "Project detail");
     await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
@@ -279,7 +286,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Home");
-    stdin.write("3");
+    stdin.write("4");
     await waitForFrameText(lastFrame, "Ship");
     stdin.write("h");
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -303,7 +310,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Home");
-    stdin.write("4");
+    stdin.write("5");
     await waitForFrameText(lastFrame, "Project detail");
     await new Promise((resolve) => setTimeout(resolve, 10));
     stdin.write("j");
@@ -311,7 +318,7 @@ describe("App", () => {
     stdin.write("\r");
     await waitForFrameText(lastFrame, "Open · Any priority · Inbox");
 
-    stdin.write("4");
+    stdin.write("5");
     await waitForFrameText(lastFrame, "Project detail");
     stdin.write("a");
     await waitForFrameText(lastFrame, "Open · Any priority · All Projects");
@@ -328,7 +335,7 @@ describe("App", () => {
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
 
-    expect(lastFrame()).toContain("1/2/3/4/5 Home/Habits/Tasks/Projects/Data Status");
+    expect(lastFrame()).toContain("1/2/3/4/5/6 Home/Habits/Journal/Tasks/Projects/Data Status");
     expect(lastFrame()).toContain("?      Help");
     expect(lastFrame()).toContain("j/↓    Down");
     expect(lastFrame()).toContain("Enter  Select/Open/Submit");
@@ -349,7 +356,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Home");
-    stdin.write("3");
+    stdin.write("4");
     await waitForFrameText(lastFrame, "Ship");
     expect(lastFrame()).toContain("c Comment");
 
@@ -369,7 +376,7 @@ describe("App", () => {
       />,
     );
 
-    stdin.write("4");
+    stdin.write("5");
     await waitForFrameText(lastFrame, "Project detail");
     stdin.write("?");
     await waitForFrameText(lastFrame, "Help");
@@ -386,7 +393,7 @@ describe("App", () => {
     const connection = createFakeConnection(createConnectedSnapshot());
     const client = createFakeClient();
     const { stdin } = render(<App connection={connection} toduClient={client} />);
-    stdin.write("3");
+    stdin.write("4");
 
     await vi.waitFor(() => {
       expect(client.task.list).toHaveBeenCalledTimes(1);
@@ -411,7 +418,7 @@ describe("App", () => {
     );
 
     await waitForFrameText(lastFrame, "Home");
-    stdin.write("3");
+    stdin.write("4");
     await waitForFrameText(lastFrame, "Ship");
     await vi.waitFor(() => {
       expect(connection.request).toHaveBeenCalledTimes(1);

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -13,6 +13,7 @@ import { DataStatusScreen } from "../screens/DataStatusScreen.js";
 import { HabitsScreen } from "../screens/HabitsScreen.js";
 import { HelpScreen } from "../screens/HelpScreen.js";
 import { HomeScreen } from "../screens/HomeScreen.js";
+import { JournalScreen } from "../screens/JournalScreen.js";
 import { ProjectsScreen } from "../screens/ProjectsScreen.js";
 import { TasksScreen } from "../screens/TasksScreen.js";
 import {
@@ -263,6 +264,16 @@ function RouteScreen({
   if (route === "habits") {
     return canShowDataScreens ? (
       <HabitsScreen client={toduClient} dataQueriesEnabled={dataQueriesEnabled} />
+    ) : null;
+  }
+
+  if (route === "journal") {
+    return canShowDataScreens ? (
+      <JournalScreen
+        client={toduClient}
+        dataQueriesEnabled={dataQueriesEnabled}
+        onGlobalInputEnabledChange={onGlobalInputEnabledChange}
+      />
     ) : null;
   }
 

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -8,13 +8,14 @@ export interface TuiKeyBinding {
 export const primaryRouteKeyBindings: readonly TuiKeyBinding[] = [
   { keys: "1", description: "Home" },
   { keys: "2", description: "Habits" },
-  { keys: "3", description: "Tasks" },
-  { keys: "4", description: "Projects" },
-  { keys: "5", description: "Data Status" },
+  { keys: "3", description: "Journal" },
+  { keys: "4", description: "Tasks" },
+  { keys: "5", description: "Projects" },
+  { keys: "6", description: "Data Status" },
 ] as const;
 
 export const globalKeyBindings: readonly TuiKeyBinding[] = [
-  { keys: "1/2/3/4/5", description: "Home/Habits/Tasks/Projects/Data Status" },
+  { keys: "1/2/3/4/5/6", description: "Home/Habits/Journal/Tasks/Projects/Data Status" },
   { keys: "?", description: "Help" },
   { keys: "q", description: "Back/Quit" },
   { keys: "j/↓", description: "Down" },
@@ -44,6 +45,7 @@ export type FooterContext =
   | "projects"
   | "home"
   | "habits"
+  | "journal"
   | "data-status"
   | "help";
 
@@ -87,6 +89,12 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
   habits: [
     { keys: "j/k/↑↓", description: "Select" },
     { keys: "Enter/Space", description: "Toggle" },
+    { keys: "?", description: "Help" },
+    { keys: "q", description: "Quit" },
+  ],
+  journal: [
+    { keys: "Shift+H/L", description: "Previous/Next Week" },
+    { keys: "n", description: "New Entry" },
     { keys: "?", description: "Help" },
     { keys: "q", description: "Quit" },
   ],
@@ -139,14 +147,18 @@ export function resolveGlobalKeyAction(input: string, key: AppKeyboardKey): AppK
   }
 
   if (input === "3") {
-    return { type: "navigate", route: "tasks" };
+    return { type: "navigate", route: "journal" };
   }
 
   if (input === "4") {
-    return { type: "navigate", route: "projects" };
+    return { type: "navigate", route: "tasks" };
   }
 
   if (input === "5") {
+    return { type: "navigate", route: "projects" };
+  }
+
+  if (input === "6") {
     return { type: "navigate", route: "data-status" };
   }
 

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -93,6 +93,8 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
     { keys: "q", description: "Quit" },
   ],
   journal: [
+    { keys: "j/k/↑↓", description: "Select" },
+    { keys: "Enter", description: "Edit" },
     { keys: "Shift+H/L", description: "Previous/Next Week" },
     { keys: "n", description: "New Entry" },
     { keys: "?", description: "Help" },

--- a/packages/tui/src/app/routes.ts
+++ b/packages/tui/src/app/routes.ts
@@ -1,4 +1,12 @@
-export const appRoutes = ["home", "habits", "tasks", "projects", "data-status", "help"] as const;
+export const appRoutes = [
+  "home",
+  "habits",
+  "journal",
+  "tasks",
+  "projects",
+  "data-status",
+  "help",
+] as const;
 
 export type AppRoute = (typeof appRoutes)[number];
 export type PrimaryAppRoute = Exclude<AppRoute, "help">;
@@ -10,6 +18,7 @@ export const routeLabels: Record<AppRoute, string> = {
   projects: "Projects",
   home: "Home",
   habits: "Habits",
+  journal: "Journal",
   "data-status": "Data Status",
   help: "Help",
 };

--- a/packages/tui/src/components/AppFrame.test.tsx
+++ b/packages/tui/src/components/AppFrame.test.tsx
@@ -34,9 +34,10 @@ describe("AppFrame", () => {
     expect(lastFrame()).toContain("Open · Any priority · All Projects");
     expect(lastFrame()).toContain("1 Home");
     expect(lastFrame()).toContain("2 Habits");
-    expect(lastFrame()).toContain("3 Tasks");
-    expect(lastFrame()).toContain("4 Projects");
-    expect(lastFrame()).toContain("5 Data Status");
+    expect(lastFrame()).toContain("3 Journal");
+    expect(lastFrame()).toContain("4 Tasks");
+    expect(lastFrame()).toContain("5 Projects");
+    expect(lastFrame()).toContain("6 Data Status");
     expect(lastFrame()).toContain("body content");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("← Projects");

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -10,6 +10,7 @@ describe("HelpBar", () => {
     ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
     ["home", ["Shift+J/K Section", "j/k/↑↓ Select item", "? Help", "q Quit"]],
     ["habits", ["j/k/↑↓ Select", "Enter/Space Toggle", "? Help", "q Quit"]],
+    ["journal", ["Shift+H/L Previous/Next Week", "n New Entry", "? Help", "q Quit"]],
     ["data-status", ["? Help", "q Quit"]],
     ["help", ["q Back"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],

--- a/packages/tui/src/components/HelpBar.test.tsx
+++ b/packages/tui/src/components/HelpBar.test.tsx
@@ -10,7 +10,17 @@ describe("HelpBar", () => {
     ["projects", ["↑↓ Select", "Enter Open Tasks", "a All Projects", "? Help", "q Quit"]],
     ["home", ["Shift+J/K Section", "j/k/↑↓ Select item", "? Help", "q Quit"]],
     ["habits", ["j/k/↑↓ Select", "Enter/Space Toggle", "? Help", "q Quit"]],
-    ["journal", ["Shift+H/L Previous/Next Week", "n New Entry", "? Help", "q Quit"]],
+    [
+      "journal",
+      [
+        "j/k/↑↓ Select",
+        "Enter Edit",
+        "Shift+H/L Previous/Next Week",
+        "n New Entry",
+        "? Help",
+        "q Quit",
+      ],
+    ],
     ["data-status", ["? Help", "q Quit"]],
     ["help", ["q Back"]],
     ["cancel-confirmation", ["y Confirm", "n/Esc Cancel"]],

--- a/packages/tui/src/daemon/todu-client.test.ts
+++ b/packages/tui/src/daemon/todu-client.test.ts
@@ -102,6 +102,7 @@ describe("createTuiToduClient", () => {
       .fn()
       .mockResolvedValueOnce({ ok: true, value: [] })
       .mockResolvedValueOnce({ ok: true, value: [] })
+      .mockResolvedValueOnce({ ok: true, value: { id: "note-1", content: "Updated" } })
       .mockResolvedValueOnce({
         ok: true,
         value: { local: { mode: "standalone" }, remote: { state: "disconnected" } },
@@ -110,13 +111,18 @@ describe("createTuiToduClient", () => {
 
     await client.actor.list();
     await client.note.list({ entityType: "task", entityId: "task-1" });
+    await client.note.update("note-1", { content: "Updated" });
     await client.sync.status();
 
     expect(request).toHaveBeenNthCalledWith(1, "actor.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "note.list", {
       filter: { entityType: "task", entityId: "task-1" },
     });
-    expect(request).toHaveBeenNthCalledWith(3, "sync.status", {});
+    expect(request).toHaveBeenNthCalledWith(3, "note.update", {
+      id: "note-1",
+      input: { content: "Updated" },
+    });
+    expect(request).toHaveBeenNthCalledWith(4, "sync.status", {});
   });
 
   it("throws user-facing mapped errors instead of raw protocol frames", async () => {

--- a/packages/tui/src/daemon/todu-client.ts
+++ b/packages/tui/src/daemon/todu-client.ts
@@ -15,6 +15,7 @@ import type {
   TaskId,
   TaskSortOptions,
   TaskWithDetail,
+  UpdateNoteInput,
   UpdateTaskInput,
 } from "@todu/core";
 import type { DaemonConnection, DaemonConnectionError } from "./connection.js";
@@ -47,6 +48,7 @@ export interface TuiToduClient {
   note: {
     list(filter?: NoteFilter): Promise<Note[]>;
     create(input: CreateNoteInput): Promise<Note>;
+    update(id: string, input: UpdateNoteInput): Promise<Note>;
   };
   habit: {
     list(filter?: HabitFilter): Promise<Habit[]>;
@@ -108,6 +110,7 @@ export function createTuiToduClient(daemon: Pick<DaemonConnection, "request">): 
     note: {
       list: (filter) => invoke<Note[]>("note.list", { filter }),
       create: (input) => invoke<Note>("note.create", { input }),
+      update: (id, input) => invoke<Note>("note.update", { id, input }),
     },
     habit: {
       list: (filter) => invoke<Habit[]>("habit.list", { filter }),

--- a/packages/tui/src/screens/DataStatusScreen.test.tsx
+++ b/packages/tui/src/screens/DataStatusScreen.test.tsx
@@ -31,7 +31,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
       update: vi.fn(),
       createComment: vi.fn(),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
     habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
       status: vi

--- a/packages/tui/src/screens/HabitsScreen.test.tsx
+++ b/packages/tui/src/screens/HabitsScreen.test.tsx
@@ -43,7 +43,7 @@ function createClient(): TuiToduClient {
       update: vi.fn(),
       createComment: vi.fn(),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
     habit: {
       list: vi
         .fn()

--- a/packages/tui/src/screens/HomeScreen.test.tsx
+++ b/packages/tui/src/screens/HomeScreen.test.tsx
@@ -67,7 +67,7 @@ function createClient(): TuiToduClient {
       update: vi.fn(),
       createComment: vi.fn(),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
     habit: {
       list: vi
         .fn()

--- a/packages/tui/src/screens/JournalScreen.test.tsx
+++ b/packages/tui/src/screens/JournalScreen.test.tsx
@@ -15,6 +15,23 @@ function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
 }
 
 function createClient(): TuiToduClient {
+  const entries = [
+    {
+      id: "note-1",
+      content: "Started the journal\nThis full body stays hidden in the list.",
+      author: "Erik",
+      tags: [],
+      createdAt: "2026-07-22T15:30:00.000Z",
+    },
+    {
+      id: "note-2",
+      content: "Second reflection",
+      author: "Erik",
+      tags: [],
+      createdAt: "2026-07-23T15:30:00.000Z",
+    },
+  ];
+
   return {
     actor: { list: vi.fn().mockResolvedValue([]) },
     project: { list: vi.fn().mockResolvedValue([]), get: vi.fn() },
@@ -25,22 +42,20 @@ function createClient(): TuiToduClient {
       createComment: vi.fn(),
     },
     note: {
-      list: vi.fn().mockResolvedValue([
-        {
-          id: "note-1",
-          content: "Started the journal",
-          author: "Erik",
-          tags: [],
-          createdAt: "2026-07-22T15:30:00.000Z",
-        },
-      ]),
+      list: vi.fn().mockResolvedValue(entries),
       create: vi.fn().mockResolvedValue({
-        id: "note-2",
+        id: "note-3",
         content: "New reflection",
         author: "Erik",
         tags: [],
-        createdAt: "2026-07-22T16:00:00.000Z",
+        createdAt: "2026-07-24T16:00:00.000Z",
       }),
+      update: vi.fn().mockImplementation((id: string, input: { content?: string }) =>
+        Promise.resolve({
+          ...entries.find((entry) => entry.id === id),
+          content: input.content ?? "",
+        }),
+      ),
     },
     habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
@@ -60,7 +75,7 @@ async function waitForFrameText(lastFrame: () => string | undefined, text: strin
 }
 
 describe("JournalScreen", () => {
-  it("lists standalone entries for the selected Sunday-through-Saturday week", async () => {
+  it("lists concise rows for the selected Sunday-through-Saturday week", async () => {
     const client = createClient();
     const { lastFrame } = renderWithQuery(
       <JournalScreen
@@ -72,6 +87,8 @@ describe("JournalScreen", () => {
 
     await waitForFrameText(lastFrame, "Started the journal");
     expect(lastFrame()).toContain("Jul 19 – Jul 25, 2026");
+    expect(lastFrame()).toContain("> Wed, Jul 22");
+    expect(lastFrame()).not.toContain("This full body stays hidden in the list.");
     expect(client.note.list).toHaveBeenCalledWith({
       journal: true,
       createdFrom: "2026-07-19",
@@ -107,7 +124,29 @@ describe("JournalScreen", () => {
     await waitForFrameText(lastFrame, "Started the journal");
     stdin.write("n");
     await waitForFrameText(lastFrame, "Journal entry added.");
-    expect(composeEntry).toHaveBeenCalledOnce();
+    expect(composeEntry).toHaveBeenCalledWith("");
     expect(client.note.create).toHaveBeenCalledWith({ content: "New reflection" });
+  });
+
+  it("selects an entry and updates it through the terminal editor", async () => {
+    const client = createClient();
+    const composeEntry = vi.fn().mockReturnValue("Updated second reflection");
+    const { stdin, lastFrame } = renderWithQuery(
+      <JournalScreen
+        client={client}
+        initialDate={new Date(2026, 6, 22, 12)}
+        composeEntry={composeEntry}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "> Wed, Jul 22");
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "> Thu, Jul 23");
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "Journal entry updated.");
+    expect(composeEntry).toHaveBeenCalledWith("Second reflection");
+    expect(client.note.update).toHaveBeenCalledWith("note-2", {
+      content: "Updated second reflection",
+    });
   });
 });

--- a/packages/tui/src/screens/JournalScreen.test.tsx
+++ b/packages/tui/src/screens/JournalScreen.test.tsx
@@ -75,7 +75,7 @@ async function waitForFrameText(lastFrame: () => string | undefined, text: strin
 }
 
 describe("JournalScreen", () => {
-  it("lists concise rows for the selected Sunday-through-Saturday week", async () => {
+  it("lists date-and-time-only rows for the selected Sunday-through-Saturday week", async () => {
     const client = createClient();
     const { lastFrame } = renderWithQuery(
       <JournalScreen
@@ -85,10 +85,11 @@ describe("JournalScreen", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Started the journal");
+    await waitForFrameText(lastFrame, "> Wed, Jul 22");
     expect(lastFrame()).toContain("Jul 19 – Jul 25, 2026");
-    expect(lastFrame()).toContain("> Wed, Jul 22");
+    expect(lastFrame()).not.toContain("Started the journal");
     expect(lastFrame()).not.toContain("This full body stays hidden in the list.");
+    expect(lastFrame()).not.toContain("Second reflection");
     expect(client.note.list).toHaveBeenCalledWith({
       journal: true,
       createdFrom: "2026-07-19",
@@ -121,7 +122,7 @@ describe("JournalScreen", () => {
       />,
     );
 
-    await waitForFrameText(lastFrame, "Started the journal");
+    await waitForFrameText(lastFrame, "> Wed, Jul 22");
     stdin.write("n");
     await waitForFrameText(lastFrame, "Journal entry added.");
     expect(composeEntry).toHaveBeenCalledWith("");

--- a/packages/tui/src/screens/JournalScreen.test.tsx
+++ b/packages/tui/src/screens/JournalScreen.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render } from "ink-testing-library";
+import type { JSX, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { TuiToduClient } from "../daemon/todu-client.js";
+import { createTuiQueryClient } from "../state/query-client.js";
+import { JournalScreen } from "./JournalScreen.js";
+
+function renderWithQuery(children: ReactNode): ReturnType<typeof render> {
+  const queryClient = createTuiQueryClient();
+  function Wrapper(): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return render(<Wrapper />);
+}
+
+function createClient(): TuiToduClient {
+  return {
+    actor: { list: vi.fn().mockResolvedValue([]) },
+    project: { list: vi.fn().mockResolvedValue([]), get: vi.fn() },
+    task: {
+      list: vi.fn().mockResolvedValue([]),
+      get: vi.fn(),
+      update: vi.fn(),
+      createComment: vi.fn(),
+    },
+    note: {
+      list: vi.fn().mockResolvedValue([
+        {
+          id: "note-1",
+          content: "Started the journal",
+          author: "Erik",
+          tags: [],
+          createdAt: "2026-07-22T15:30:00.000Z",
+        },
+      ]),
+      create: vi.fn().mockResolvedValue({
+        id: "note-2",
+        content: "New reflection",
+        author: "Erik",
+        tags: [],
+        createdAt: "2026-07-22T16:00:00.000Z",
+      }),
+    },
+    habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
+    sync: {
+      status: vi
+        .fn()
+        .mockResolvedValue({ local: { mode: "standalone" }, remote: { state: "disconnected" } }),
+    },
+  };
+}
+
+async function waitForFrameText(lastFrame: () => string | undefined, text: string): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (lastFrame()?.includes(text)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for frame text: ${text}\nLast frame:\n${lastFrame() ?? ""}`);
+}
+
+describe("JournalScreen", () => {
+  it("lists standalone entries for the selected Sunday-through-Saturday week", async () => {
+    const client = createClient();
+    const { lastFrame } = renderWithQuery(
+      <JournalScreen
+        client={client}
+        initialDate={new Date(2026, 6, 22, 12)}
+        timezone="America/Chicago"
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Started the journal");
+    expect(lastFrame()).toContain("Jul 19 – Jul 25, 2026");
+    expect(client.note.list).toHaveBeenCalledWith({
+      journal: true,
+      createdFrom: "2026-07-19",
+      createdTo: "2026-07-25",
+      timezone: "America/Chicago",
+    });
+  });
+
+  it("moves to adjacent weeks with Shift+L and Shift+H", async () => {
+    const client = createClient();
+    const { stdin, lastFrame } = renderWithQuery(
+      <JournalScreen client={client} initialDate={new Date(2026, 6, 22, 12)} />,
+    );
+
+    await waitForFrameText(lastFrame, "Jul 19 – Jul 25, 2026");
+    stdin.write("L");
+    await waitForFrameText(lastFrame, "Jul 26 – Aug 1, 2026");
+    stdin.write("H");
+    await waitForFrameText(lastFrame, "Jul 19 – Jul 25, 2026");
+  });
+
+  it("creates an entry composed in the terminal editor", async () => {
+    const client = createClient();
+    const composeEntry = vi.fn().mockReturnValue("New reflection");
+    const { stdin, lastFrame } = renderWithQuery(
+      <JournalScreen
+        client={client}
+        initialDate={new Date(2026, 6, 22, 12)}
+        composeEntry={composeEntry}
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Started the journal");
+    stdin.write("n");
+    await waitForFrameText(lastFrame, "Journal entry added.");
+    expect(composeEntry).toHaveBeenCalledOnce();
+    expect(client.note.create).toHaveBeenCalledWith({ content: "New reflection" });
+  });
+});

--- a/packages/tui/src/screens/JournalScreen.tsx
+++ b/packages/tui/src/screens/JournalScreen.tsx
@@ -1,0 +1,158 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Note, NoteFilter } from "@todu/core";
+import { Box, Text, useApp, useInput } from "ink";
+import type { JSX } from "react";
+import { useMemo, useState } from "react";
+import { Pane } from "../components/Pane.js";
+import { ToastLine, type ToastTone } from "../components/ToastLine.js";
+import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
+import { composeJournalEntry, normalizeCommentContent } from "../state/comment-actions.js";
+import { createJournalWeek, moveJournalWeek } from "../state/journal-week.js";
+import { queryKeys } from "../state/query-keys.js";
+
+export interface JournalScreenProps {
+  client: TuiToduClient;
+  dataQueriesEnabled?: boolean;
+  onGlobalInputEnabledChange?: (enabled: boolean) => void;
+  composeEntry?: () => string | null;
+  initialDate?: Date;
+  timezone?: string;
+}
+
+export function JournalScreen({
+  client,
+  dataQueriesEnabled = true,
+  onGlobalInputEnabledChange,
+  composeEntry = composeJournalEntry,
+  initialDate,
+  timezone = resolveLocalTimezone(),
+}: JournalScreenProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const { suspendTerminal } = useApp();
+  const [selectedDate, setSelectedDate] = useState(() => initialDate ?? new Date());
+  const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
+  const week = useMemo(() => createJournalWeek(selectedDate), [selectedDate]);
+  const filter = useMemo<NoteFilter>(
+    () => ({
+      journal: true,
+      createdFrom: week.startDate,
+      createdTo: week.endDate,
+      timezone,
+    }),
+    [timezone, week.endDate, week.startDate],
+  );
+  const entriesQuery = useQuery({
+    queryKey: queryKeys.notes(filter),
+    queryFn: () => client.note.list(filter),
+    enabled: dataQueriesEnabled,
+  });
+  const entries = useMemo(
+    () =>
+      [...(entriesQuery.data ?? [])].sort((left, right) =>
+        left.createdAt.localeCompare(right.createdAt),
+      ),
+    [entriesQuery.data],
+  );
+  const createMutation = useMutation({
+    mutationFn: (content: string) => client.note.create({ content }),
+  });
+
+  const openEntryEditor = async (): Promise<void> => {
+    if (!dataQueriesEnabled) {
+      setFeedback({
+        message: "Journal actions unavailable while daemon is disconnected.",
+        tone: "error",
+      });
+      return;
+    }
+
+    onGlobalInputEnabledChange?.(false);
+    try {
+      let composedContent: string | null = null;
+      await suspendTerminal(() => {
+        composedContent = composeEntry();
+      });
+      const content = normalizeCommentContent(composedContent ?? "");
+      if (!content) {
+        setFeedback({ message: "Cancelled journal entry.", tone: "info" });
+        return;
+      }
+
+      await createMutation.mutateAsync(content);
+      setFeedback({ message: "Journal entry added.", tone: "success" });
+      await queryClient.invalidateQueries({ queryKey: ["notes"] });
+    } catch (error) {
+      setFeedback({ message: formatToduClientError(error), tone: "error" });
+    } finally {
+      onGlobalInputEnabledChange?.(true);
+    }
+  };
+
+  useInput((input, key) => {
+    const normalizedInput = input.toLowerCase();
+    if (key.shift && normalizedInput === "l") {
+      setSelectedDate((current) => moveJournalWeek(current, "next"));
+      setFeedback(null);
+      return;
+    }
+    if (key.shift && normalizedInput === "h") {
+      setSelectedDate((current) => moveJournalWeek(current, "previous"));
+      setFeedback(null);
+      return;
+    }
+    if (key.ctrl || key.shift || createMutation.isPending) {
+      return;
+    }
+    if (input === "n") {
+      setFeedback(null);
+      void openEntryEditor();
+    }
+  });
+
+  const title = entriesQuery.isLoading
+    ? `Week • ${week.label} • loading…`
+    : `Week • ${week.label} • ${entries.length} ${entries.length === 1 ? "entry" : "entries"}`;
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      <Pane title={title} width="100%" focused>
+        {entriesQuery.error ? (
+          <Box flexDirection="column">
+            <Text color="red">Journal unavailable</Text>
+            <Text color="gray">{formatToduClientError(entriesQuery.error)}</Text>
+          </Box>
+        ) : null}
+        {!entriesQuery.error && entriesQuery.isLoading ? (
+          <Text color="gray">Loading journal entries…</Text>
+        ) : null}
+        {!entriesQuery.error && !entriesQuery.isLoading && entries.length === 0 ? (
+          <Text color="gray">No journal entries this week.</Text>
+        ) : null}
+        {!entriesQuery.error && !entriesQuery.isLoading
+          ? entries.map((entry) => (
+              <Box key={entry.id} flexDirection="column" marginBottom={1}>
+                <Text color="cyan">{formatJournalEntryDate(entry, timezone)}</Text>
+                <Text>{entry.content}</Text>
+              </Box>
+            ))
+          : null}
+      </Pane>
+      <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
+    </Box>
+  );
+}
+
+function resolveLocalTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function formatJournalEntryDate(entry: Note, timezone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: timezone,
+  }).format(new Date(entry.createdAt));
+}

--- a/packages/tui/src/screens/JournalScreen.tsx
+++ b/packages/tui/src/screens/JournalScreen.tsx
@@ -1,35 +1,47 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Note, NoteFilter } from "@todu/core";
-import { Box, Text, useApp, useInput } from "ink";
+import { Box, Text, useApp, useInput, useStdout } from "ink";
 import type { JSX } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Pane } from "../components/Pane.js";
 import { ToastLine, type ToastTone } from "../components/ToastLine.js";
+import { getVisibleTaskWindow } from "../components/tasks/TaskListPane.js";
 import { formatToduClientError, type TuiToduClient } from "../daemon/todu-client.js";
 import { composeJournalEntry, normalizeCommentContent } from "../state/comment-actions.js";
 import { createJournalWeek, moveJournalWeek } from "../state/journal-week.js";
+import { formatListWindowIndicator } from "../state/list-window.js";
 import { queryKeys } from "../state/query-keys.js";
+import { getSelectedItem, moveSelection, resolveSelectedId } from "../state/selection.js";
+
+const MIN_VISIBLE_ENTRIES = 1;
 
 export interface JournalScreenProps {
   client: TuiToduClient;
   dataQueriesEnabled?: boolean;
   onGlobalInputEnabledChange?: (enabled: boolean) => void;
-  composeEntry?: () => string | null;
+  composeEntry?: (initialContent: string) => string | null;
   initialDate?: Date;
   timezone?: string;
+}
+
+interface SaveEntryInput {
+  entry: Note | null;
+  content: string;
 }
 
 export function JournalScreen({
   client,
   dataQueriesEnabled = true,
   onGlobalInputEnabledChange,
-  composeEntry = composeJournalEntry,
+  composeEntry = defaultComposeEntry,
   initialDate,
   timezone = resolveLocalTimezone(),
 }: JournalScreenProps): JSX.Element {
   const queryClient = useQueryClient();
   const { suspendTerminal } = useApp();
+  const { stdout } = useStdout();
   const [selectedDate, setSelectedDate] = useState(() => initialDate ?? new Date());
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
   const week = useMemo(() => createJournalWeek(selectedDate), [selectedDate]);
   const filter = useMemo<NoteFilter>(
@@ -53,11 +65,24 @@ export function JournalScreen({
       ),
     [entriesQuery.data],
   );
-  const createMutation = useMutation({
-    mutationFn: (content: string) => client.note.create({ content }),
+  const effectiveSelectedEntryId = resolveSelectedId(entries, selectedEntryId);
+  const selectedEntry = getSelectedItem(entries, effectiveSelectedEntryId);
+  const entryWindow = getVisibleTaskWindow(
+    entries,
+    effectiveSelectedEntryId,
+    resolveMaxVisibleEntries(stdout.rows),
+  );
+  const saveMutation = useMutation({
+    mutationFn: ({ entry, content }: SaveEntryInput) =>
+      entry ? client.note.update(entry.id, { content }) : client.note.create({ content }),
   });
 
-  const openEntryEditor = async (): Promise<void> => {
+  useEffect(() => {
+    if (!entriesQuery.data) return;
+    setSelectedEntryId((current) => resolveSelectedId(entries, current));
+  }, [entries, entriesQuery.data]);
+
+  const openEntryEditor = async (entry: Note | null): Promise<void> => {
     if (!dataQueriesEnabled) {
       setFeedback({
         message: "Journal actions unavailable while daemon is disconnected.",
@@ -70,7 +95,7 @@ export function JournalScreen({
     try {
       let composedContent: string | null = null;
       await suspendTerminal(() => {
-        composedContent = composeEntry();
+        composedContent = composeEntry(entry?.content ?? "");
       });
       const content = normalizeCommentContent(composedContent ?? "");
       if (!content) {
@@ -78,8 +103,19 @@ export function JournalScreen({
         return;
       }
 
-      await createMutation.mutateAsync(content);
-      setFeedback({ message: "Journal entry added.", tone: "success" });
+      const savedEntry = await saveMutation.mutateAsync({ entry, content });
+      queryClient.setQueryData<Note[]>(queryKeys.notes(filter), (current = []) =>
+        entry
+          ? current.map((currentEntry) =>
+              currentEntry.id === savedEntry.id ? savedEntry : currentEntry,
+            )
+          : [...current, savedEntry],
+      );
+      setSelectedEntryId(savedEntry.id);
+      setFeedback({
+        message: entry ? "Journal entry updated." : "Journal entry added.",
+        tone: "success",
+      });
       await queryClient.invalidateQueries({ queryKey: ["notes"] });
     } catch (error) {
       setFeedback({ message: formatToduClientError(error), tone: "error" });
@@ -100,18 +136,32 @@ export function JournalScreen({
       setFeedback(null);
       return;
     }
-    if (key.ctrl || key.shift || createMutation.isPending) {
+    if (key.ctrl || key.shift || saveMutation.isPending) return;
+
+    if (input === "j" || key.downArrow) {
+      setSelectedEntryId((current) => moveSelection(entries, current, "next"));
+      return;
+    }
+    if (input === "k" || key.upArrow) {
+      setSelectedEntryId((current) => moveSelection(entries, current, "previous"));
       return;
     }
     if (input === "n") {
       setFeedback(null);
-      void openEntryEditor();
+      void openEntryEditor(null);
+      return;
+    }
+    if ((key.return || input === "\r") && selectedEntry) {
+      setFeedback(null);
+      void openEntryEditor(selectedEntry);
     }
   });
 
   const title = entriesQuery.isLoading
     ? `Week • ${week.label} • loading…`
     : `Week • ${week.label} • ${entries.length} ${entries.length === 1 ? "entry" : "entries"}`;
+  const aboveIndicator = formatListWindowIndicator(entryWindow, "above");
+  const belowIndicator = formatListWindowIndicator(entryWindow, "below");
 
   return (
     <Box flexDirection="column" flexGrow={1}>
@@ -128,18 +178,36 @@ export function JournalScreen({
         {!entriesQuery.error && !entriesQuery.isLoading && entries.length === 0 ? (
           <Text color="gray">No journal entries this week.</Text>
         ) : null}
+        {!entriesQuery.error && !entriesQuery.isLoading && aboveIndicator ? (
+          <Text color="gray">{aboveIndicator}</Text>
+        ) : null}
         {!entriesQuery.error && !entriesQuery.isLoading
-          ? entries.map((entry) => (
-              <Box key={entry.id} flexDirection="column" marginBottom={1}>
-                <Text color="cyan">{formatJournalEntryDate(entry, timezone)}</Text>
-                <Text>{entry.content}</Text>
-              </Box>
-            ))
+          ? entryWindow.items.map((entry) => {
+              const selected = entry.id === effectiveSelectedEntryId;
+              return (
+                <Text
+                  key={entry.id}
+                  color={selected ? "cyan" : undefined}
+                  inverse={selected}
+                  wrap="truncate-end"
+                >
+                  {selected ? ">" : " "} {formatJournalEntryDate(entry, timezone)}{" "}
+                  {formatEntryPreview(entry)}
+                </Text>
+              );
+            })
           : null}
+        {!entriesQuery.error && !entriesQuery.isLoading && belowIndicator ? (
+          <Text color="gray">{belowIndicator}</Text>
+        ) : null}
       </Pane>
       <ToastLine message={feedback?.message ?? null} tone={feedback?.tone ?? "info"} />
     </Box>
   );
+}
+
+function defaultComposeEntry(initialContent: string): string | null {
+  return composeJournalEntry({ initialContent });
 }
 
 function resolveLocalTimezone(): string {
@@ -155,4 +223,18 @@ function formatJournalEntryDate(entry: Note, timezone: string): string {
     minute: "2-digit",
     timeZone: timezone,
   }).format(new Date(entry.createdAt));
+}
+
+function formatEntryPreview(entry: Note): string {
+  return (
+    entry.content
+      .split(/\r?\n/)
+      .find((line) => line.trim().length > 0)
+      ?.trim() ?? "(empty)"
+  );
+}
+
+function resolveMaxVisibleEntries(rows: number | undefined): number {
+  const terminalRows = rows && rows > 0 ? rows : 24;
+  return Math.max(MIN_VISIBLE_ENTRIES, terminalRows - 11);
 }

--- a/packages/tui/src/screens/JournalScreen.tsx
+++ b/packages/tui/src/screens/JournalScreen.tsx
@@ -191,8 +191,7 @@ export function JournalScreen({
                   inverse={selected}
                   wrap="truncate-end"
                 >
-                  {selected ? ">" : " "} {formatJournalEntryDate(entry, timezone)}{" "}
-                  {formatEntryPreview(entry)}
+                  {selected ? ">" : " "} {formatJournalEntryDate(entry, timezone)}
                 </Text>
               );
             })
@@ -223,15 +222,6 @@ function formatJournalEntryDate(entry: Note, timezone: string): string {
     minute: "2-digit",
     timeZone: timezone,
   }).format(new Date(entry.createdAt));
-}
-
-function formatEntryPreview(entry: Note): string {
-  return (
-    entry.content
-      .split(/\r?\n/)
-      .find((line) => line.trim().length > 0)
-      ?.trim() ?? "(empty)"
-  );
 }
 
 function resolveMaxVisibleEntries(rows: number | undefined): number {

--- a/packages/tui/src/screens/ProjectsScreen.test.tsx
+++ b/packages/tui/src/screens/ProjectsScreen.test.tsx
@@ -53,7 +53,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
       update: vi.fn(),
       createComment: vi.fn(),
     },
-    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn() },
+    note: { list: vi.fn().mockResolvedValue([]), create: vi.fn(), update: vi.fn() },
     habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {
       status: vi

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -86,6 +86,7 @@ function createClient(overrides: Partial<TuiToduClient> = {}): TuiToduClient {
           Promise.resolve(comments.filter((comment) => comment.entityId === filter.entityId)),
         ),
       create: vi.fn(),
+      update: vi.fn(),
     },
     habit: { list: vi.fn().mockResolvedValue([]), check: vi.fn(), uncheck: vi.fn() },
     sync: {

--- a/packages/tui/src/state/comment-actions.test.ts
+++ b/packages/tui/src/state/comment-actions.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   CommentEditorError,
@@ -40,6 +40,23 @@ describe("comment actions", () => {
 
     expect(composeJournalEntry({ env: { EDITOR: "nano" }, spawnEditor })).toBe("Weekly reflection");
     expect(spawnEditor).toHaveBeenCalledWith("nano", [expect.stringContaining("entry.md")]);
+  });
+
+  it("prefills journal files when editing an existing entry", () => {
+    const spawnEditor = vi.fn((_command: string, args: readonly string[]) => {
+      const entryPath = args.at(-1) ?? "";
+      expect(readFileSync(entryPath, "utf8")).toBe("Existing reflection");
+      writeFileSync(entryPath, "Updated reflection\n");
+      return { status: 0, signal: null };
+    });
+
+    expect(
+      composeJournalEntry({
+        env: { EDITOR: "nano" },
+        initialContent: "Existing reflection",
+        spawnEditor,
+      }),
+    ).toBe("Updated reflection");
   });
 
   it("treats unchanged empty editor content as cancellation", () => {

--- a/packages/tui/src/state/comment-actions.test.ts
+++ b/packages/tui/src/state/comment-actions.test.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   CommentEditorError,
+  composeJournalEntry,
   composeTaskComment,
   normalizeCommentContent,
 } from "./comment-actions.js";
@@ -29,6 +30,16 @@ describe("comment actions", () => {
       }),
     ).toBe("Composed in the editor");
     expect(spawnEditor).toHaveBeenCalledWith("code", ["--wait", expect.any(String)]);
+  });
+
+  it("composes journal entries with a dedicated temporary file", () => {
+    const spawnEditor = vi.fn((_command: string, args: readonly string[]) => {
+      writeFileSync(args.at(-1) ?? "", "Weekly reflection\n");
+      return { status: 0, signal: null };
+    });
+
+    expect(composeJournalEntry({ env: { EDITOR: "nano" }, spawnEditor })).toBe("Weekly reflection");
+    expect(spawnEditor).toHaveBeenCalledWith("nano", [expect.stringContaining("entry.md")]);
   });
 
   it("treats unchanged empty editor content as cancellation", () => {

--- a/packages/tui/src/state/comment-actions.ts
+++ b/packages/tui/src/state/comment-actions.ts
@@ -21,15 +21,42 @@ export interface ComposeTaskCommentOptions {
   spawnEditor?: (command: string, args: readonly string[]) => EditorProcessResult;
 }
 
+interface ComposeEditorContentOptions extends ComposeTaskCommentOptions {
+  documentLabel: string;
+  temporaryPrefix: string;
+  fileName: string;
+}
+
 export function normalizeCommentContent(content: string): string | null {
   const trimmed = content.trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function composeTaskComment({
+export function composeTaskComment(options: ComposeTaskCommentOptions = {}): string | null {
+  return composeEditorContent({
+    ...options,
+    documentLabel: "comment",
+    temporaryPrefix: "todu-comment-",
+    fileName: "comment.md",
+  });
+}
+
+export function composeJournalEntry(options: ComposeTaskCommentOptions = {}): string | null {
+  return composeEditorContent({
+    ...options,
+    documentLabel: "journal entry",
+    temporaryPrefix: "todu-journal-",
+    fileName: "entry.md",
+  });
+}
+
+function composeEditorContent({
+  documentLabel,
+  temporaryPrefix,
+  fileName,
   env = process.env,
   spawnEditor = defaultSpawnEditor,
-}: ComposeTaskCommentOptions = {}): string | null {
+}: ComposeEditorContentOptions): string | null {
   const configuredEditor = env.VISUAL?.trim() || env.EDITOR?.trim();
   if (!configuredEditor) {
     throw new CommentEditorError("No terminal editor configured. Set VISUAL or EDITOR.");
@@ -45,11 +72,11 @@ export function composeTaskComment({
   let failure: unknown;
 
   try {
-    temporaryDirectory = mkdtempSync(join(tmpdir(), "todu-comment-"));
-    const commentPath = join(temporaryDirectory, "comment.md");
-    writeFileSync(commentPath, "", { encoding: "utf8", mode: 0o600 });
+    temporaryDirectory = mkdtempSync(join(tmpdir(), temporaryPrefix));
+    const contentPath = join(temporaryDirectory, fileName);
+    writeFileSync(contentPath, "", { encoding: "utf8", mode: 0o600 });
 
-    const result = spawnEditor(command, [...editorArgs, commentPath]);
+    const result = spawnEditor(command, [...editorArgs, contentPath]);
     if (result.error) {
       throw new CommentEditorError(
         `Failed to launch terminal editor "${command}": ${result.error.message}`,
@@ -57,7 +84,7 @@ export function composeTaskComment({
     }
     if (result.signal) {
       throw new CommentEditorError(
-        `Terminal editor "${command}" was terminated by ${result.signal}; comment was not added.`,
+        `Terminal editor "${command}" was terminated by ${result.signal}; ${documentLabel} was not added.`,
       );
     }
     if (result.status === null) {
@@ -65,17 +92,17 @@ export function composeTaskComment({
     }
     if (result.status !== 0) {
       throw new CommentEditorError(
-        `Terminal editor "${command}" exited with status ${result.status}; comment was not added.`,
+        `Terminal editor "${command}" exited with status ${result.status}; ${documentLabel} was not added.`,
       );
     }
 
-    content = normalizeCommentContent(readFileSync(commentPath, "utf8"));
+    content = normalizeCommentContent(readFileSync(contentPath, "utf8"));
   } catch (error) {
     failure =
       error instanceof CommentEditorError
         ? error
         : new CommentEditorError(
-            `Unable to compose task comment with terminal editor "${command}": ${formatError(error)}`,
+            `Unable to compose ${documentLabel} with terminal editor "${command}": ${formatError(error)}`,
           );
   }
 
@@ -84,7 +111,7 @@ export function composeTaskComment({
       rmSync(temporaryDirectory, { recursive: true, force: true });
     } catch (error) {
       failure ??= new CommentEditorError(
-        `Unable to remove temporary task comment file: ${formatError(error)}`,
+        `Unable to remove temporary ${documentLabel} file: ${formatError(error)}`,
       );
     }
   }

--- a/packages/tui/src/state/comment-actions.ts
+++ b/packages/tui/src/state/comment-actions.ts
@@ -18,6 +18,7 @@ interface EditorProcessResult {
 
 export interface ComposeTaskCommentOptions {
   env?: NodeJS.ProcessEnv;
+  initialContent?: string;
   spawnEditor?: (command: string, args: readonly string[]) => EditorProcessResult;
 }
 
@@ -55,6 +56,7 @@ function composeEditorContent({
   temporaryPrefix,
   fileName,
   env = process.env,
+  initialContent = "",
   spawnEditor = defaultSpawnEditor,
 }: ComposeEditorContentOptions): string | null {
   const configuredEditor = env.VISUAL?.trim() || env.EDITOR?.trim();
@@ -74,7 +76,7 @@ function composeEditorContent({
   try {
     temporaryDirectory = mkdtempSync(join(tmpdir(), temporaryPrefix));
     const contentPath = join(temporaryDirectory, fileName);
-    writeFileSync(contentPath, "", { encoding: "utf8", mode: 0o600 });
+    writeFileSync(contentPath, initialContent, { encoding: "utf8", mode: 0o600 });
 
     const result = spawnEditor(command, [...editorArgs, contentPath]);
     if (result.error) {

--- a/packages/tui/src/state/journal-week.test.ts
+++ b/packages/tui/src/state/journal-week.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createJournalWeek, moveJournalWeek } from "./journal-week.js";
+
+describe("journal week", () => {
+  it("uses Sunday through Saturday boundaries", () => {
+    const week = createJournalWeek(new Date(2026, 6, 22, 12));
+
+    expect(week.startDate).toBe("2026-07-19");
+    expect(week.endDate).toBe("2026-07-25");
+    expect(week.label).toBe("Jul 19 – Jul 25, 2026");
+  });
+
+  it("moves between adjacent weeks", () => {
+    const selectedDate = new Date(2026, 6, 22, 12);
+
+    expect(createJournalWeek(moveJournalWeek(selectedDate, "next")).startDate).toBe("2026-07-26");
+    expect(createJournalWeek(moveJournalWeek(selectedDate, "previous")).startDate).toBe(
+      "2026-07-12",
+    );
+  });
+
+  it("formats labels across month and year boundaries", () => {
+    expect(createJournalWeek(new Date(2026, 11, 31, 12)).label).toBe("Dec 27, 2026 – Jan 2, 2027");
+  });
+});

--- a/packages/tui/src/state/journal-week.ts
+++ b/packages/tui/src/state/journal-week.ts
@@ -1,0 +1,58 @@
+export interface JournalWeek {
+  start: Date;
+  end: Date;
+  startDate: string;
+  endDate: string;
+  label: string;
+}
+
+export type JournalWeekDirection = "previous" | "next";
+
+export function createJournalWeek(reference: Date): JournalWeek {
+  const start = createLocalDate(reference, -reference.getDay());
+  const end = createLocalDate(start, 6);
+
+  return {
+    start,
+    end,
+    startDate: formatLocalDate(start),
+    endDate: formatLocalDate(end),
+    label: formatWeekLabel(start, end),
+  };
+}
+
+export function moveJournalWeek(reference: Date, direction: JournalWeekDirection): Date {
+  return createLocalDate(reference, direction === "next" ? 7 : -7);
+}
+
+function createLocalDate(reference: Date, dayOffset: number): Date {
+  return new Date(
+    reference.getFullYear(),
+    reference.getMonth(),
+    reference.getDate() + dayOffset,
+    12,
+  );
+}
+
+function formatLocalDate(date: Date): string {
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatWeekLabel(start: Date, end: Date): string {
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const monthDay = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
+  const monthDayYear = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  if (sameYear) {
+    return `${monthDay.format(start)} – ${monthDayYear.format(end)}`;
+  }
+
+  return `${monthDayYear.format(start)} – ${monthDayYear.format(end)}`;
+}


### PR DESCRIPTION
## Summary

- add a Journal screen on primary route `3`
- show selectable date-and-time-only rows for Sunday-through-Saturday weeks
- keep journal content hidden until editing
- navigate entries with `j/k` or arrows and weeks with `Shift+H/L`
- create entries with `n` using the configured terminal editor
- edit the selected entry with Enter and persist changes through `note.update`
- add a minor `@todu/tui` changeset

## Verification

- `make pre-pr` (842 tests)
- focused Journal, editor, client, routing, and help tests

Task: #task-37f95df8