### PR TITLE
chore: release @todu/engine 0.23.6

### DIFF
--- a/.changeset/prevent-task-history-growth.md
+++ b/.changeset/prevent-task-history-growth.md
@@ -1,5 +1,0 @@
----
-"@todu/engine": patch
----
-
-Prevent identical imported task updates from growing Automerge history, safely skip remote sync sends while a WebSocket is closing, and provide a guarded task-list compaction utility for repairing existing histories.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13298,7 +13298,7 @@
     },
     "packages/engine": {
       "name": "@todu/engine",
-      "version": "0.23.5",
+      "version": "0.23.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -13309,6 +13309,9 @@
         "@todu/core": "*",
         "rrule": "^2.8.1",
         "ws": "^8.19.0"
+      },
+      "bin": {
+        "todu-engine-compact-task-lists": "scripts/compact-task-lists.mjs"
       },
       "devDependencies": {
         "@types/ws": "^8.18.1"

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @todu/engine
 
+## 0.23.6
+
+### Patch Changes
+
+- c64c3e1: Prevent identical imported task updates from growing Automerge history, safely skip remote sync sends while a WebSocket is closing, and provide a guarded task-list compaction utility for repairing existing histories.
+
 ## 0.23.5
 
 ### Patch Changes

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@todu/engine",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "Task management engine with offline-first CRDT storage and sync",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release `@todu/engine@0.23.6` with:

- idempotent imported task updates that prevent redundant Automerge history growth
- safe remote-sync handling while a WebSocket is closing
- the guarded `todu-engine-compact-task-lists` recovery utility

## Verification

- `npm run check:ci`
- `npm test` — 849 tests passed
- `make version-check`

## Recovery gate

Merging this PR triggers the npm publish workflow. Do not compact production documents until `@todu/engine@0.23.6` is published, installed on the authoritative machine, and all stale daemons are stopped. Recovery remains tracked in #537.
