### PR TITLE
fix(engine): prevent task history growth and add recovery compactor

### DIFF
--- a/.changeset/prevent-task-history-growth.md
+++ b/.changeset/prevent-task-history-growth.md
@@ -1,0 +1,5 @@
+---
+"@todu/engine": patch
+---
+
+Prevent identical imported task updates from growing Automerge history and safely skip remote sync sends while a WebSocket is closing.

--- a/.changeset/prevent-task-history-growth.md
+++ b/.changeset/prevent-task-history-growth.md
@@ -2,4 +2,4 @@
 "@todu/engine": patch
 ---
 
-Prevent identical imported task updates from growing Automerge history and safely skip remote sync sends while a WebSocket is closing.
+Prevent identical imported task updates from growing Automerge history, safely skip remote sync sends while a WebSocket is closing, and provide a guarded task-list compaction utility for repairing existing histories.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "todu-engine-compact-task-lists": "./scripts/compact-task-lists.mjs"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/engine/scripts/compact-task-lists.mjs
+++ b/packages/engine/scripts/compact-task-lists.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { Repo } from "@automerge/automerge-repo/slim";
+import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
+import { compactTaskListDocument } from "../dist/maintenance.js";
+import { ensureAutomergeWasmInitialized } from "../dist/automerge-init.js";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArguments(arguments_) {
+  const options = { apply: false };
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--apply") {
+      options.apply = true;
+    } else if (argument === "--storage-path") {
+      options.storagePath = arguments_[index + 1];
+      index += 1;
+    } else if (argument === "--backup-path") {
+      options.backupPath = arguments_[index + 1];
+      index += 1;
+    } else {
+      fail(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!options.apply) fail("Refusing to modify data without --apply");
+  if (!options.storagePath) fail("Missing required --storage-path");
+  if (!options.backupPath) fail("Missing required --backup-path");
+  return options;
+}
+
+function assertSafePaths(storagePath, backupPath) {
+  if (!fs.statSync(storagePath, { throwIfNoEntry: false })?.isDirectory()) {
+    fail(`Storage directory does not exist: ${storagePath}`);
+  }
+  if (!fs.existsSync(path.join(storagePath, "todu-catalog.id"))) {
+    fail(`Todu catalog marker not found in ${storagePath}`);
+  }
+  if (fs.existsSync(path.join(storagePath, "daemon.pid"))) {
+    fail(`Daemon PID file exists in ${storagePath}; stop the daemon before compaction`);
+  }
+  if (fs.existsSync(path.join(storagePath, "daemon.sock"))) {
+    fail(`Daemon socket exists in ${storagePath}; stop the daemon before compaction`);
+  }
+  if (fs.existsSync(backupPath)) {
+    fail(`Backup path already exists: ${backupPath}`);
+  }
+
+  const relativeBackupPath = path.relative(storagePath, backupPath);
+  if (relativeBackupPath === "" || (!relativeBackupPath.startsWith("..") && !path.isAbsolute(relativeBackupPath))) {
+    fail("Backup path must be outside the storage directory");
+  }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const storagePath = path.resolve(options.storagePath);
+  const backupPath = path.resolve(options.backupPath);
+  assertSafePaths(storagePath, backupPath);
+
+  console.log(`Creating backup: ${backupPath}`);
+  fs.cpSync(storagePath, backupPath, { recursive: true, errorOnExist: true, force: false });
+
+  await ensureAutomergeWasmInitialized();
+  const catalogId = fs.readFileSync(path.join(storagePath, "todu-catalog.id"), "utf8").trim();
+  const repo = new Repo({ storage: new NodeFSStorageAdapter(storagePath) });
+  const catalog = await repo.find(catalogId);
+  await catalog.whenReady();
+  const projects = (catalog.doc()?.projects ?? []).filter(
+    (project) => catalog.doc()?.taskListDocIds[project.id] !== undefined,
+  );
+
+  console.log(`Compacting ${projects.length} task-list documents`);
+  for (const [index, project] of projects.entries()) {
+    const result = await compactTaskListDocument(repo, catalog, project.id);
+    await repo.removeFromCache(result.oldDocumentId);
+    console.log(
+      JSON.stringify({
+        progress: `${index + 1}/${projects.length}`,
+        projectId: project.id,
+        projectName: project.name,
+        taskCount: result.taskCount,
+        oldDocumentId: result.oldDocumentId,
+        newDocumentId: result.newDocumentId,
+        operationCount: result.operationCount,
+        rssMiB: Math.round(process.memoryUsage().rss / 1024 / 1024),
+      }),
+    );
+  }
+
+  await repo.flush([catalog.documentId]);
+  console.log("Compaction complete. Keep the backup until all upgraded replicas are verified.");
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error("Compaction failed. Keep all daemons stopped and restore the backup before retrying.");
+    process.exit(1);
+  },
+);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -40,6 +40,8 @@ import {
 
 export type { RemoteSyncConfig } from "@todu/core";
 export { registerHabitProcessor } from "./habits.js";
+export type { TaskListCompactionResult } from "./maintenance.js";
+export { compactTaskListDocument } from "./maintenance.js";
 export type { UpcomingOccurrence } from "./recurring.js";
 // Re-export schedule utilities for consumers
 export {

--- a/packages/engine/src/maintenance.integration.test.ts
+++ b/packages/engine/src/maintenance.integration.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { DocumentId, Repo } from "@automerge/automerge-repo/slim";
+import type { CatalogDocument, TaskListDocument } from "@todu/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTodu, type Todu } from "./index.js";
+import { compactTaskListDocument } from "./maintenance.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("task-list document compaction", () => {
+  it("replaces the document while preserving its current logical state", async () => {
+    const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), "todu-compaction-"));
+    temporaryDirectories.push(storagePath);
+    const todu = await createTodu({ storagePath });
+
+    try {
+      const projectResult = await todu.project.create({ name: "Compaction test" });
+      expect(projectResult.ok).toBe(true);
+      if (!projectResult.ok) return;
+
+      const taskResult = await todu.task.create({
+        projectId: projectResult.value.id,
+        title: "Preserve me",
+        description: "Preserve this description reference",
+        labels: ["recovery"],
+      });
+      expect(taskResult.ok).toBe(true);
+      if (!taskResult.ok) return;
+
+      const repo = (todu.task as Todu["task"] & { _repo: Repo })._repo;
+      const catalog = await repo.find<CatalogDocument>(todu.sync.getCatalogId() as DocumentId);
+      await catalog.whenReady();
+      const oldDocumentId = catalog.doc()?.taskListDocIds[projectResult.value.id] as DocumentId;
+      const oldHandle = await repo.find<TaskListDocument>(oldDocumentId);
+      await oldHandle.whenReady();
+      const before = JSON.parse(JSON.stringify(oldHandle.doc())) as TaskListDocument;
+
+      const result = await compactTaskListDocument(repo, catalog, projectResult.value.id);
+      const replacement = await repo.find<TaskListDocument>(result.newDocumentId);
+      await replacement.whenReady();
+
+      expect(result.oldDocumentId).toBe(oldDocumentId);
+      expect(result.newDocumentId).not.toBe(oldDocumentId);
+      expect(result.taskCount).toBe(1);
+      expect(catalog.doc()?.taskListDocIds[projectResult.value.id]).toBe(result.newDocumentId);
+      expect(JSON.parse(JSON.stringify(replacement.doc()))).toEqual(before);
+
+      const listed = await todu.task.list({ projectId: projectResult.value.id });
+      expect(listed.ok).toBe(true);
+      if (listed.ok) {
+        expect(listed.value).toHaveLength(1);
+        expect(listed.value[0]?.title).toBe("Preserve me");
+      }
+    } finally {
+      await todu.close();
+    }
+  });
+});

--- a/packages/engine/src/maintenance.ts
+++ b/packages/engine/src/maintenance.ts
@@ -1,0 +1,59 @@
+import type { DocHandle, DocumentId, Repo } from "@automerge/automerge-repo/slim";
+import type { CatalogDocument, ProjectId, TaskListDocument } from "@todu/core";
+
+export interface TaskListCompactionResult {
+  projectId: ProjectId;
+  oldDocumentId: DocumentId;
+  newDocumentId: DocumentId;
+  taskCount: number;
+  operationCount?: number;
+}
+
+function cloneTaskListDocument(document: TaskListDocument): TaskListDocument {
+  return JSON.parse(JSON.stringify(document)) as TaskListDocument;
+}
+
+/**
+ * Replaces one task-list document with a clean snapshot of its current logical state.
+ * The caller must ensure all writers are stopped and must retain a backup for rollback.
+ */
+export async function compactTaskListDocument(
+  repo: Repo,
+  catalog: DocHandle<CatalogDocument>,
+  projectId: ProjectId,
+): Promise<TaskListCompactionResult> {
+  const oldDocumentId = catalog.doc()?.taskListDocIds[projectId] as DocumentId | undefined;
+  if (!oldDocumentId) {
+    throw new Error(`Task-list document not found for project ${projectId}`);
+  }
+
+  const oldHandle = await repo.find<TaskListDocument>(oldDocumentId);
+  await oldHandle.whenReady();
+  const oldDocument = oldHandle.doc();
+  if (!oldDocument) {
+    throw new Error(`Task-list document ${oldDocumentId} is unavailable for project ${projectId}`);
+  }
+
+  const snapshot = cloneTaskListDocument(oldDocument);
+  const operationCount = repo.metrics().documents[oldDocumentId]?.size.numOps;
+  const replacement = repo.create<TaskListDocument>();
+  replacement.change((document) => {
+    document.projectId = snapshot.projectId;
+    document.tasks = snapshot.tasks;
+    document.detailDocIds = snapshot.detailDocIds;
+    document.descriptionSearchTextByTaskId = snapshot.descriptionSearchTextByTaskId;
+  });
+
+  catalog.change((document) => {
+    document.taskListDocIds[projectId] = replacement.documentId;
+  });
+  await repo.flush([replacement.documentId, catalog.documentId]);
+
+  return {
+    projectId,
+    oldDocumentId,
+    newDocumentId: replacement.documentId,
+    taskCount: snapshot.tasks.length,
+    operationCount,
+  };
+}

--- a/packages/engine/src/sync-client.test.ts
+++ b/packages/engine/src/sync-client.test.ts
@@ -69,6 +69,29 @@ describe("hardenWebSocketClientAdapterErrors", () => {
     expect(adapter.eventNames()).toEqual([]);
   });
 
+  it("drops messages and disconnects the peer while the remote socket is closing", () => {
+    const adapter = new WebSocketClientAdapter("ws://localhost:1", 25);
+    const peerDisconnected = vi.fn();
+    const logger = { warn: vi.fn() };
+    adapter.remotePeerId = "remote-peer" as typeof adapter.remotePeerId;
+    adapter.socket = {
+      OPEN: 1,
+      readyState: 2,
+    } as WebSocketClientAdapter["socket"];
+    adapter.on("peer-disconnected", peerDisconnected);
+    hardenWebSocketClientAdapterErrors(adapter, logger, { watchdogOwnsReconnect: true });
+
+    expect(() => {
+      adapter.send({} as Parameters<WebSocketClientAdapter["send"]>[0]);
+    }).not.toThrow();
+    expect(peerDisconnected).toHaveBeenCalledWith({ peerId: "remote-peer" });
+    expect(adapter.remotePeerId).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "remote sync adapter skipped message while socket not ready",
+      { readyState: 2 },
+    );
+  });
+
   it("leaves reconnect ownership to the watchdog after a socket closes", () => {
     vi.useFakeTimers();
     try {

--- a/packages/engine/src/sync-client.ts
+++ b/packages/engine/src/sync-client.ts
@@ -118,6 +118,7 @@ export function hardenWebSocketClientAdapterErrors(
   const originalOnError = adapter.onError;
   const originalConnect = adapter.connect.bind(adapter);
   const originalDisconnect = adapter.disconnect.bind(adapter);
+  const originalSend = adapter.send.bind(adapter);
 
   adapter.onError = (event) => {
     logger?.warn("remote sync adapter error", {
@@ -137,12 +138,26 @@ export function hardenWebSocketClientAdapterErrors(
   };
 
   if (options.watchdogOwnsReconnect) {
-    adapter.onClose = () => {
-      if (disposedAdapters.has(adapter)) return;
+    const markRemotePeerDisconnected = (): void => {
+      if (disposedAdapters.has(adapter) || !adapter.remotePeerId) return;
 
-      if (adapter.remotePeerId) {
-        adapter.emit("peer-disconnected", { peerId: adapter.remotePeerId });
+      const peerId = adapter.remotePeerId;
+      adapter.remotePeerId = undefined;
+      adapter.emit("peer-disconnected", { peerId });
+    };
+
+    adapter.onClose = markRemotePeerDisconnected;
+    adapter.send = (...args: Parameters<WebSocketClientAdapter["send"]>) => {
+      const socket = adapter.socket;
+      if (!socket || socket.readyState !== socket.OPEN) {
+        logger?.warn("remote sync adapter skipped message while socket not ready", {
+          readyState: socket?.readyState,
+        });
+        markRemotePeerDisconnected();
+        return;
       }
+
+      originalSend(...args);
     };
   }
 

--- a/packages/engine/src/tasks.integration.test.ts
+++ b/packages/engine/src/tasks.integration.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Repo } from "@automerge/automerge-repo";
+import { type DocumentId, Repo } from "@automerge/automerge-repo";
 import { NodeFSStorageAdapter } from "@automerge/automerge-repo-storage-nodefs";
 import type { CatalogDocument, ProjectId, Task, TaskId, TaskListDocument } from "@todu/core";
 import {
@@ -31,6 +31,27 @@ async function readCatalogDocument(storagePath: string): Promise<CatalogDocument
   } finally {
     await repo.shutdown();
   }
+}
+
+async function readTaskDocumentChangeCounts(
+  todu: Todu,
+  projectId: ProjectId,
+  taskId: TaskId,
+): Promise<{ taskList: number; detail: number }> {
+  const repo = (todu.task as Todu["task"] & { _repo: Repo })._repo;
+  const catalogHandle = await repo.find<CatalogDocument>(todu.sync.getCatalogId() as DocumentId);
+  const taskListDocId = catalogHandle.doc()?.taskListDocIds[projectId];
+  if (!taskListDocId) throw new Error(`task list not found for project ${projectId}`);
+
+  const taskListHandle = await repo.find<TaskListDocument>(taskListDocId);
+  const detailDocId = taskListHandle.doc()?.detailDocIds[taskId];
+  if (!detailDocId) throw new Error(`task detail not found for task ${taskId}`);
+
+  const metrics = repo.metrics().documents;
+  return {
+    taskList: metrics[taskListDocId]?.size.numChanges ?? 0,
+    detail: metrics[detailDocId]?.size.numChanges ?? 0,
+  };
 }
 
 async function removeDescriptionSearchIndex(
@@ -1064,6 +1085,41 @@ describe("task namespace", () => {
       if (!result.ok) return;
       expect(result.value.externalId).toBe("gh-101");
       expect(result.value.sourceUrl).toBe("https://example.com/issues/101");
+    });
+
+    it("does not append Automerge history for identical imported updates", async () => {
+      const firstUpdate = await todu.task.update(taskId, {
+        title: "Imported title",
+        status: "active",
+        priority: "medium",
+        labels: ["sync"],
+        assigneeActorIds: [],
+        assignees: [],
+        externalId: "forgejo-42",
+        sourceUrl: "https://forge.example.test/issues/42",
+        description: "Imported description",
+        updatedAt: "2026-07-04T14:34:32.000Z",
+      });
+      if (!firstUpdate.ok) throw new Error("initial imported update failed");
+
+      const before = await readTaskDocumentChangeCounts(todu, projectId, taskId);
+      const identicalInput = {
+        title: firstUpdate.value.title,
+        status: firstUpdate.value.status,
+        priority: firstUpdate.value.priority,
+        labels: firstUpdate.value.labels,
+        assigneeActorIds: firstUpdate.value.assigneeActorIds,
+        assignees: firstUpdate.value.assignees,
+        externalId: firstUpdate.value.externalId,
+        sourceUrl: firstUpdate.value.sourceUrl,
+        description: firstUpdate.value.description,
+        updatedAt: firstUpdate.value.updatedAt,
+      };
+
+      expect((await todu.task.update(taskId, identicalInput)).ok).toBe(true);
+      expect((await todu.task.update(taskId, identicalInput)).ok).toBe(true);
+
+      expect(await readTaskDocumentChangeCounts(todu, projectId, taskId)).toEqual(before);
     });
 
     it("updates imported updatedAt without changing createdAt", async () => {

--- a/packages/engine/src/tasks.ts
+++ b/packages/engine/src/tasks.ts
@@ -115,6 +115,24 @@ export function createTaskNamespace(
     return content.trim().toLowerCase();
   }
 
+  function arraysEqual<T>(left: readonly T[], right: readonly T[]): boolean {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+  }
+
+  function approvalsEqual(
+    left: ImportedContentApproval | undefined,
+    right: ImportedContentApproval | undefined,
+  ): boolean {
+    return (
+      left?.state === right?.state &&
+      left?.sourceBindingId === right?.sourceBindingId &&
+      left?.sourceActorId === right?.sourceActorId &&
+      left?.sourceFingerprint === right?.sourceFingerprint &&
+      left?.reviewedAt === right?.reviewedAt &&
+      left?.reviewedByActorId === right?.reviewedByActorId
+    );
+  }
+
   function taskMatchesSearch(task: Task, descriptionSearchText: string, query: string): boolean {
     const normalizedQuery = normalizeTaskSearchText(query);
     if (normalizedQuery.length === 0) return true;
@@ -551,64 +569,56 @@ export function createTaskNamespace(
       const updatedAt = input.updatedAt
         ? normalizeTaskTimestamp(input.updatedAt)
         : new Date().toISOString();
+      const currentTask = result.task;
+      const title = input.title?.trim();
+      const externalId = input.externalId?.trim();
+      const sourceUrl = input.sourceUrl?.trim();
+      const metadataChanged =
+        (title !== undefined && title !== currentTask.title) ||
+        (input.status !== undefined && input.status !== currentTask.status) ||
+        (input.priority !== undefined && input.priority !== currentTask.priority) ||
+        (input.labels !== undefined && !arraysEqual(input.labels, currentTask.labels)) ||
+        (input.assigneeActorIds !== undefined &&
+          !arraysEqual(input.assigneeActorIds, currentTask.assigneeActorIds)) ||
+        (input.assignees !== undefined && !arraysEqual(input.assignees, currentTask.assignees)) ||
+        (input.dueDate !== undefined && input.dueDate !== currentTask.dueDate) ||
+        (input.scheduledDate !== undefined && input.scheduledDate !== currentTask.scheduledDate) ||
+        (externalId !== undefined && externalId !== currentTask.externalId) ||
+        (sourceUrl !== undefined && sourceUrl !== currentTask.sourceUrl);
+      const timestampChanged = input.updatedAt !== undefined && updatedAt !== currentTask.updatedAt;
 
-      // Update metadata in task list document
-      result.listHandle.change((doc) => {
-        const task = doc.tasks[result.index];
-        if (input.title !== undefined) task.title = input.title.trim();
-        if (input.status !== undefined) task.status = input.status;
-        if (input.priority !== undefined) task.priority = input.priority;
-        if (input.labels !== undefined) {
-          // Replace labels array entirely
-          task.labels.splice(0, task.labels.length, ...input.labels);
-        }
-        if (input.assigneeActorIds !== undefined) {
-          task.assigneeActorIds.splice(0, task.assigneeActorIds.length, ...input.assigneeActorIds);
-        }
-        if (input.assignees !== undefined) {
-          // Replace assignees array entirely
-          task.assignees.splice(0, task.assignees.length, ...input.assignees);
-        }
-        if (input.dueDate !== undefined) task.dueDate = input.dueDate;
-        if (input.scheduledDate !== undefined) task.scheduledDate = input.scheduledDate;
-        if (input.externalId !== undefined) task.externalId = input.externalId.trim();
-        if (input.sourceUrl !== undefined) task.sourceUrl = input.sourceUrl.trim();
-
-        task.updatedAt = updatedAt;
-      });
-
-      // Update description in detail document if changed
       let description: string | undefined;
       let descriptionApproval: ImportedContentApproval | undefined;
-      const listDoc = result.listHandle.doc();
-      const detailDocId = listDoc?.detailDocIds[id];
+      const detailDocId = result.listHandle.doc()?.detailDocIds[id];
+      let createdDetailDocId: DocumentId | undefined;
+      let contentChanged = false;
 
       if (detailDocId) {
         const detailHandle = await repo.find<TaskDetailDocument>(detailDocId as DocumentId);
+        const currentDetail = detailHandle.doc();
 
-        if (input.description !== undefined || input.descriptionApproval !== undefined) {
-          detailHandle.change((doc) => {
-            const nextDescription =
-              input.description !== undefined ? input.description.trim() : doc.description;
-            doc.description = nextDescription;
-            doc.descriptionApproval = normalizeContentApproval(
-              nextDescription,
-              input.descriptionApproval,
-            );
-          });
+        if (
+          currentDetail &&
+          (input.description !== undefined || input.descriptionApproval !== undefined)
+        ) {
+          const nextDescription =
+            input.description !== undefined ? input.description.trim() : currentDetail.description;
+          const nextApproval = normalizeContentApproval(nextDescription, input.descriptionApproval);
+          contentChanged =
+            nextDescription !== currentDetail.description ||
+            !approvalsEqual(nextApproval, currentDetail.descriptionApproval);
+
+          if (contentChanged) {
+            detailHandle.change((doc) => {
+              doc.description = nextDescription;
+              doc.descriptionApproval = nextApproval;
+            });
+          }
         }
 
         const detailDoc = detailHandle.doc();
         description = detailDoc?.description;
         if (detailDoc?.description !== undefined) {
-          const searchText = normalizeTaskSearchText(detailDoc.description);
-          result.listHandle.change((doc) => {
-            if (searchText.length > 0) {
-              doc.descriptionSearchTextByTaskId[id] = searchText;
-            } else {
-              delete doc.descriptionSearchTextByTaskId[id];
-            }
-          });
           descriptionApproval = normalizeContentApproval(
             detailDoc.description,
             detailDoc.descriptionApproval,
@@ -626,11 +636,9 @@ export function createTaskNamespace(
             doc.descriptionApproval = template.descriptionApproval;
           }
         });
-        result.listHandle.change((doc) => {
-          doc.detailDocIds[id] = detailHandle.documentId;
-          doc.descriptionSearchTextByTaskId[id] = normalizeTaskSearchText(descriptionText);
-        });
+        createdDetailDocId = detailHandle.documentId;
         description = descriptionText;
+        contentChanged = true;
       } else if (input.descriptionApproval !== undefined) {
         return err(
           validationError(
@@ -638,6 +646,70 @@ export function createTaskNamespace(
             "Cannot update description approval without an existing description",
           ),
         );
+      }
+
+      const searchText =
+        description !== undefined ? normalizeTaskSearchText(description) : undefined;
+      const currentSearchText = result.listHandle.doc()?.descriptionSearchTextByTaskId[id];
+      const searchIndexChanged =
+        searchText !== undefined &&
+        (searchText.length > 0
+          ? searchText !== currentSearchText
+          : currentSearchText !== undefined);
+      const taskListChanged =
+        metadataChanged || timestampChanged || contentChanged || searchIndexChanged;
+
+      if (taskListChanged) {
+        result.listHandle.change((doc) => {
+          const task = doc.tasks[result.index];
+          if (title !== undefined && title !== task.title) task.title = title;
+          if (input.status !== undefined && input.status !== task.status)
+            task.status = input.status;
+          if (input.priority !== undefined && input.priority !== task.priority) {
+            task.priority = input.priority;
+          }
+          if (input.labels !== undefined && !arraysEqual(input.labels, task.labels)) {
+            task.labels.splice(0, task.labels.length, ...input.labels);
+          }
+          if (
+            input.assigneeActorIds !== undefined &&
+            !arraysEqual(input.assigneeActorIds, task.assigneeActorIds)
+          ) {
+            task.assigneeActorIds.splice(
+              0,
+              task.assigneeActorIds.length,
+              ...input.assigneeActorIds,
+            );
+          }
+          if (input.assignees !== undefined && !arraysEqual(input.assignees, task.assignees)) {
+            task.assignees.splice(0, task.assignees.length, ...input.assignees);
+          }
+          if (input.dueDate !== undefined && input.dueDate !== task.dueDate) {
+            task.dueDate = input.dueDate;
+          }
+          if (input.scheduledDate !== undefined && input.scheduledDate !== task.scheduledDate) {
+            task.scheduledDate = input.scheduledDate;
+          }
+          if (externalId !== undefined && externalId !== task.externalId) {
+            task.externalId = externalId;
+          }
+          if (sourceUrl !== undefined && sourceUrl !== task.sourceUrl) {
+            task.sourceUrl = sourceUrl;
+          }
+          if (metadataChanged || timestampChanged || contentChanged) {
+            task.updatedAt = updatedAt;
+          }
+          if (createdDetailDocId) {
+            doc.detailDocIds[id] = createdDetailDocId;
+          }
+          if (searchText !== undefined) {
+            if (searchText.length > 0 && searchText !== currentSearchText) {
+              doc.descriptionSearchTextByTaskId[id] = searchText;
+            } else if (searchText.length === 0 && currentSearchText !== undefined) {
+              delete doc.descriptionSearchTextByTaskId[id];
+            }
+          }
+        });
       }
 
       // Read back updated task


### PR DESCRIPTION
## Summary

- make imported task updates idempotent so unchanged integration polls do not append Automerge history
- skip outbound remote-sync messages while the WebSocket is closing and hand recovery to the watchdog
- add a guarded, backup-first task-list compaction utility for repairing existing bloated documents

## Root cause

Production task-list documents had accumulated repeated near-full task rewrites from integration polling even when imported values were unchanged. The largest documents contained 10–29 million Automerge operations and required 1–4 GB each to load. Loading those histories saturated the daemon and exposed a separate `Websocket not ready (2)` send during the socket's `CLOSING` state.

## Recovery utility

The packaged `todu-engine-compact-task-lists` command:

- requires explicit `--apply`, `--storage-path`, and `--backup-path`
- refuses to run when default daemon PID or socket markers exist
- creates a complete external backup before mutation
- replaces each task-list document with a clean snapshot
- preserves tasks, detail-document references, and description search indexes
- flushes each replacement and catalog pointer update before continuing
- retains old documents for rollback

A complete copied production dataset was compacted with the packaged command. All 1,691 tasks were preserved; a fresh `task.list` completed in 1.7 seconds at 357 MiB RSS instead of timing out after expanding into multiple gigabytes.

## Verification

- `make pre-pr` — 849 tests, typecheck, lint, and build passed
- sync-server integration suite — 25 tests passed
- task integration suite — 69 tests passed
- maintenance integration test passed
- packaged utility smoke test passed
- full copied-production compaction passed for all 32 task-list documents

## Operational safety

Do not compact live shared data from this PR build. Recovery remains blocked on review, release, coordinated daemon shutdown, authoritative-replica selection, and backup. The multi-machine runbook is tracked in #537.

Closes #537 only after the coordinated production recovery is complete.
