### PR TITLE
chore: release @todu/engine 0.23.5

### DIFF
--- a/.changeset/remote-sync-reconnect-cleanup.md
+++ b/.changeset/remote-sync-reconnect-cleanup.md
@@ -1,5 +1,0 @@
----
-"@todu/engine": patch
----
-
-Fully dispose stale remote sync adapters before watchdog reconnection to prevent outdated-document errors and resource growth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13298,7 +13298,7 @@
     },
     "packages/engine": {
       "name": "@todu/engine",
-      "version": "0.23.4",
+      "version": "0.23.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @todu/engine
 
+## 0.23.5
+
+### Patch Changes
+
+- adab40b: Fully dispose stale remote sync adapters before watchdog reconnection to prevent outdated-document errors and resource growth.
+
 ## 0.23.4
 
 ### Patch Changes

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@todu/engine",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "Task management engine with offline-first CRDT storage and sync",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@todu/engine` from 0.23.4 to 0.23.5
- add the remote sync reconnect cleanup to the engine changelog
- consume the pending Changeset

## Verification

- `npm run check:ci`
- `npm test`
- `make version-check`

Merging this PR will trigger the NPM Release workflow to publish `@todu/engine@0.23.5`.