### PR TITLE
feat: open Home tasks in Tasks view

### DIFF
--- a/.changeset/friendly-homes-open.md
+++ b/.changeset/friendly-homes-open.md
@@ -1,0 +1,5 @@
+---
+"@todu/tui": minor
+---
+
+Open the selected Home task directly in the Tasks view with its project and detail selected.

--- a/packages/tui/src/app/App.test.tsx
+++ b/packages/tui/src/app/App.test.tsx
@@ -195,6 +195,7 @@ describe("App", () => {
     expect(lastFrame()).toContain("6 Data Status");
     expect(lastFrame()).toContain("↑↓ Select");
     expect(lastFrame()).toContain("Shift+J/K Section");
+    expect(lastFrame()).toContain("Enter Open Task");
   });
 
   it("shows connected daemon status without body handshake diagnostics", async () => {
@@ -256,6 +257,28 @@ describe("App", () => {
     expect(lastFrame()).toContain("? Help");
     expect(lastFrame()).toContain("q Quit");
     expect(lastFrame()).toContain("Tasks: 1");
+  });
+
+  it("opens the selected Home task in Tasks with its project selected", async () => {
+    const client = createFakeClient();
+    const { stdin, lastFrame } = render(
+      <App connection={createFakeConnection(createConnectedSnapshot())} toduClient={client} />,
+    );
+
+    await waitForFrameText(lastFrame, "• Ship");
+    stdin.write("J");
+    await waitForFrameText(lastFrame, "> • Ship");
+    stdin.write("\r");
+    await waitForFrameText(lastFrame, "Ship details");
+
+    expect(lastFrame()).toContain("Tasks");
+    expect(lastFrame()).toContain("> Inbox");
+    expect(lastFrame()).toContain("Task detail");
+    expect(client.task.list).toHaveBeenCalledWith({
+      status: ["active", "inprogress", "waiting"],
+      projectId: "project-1",
+    });
+    expect(client.task.get).toHaveBeenCalledWith("task-1");
   });
 
   it("selects a project and filters Tasks", async () => {

--- a/packages/tui/src/app/App.tsx
+++ b/packages/tui/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import type { Project, Task } from "@todu/core";
 import { useApp, useInput } from "ink";
 import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AppFrame } from "../components/AppFrame.js";
@@ -89,6 +90,7 @@ function AppContent({
     [projectFilter, taskListFilter],
   );
   const [tasksFooterContext, setTasksFooterContext] = useState<TasksFooterContext>("tasks-list");
+  const [homeTaskToOpen, setHomeTaskToOpen] = useState<Task | null>(null);
   const [globalInputEnabled, setGlobalInputEnabled] = useState(true);
   const [connectionSnapshot, setConnectionSnapshot] = useState<DaemonConnectionSnapshot>(() =>
     connection.getSnapshot(),
@@ -107,6 +109,9 @@ function AppContent({
   useInput(
     (input, key) => {
       const action = resolveGlobalKeyAction(input, key);
+      if (action.type === "none") {
+        return;
+      }
       const nextState = applyNavigationAction(routeState, action);
 
       if (nextState === "quit") {
@@ -114,6 +119,9 @@ function AppContent({
         return;
       }
 
+      if (action.type === "navigate") {
+        setHomeTaskToOpen(null);
+      }
       setRouteState(nextState);
     },
     { isActive: globalInputEnabled },
@@ -186,10 +194,18 @@ function AppContent({
         projectFilter={projectFilter}
         taskListFilter={taskListFilter}
         projectListFilter={projectListFilter}
+        homeTaskToOpen={homeTaskToOpen}
         onTaskListFilterChange={setTaskListFilter}
         onProjectListFilterChange={setProjectListFilter}
         onSelectProject={(project) => {
           updateProjectFilter(createProjectFilter(project));
+          setRouteState({ route: "tasks", previousRoute: "tasks" });
+        }}
+        onOpenHomeTask={(task) => {
+          setTaskListFilter(defaultTaskListFilter);
+          setProjectListFilter(defaultProjectListFilter);
+          updateProjectFilter({ projectId: task.projectId, projectName: null });
+          setHomeTaskToOpen(task);
           setRouteState({ route: "tasks", previousRoute: "tasks" });
         }}
         onSelectAllProjects={() => {
@@ -212,10 +228,12 @@ interface RouteScreenProps {
   projectFilter: ProjectFilterState;
   taskListFilter: TaskListFilterState;
   projectListFilter: ProjectListFilterState;
+  homeTaskToOpen: Task | null;
   onTaskListFilterChange: (filter: TaskListFilterState) => void;
   onProjectListFilterChange: (filter: ProjectListFilterState) => void;
-  onSelectProject: (project: import("@todu/core").Project) => void;
+  onSelectProject: (project: Project) => void;
   onSelectAllProjects: () => void;
+  onOpenHomeTask: (task: Task) => void;
   onTaskProjectFilterChange: (filter: ProjectFilterState) => void;
   onTasksFooterContextChange: (context: TasksFooterContext) => void;
   onGlobalInputEnabledChange: (enabled: boolean) => void;
@@ -229,10 +247,12 @@ function RouteScreen({
   projectFilter,
   taskListFilter,
   projectListFilter,
+  homeTaskToOpen,
   onTaskListFilterChange,
   onProjectListFilterChange,
   onSelectProject,
   onSelectAllProjects,
+  onOpenHomeTask,
   onTaskProjectFilterChange,
   onTasksFooterContextChange,
   onGlobalInputEnabledChange,
@@ -257,7 +277,11 @@ function RouteScreen({
 
   if (route === "home") {
     return canShowDataScreens ? (
-      <HomeScreen client={toduClient} dataQueriesEnabled={dataQueriesEnabled} />
+      <HomeScreen
+        client={toduClient}
+        dataQueriesEnabled={dataQueriesEnabled}
+        onOpenTask={onOpenHomeTask}
+      />
     ) : null;
   }
 
@@ -291,6 +315,7 @@ function RouteScreen({
       projectFilter={projectFilter}
       taskListFilter={taskListFilter}
       projectListFilter={projectListFilter}
+      initialTaskId={homeTaskToOpen?.id}
       onTaskListFilterChange={onTaskListFilterChange}
       onProjectListFilterChange={onProjectListFilterChange}
       statusActionsEnabled={dataQueriesEnabled}

--- a/packages/tui/src/app/keymap.ts
+++ b/packages/tui/src/app/keymap.ts
@@ -83,6 +83,7 @@ export const footerKeyBindings: Readonly<Record<FooterContext, readonly TuiKeyBi
   home: [
     { keys: "Shift+J/K", description: "Section" },
     { keys: "j/k/↑↓", description: "Select item" },
+    { keys: "Enter", description: "Open Task" },
     { keys: "?", description: "Help" },
     { keys: "q", description: "Quit" },
   ],

--- a/packages/tui/src/screens/HomeScreen.test.tsx
+++ b/packages/tui/src/screens/HomeScreen.test.tsx
@@ -137,6 +137,23 @@ describe("HomeScreen", () => {
     await waitForFrameText(lastFrame, "> Next");
   });
 
+  it("opens the selected task with Enter", async () => {
+    const onOpenTask = vi.fn();
+    const { stdin, lastFrame } = renderWithQuery(
+      <HomeScreen client={createClient()} today="2026-07-20" onOpenTask={onOpenTask} />,
+    );
+
+    await waitForFrameText(lastFrame, "> • Work now");
+    stdin.write("j");
+    await waitForFrameText(lastFrame, "> • Due today");
+    stdin.write("\r");
+
+    expect(onOpenTask).toHaveBeenCalledOnce();
+    expect(onOpenTask).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "task-today", projectId: "project-1" }),
+    );
+  });
+
   it("moves between items in the focused task section with j/k or arrow keys", async () => {
     const { stdin, lastFrame } = renderWithQuery(
       <HomeScreen client={createClient()} today="2026-07-20" />,

--- a/packages/tui/src/screens/HomeScreen.tsx
+++ b/packages/tui/src/screens/HomeScreen.tsx
@@ -24,12 +24,14 @@ export interface HomeScreenProps {
   client: TuiToduClient;
   dataQueriesEnabled?: boolean;
   today?: string;
+  onOpenTask?: (task: Task) => void;
 }
 
 export function HomeScreen({
   client,
   dataQueriesEnabled = true,
   today = localDateString(),
+  onOpenTask,
 }: HomeScreenProps): JSX.Element {
   const { stdout } = useStdout();
   const [focusedSection, setFocusedSection] = useState<HomeSection>("now");
@@ -63,6 +65,15 @@ export function HomeScreen({
     }
 
     if (key.ctrl || key.shift) {
+      return;
+    }
+
+    if (key.return || input === "\r") {
+      const selectedTaskId = effectiveSelectedTaskIds[focusedSection];
+      const selectedTask = taskSections[focusedSection].find((task) => task.id === selectedTaskId);
+      if (selectedTask) {
+        onOpenTask?.(selectedTask);
+      }
       return;
     }
 

--- a/packages/tui/src/screens/TasksScreen.test.tsx
+++ b/packages/tui/src/screens/TasksScreen.test.tsx
@@ -140,6 +140,25 @@ describe("TasksScreen", () => {
     expect(lastFrame()).not.toContain("Detail");
   });
 
+  it("opens an initial task with its project selected", async () => {
+    const client = createClient();
+    const { lastFrame } = renderWithQuery(
+      <TasksScreen
+        client={client}
+        projectFilter={{ projectId: "project-1", projectName: "todu" }}
+        initialTaskId="task-2"
+      />,
+    );
+
+    await waitForFrameText(lastFrame, "Description for Second task");
+
+    expect(lastFrame()).toContain("> todu");
+    expect(lastFrame()).toContain("Task detail");
+    expect(lastFrame()).toContain("Second task");
+    expect(lastFrame()).not.toContain("First task");
+    expect(client.task.get).toHaveBeenCalledWith("task-2");
+  });
+
   it("moves task selection with j/k and arrow keys", async () => {
     const client = createClient();
     const { stdin, lastFrame } = renderWithQuery(

--- a/packages/tui/src/screens/TasksScreen.tsx
+++ b/packages/tui/src/screens/TasksScreen.tsx
@@ -25,6 +25,7 @@ import {
 import { formatListWindowIndicator } from "../state/list-window.js";
 import {
   allProjectsFilter,
+  createProjectFilter,
   describeProjectFilter,
   type ProjectFilterState,
 } from "../state/project-filter.js";
@@ -37,6 +38,7 @@ export interface TasksScreenProps {
   projectFilter: ProjectFilterState;
   taskListFilter?: TaskListFilterState;
   projectListFilter?: ProjectListFilterState;
+  initialTaskId?: Task["id"];
   onTaskListFilterChange?: (filter: TaskListFilterState) => void;
   onProjectListFilterChange?: (filter: ProjectListFilterState) => void;
   statusActionsEnabled?: boolean;
@@ -82,6 +84,7 @@ export function TasksScreen({
   projectFilter,
   taskListFilter: taskListFilterProp,
   projectListFilter: projectListFilterProp,
+  initialTaskId,
   onTaskListFilterChange,
   onProjectListFilterChange,
   statusActionsEnabled = true,
@@ -100,8 +103,8 @@ export function TasksScreen({
     projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID,
   );
   const [focusedPane, setFocusedPane] = useState<PaneFocus>("tasks");
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [taskDetailOpen, setTaskDetailOpen] = useState(false);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(initialTaskId ?? null);
+  const [taskDetailOpen, setTaskDetailOpen] = useState(initialTaskId !== undefined);
   const [confirmCancel, setConfirmCancel] = useState(false);
   const [feedback, setFeedback] = useState<{ message: string; tone: ToastTone } | null>(null);
   const [filterModalTarget, setFilterModalTarget] = useState<PaneFocus | null>(null);
@@ -157,8 +160,10 @@ export function TasksScreen({
 
   useEffect(() => {
     setSelectedProjectOptionId(projectFilter.projectId ?? ALL_PROJECTS_OPTION_ID);
-    setTaskDetailOpen(false);
-  }, [projectFilter.projectId]);
+    if (!initialTaskId) {
+      setTaskDetailOpen(false);
+    }
+  }, [initialTaskId, projectFilter.projectId]);
 
   useEffect(() => {
     if (!projectsQuery.data) {
@@ -169,14 +174,22 @@ export function TasksScreen({
   }, [projectOptions, projectsQuery.data]);
 
   useEffect(() => {
-    if (
-      projectFilter.projectId &&
-      projectsQuery.data &&
-      !projectOptions.some((option) => option.project?.id === projectFilter.projectId)
-    ) {
-      onProjectFilterChange?.(allProjectsFilter);
+    if (!projectFilter.projectId || !projectsQuery.data) {
+      return;
     }
-  }, [onProjectFilterChange, projectFilter.projectId, projectOptions, projectsQuery.data]);
+
+    const selectedProject = projectOptions.find(
+      (option) => option.project?.id === projectFilter.projectId,
+    )?.project;
+    if (!selectedProject) {
+      onProjectFilterChange?.(allProjectsFilter);
+      return;
+    }
+
+    if (projectFilter.projectName !== selectedProject.name) {
+      onProjectFilterChange?.(createProjectFilter(selectedProject));
+    }
+  }, [onProjectFilterChange, projectFilter, projectOptions, projectsQuery.data]);
 
   useEffect(() => {
     if (!tasksQuery.data) {


### PR DESCRIPTION
## Summary

- open the selected Home task in Tasks with Enter
- select the task project and reset incompatible list filters
- open the selected task detail immediately
- update Home footer help and add a minor `@todu/tui` changeset

## Verification

- focused Home, Tasks, App, keymap, and help tests
- `make pre-pr` (845 tests)

Task: #task-5b64def2